### PR TITLE
Minor workaround for 64bit cudaAdd()

### DIFF
--- a/source/EngineGpuKernels/RenderingKernels.cuh
+++ b/source/EngineGpuKernels/RenderingKernels.cuh
@@ -28,7 +28,7 @@ __device__ __inline__ void drawAddingPixel(uint64_t* imageData, unsigned int ind
     // CUDA headers use "unsigned long long" for 64bit types, which
     // may not be struturally equivalent to std::uint64_t
     //
-    // Due to this, we need a ugly type casting workaround here
+    // Due to this, we need an ugly type casting workaround here
     //
     static_assert(sizeof(unsigned long long) == sizeof(uint64_t));
     atomicAdd(reinterpret_cast<unsigned long long*>(&imageData[index]), rawColorToAdd);

--- a/source/EngineGpuKernels/RenderingKernels.cuh
+++ b/source/EngineGpuKernels/RenderingKernels.cuh
@@ -22,7 +22,7 @@ __device__ __inline__ void drawPixel(uint64_t* imageData, unsigned int index, fl
 
 __device__ __inline__ void drawAddingPixel(uint64_t* imageData, unsigned int index, float3 const& colorToAdd)
 {
-    unsigned long rawColorToAdd = toUInt64(colorToAdd.y * 255.0f) << 16 | toUInt64(colorToAdd.x * 255.0f) << 0
+    uint64_t rawColorToAdd = toUInt64(colorToAdd.y * 255.0f) << 16 | toUInt64(colorToAdd.x * 255.0f) << 0
         | toUInt64(colorToAdd.z * 255.0f) << 32;
 
     // CUDA headers use "unsigned long long" for 64bit types, which


### PR DESCRIPTION
Sadly, the 64bit cudaAdd() definition is problematic. This PR implements a simple workaround to fix the Linux build.