### PR TITLE
Better zones UI

### DIFF
--- a/source/EngineInterface/AuxiliaryDataParserService.cpp
+++ b/source/EngineInterface/AuxiliaryDataParserService.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "AuxiliaryDataParserService.h"
 
 #include "GeneralSettings.h"
@@ -774,7 +776,8 @@ namespace
             encodeDecodeProperty(tree, currentName, defaultName, base + "name", parserTask);
             
             if (parserTask == ParserTask::Decode){
-                strncpy_s(spot.name, SIM_PARAM_SPOT_NAME_LENGTH, currentName.c_str(), SIM_PARAM_SPOT_NAME_LENGTH - 1);
+                currentName = currentName.substr(0, SIM_PARAM_SPOT_NAME_LENGTH - 1); // Leave space for null byte
+                strncpy(spot.name, currentName.c_str(), SIM_PARAM_SPOT_NAME_LENGTH);
             } 
                     
             encodeDecodeProperty(tree, spot.color, defaultSpot.color, base + "color", parserTask);

--- a/source/EngineInterface/AuxiliaryDataParserService.cpp
+++ b/source/EngineInterface/AuxiliaryDataParserService.cpp
@@ -768,6 +768,15 @@ namespace
             std::string base = "simulation parameters.spots." + std::to_string(index) + ".";
             auto& spot = parameters.spots[index];
             auto& defaultSpot = defaultParameters.spots[index];
+            
+            std::string currentName(spot.name);
+            std::string defaultName(defaultSpot.name); 
+            encodeDecodeProperty(tree, currentName, defaultName, base + "name", parserTask);
+            
+            if (parserTask == ParserTask::Decode){
+                strncpy_s(spot.name, SIM_PARAM_SPOT_NAME_LENGTH, currentName.c_str(), SIM_PARAM_SPOT_NAME_LENGTH - 1);
+            } 
+                    
             encodeDecodeProperty(tree, spot.color, defaultSpot.color, base + "color", parserTask);
             encodeDecodeProperty(tree, spot.posX, defaultSpot.posX, base + "pos.x", parserTask);
             encodeDecodeProperty(tree, spot.posY, defaultSpot.posY, base + "pos.y", parserTask);

--- a/source/EngineInterface/SimulationParametersSpot.h
+++ b/source/EngineInterface/SimulationParametersSpot.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <cstring>
 #include "SimulationParametersSpotActivatedValues.h"
 #include "SimulationParametersSpotValues.h"
 

--- a/source/EngineInterface/SimulationParametersSpot.h
+++ b/source/EngineInterface/SimulationParametersSpot.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-
+#include <string>
 #include "SimulationParametersSpotActivatedValues.h"
 #include "SimulationParametersSpotValues.h"
 

--- a/source/EngineInterface/SimulationParametersSpot.h
+++ b/source/EngineInterface/SimulationParametersSpot.h
@@ -86,8 +86,11 @@ union SpotShapeData
     RectangularSpot rectangularSpot;
 };
 
+static constexpr size_t SIM_PARAM_SPOT_NAME_LENGTH = 32;
+
 struct SimulationParametersSpot
 {
+    char name[SIM_PARAM_SPOT_NAME_LENGTH]{};
     uint32_t color = 0;
     float posX = 0;
     float posY = 0;
@@ -139,7 +142,7 @@ struct SimulationParametersSpot
             }
         }
 
-        return color == other.color && posX == other.posX && posY == other.posY && velX == other.velX && velY == other.velY
+        return (strcmp(name, other.name) == 0) && color == other.color && posX == other.posX && posY == other.posY && velX == other.velX && velY == other.velY
             && fadeoutRadius == other.fadeoutRadius && values == other.values && activatedValues == other.activatedValues && shapeType == other.shapeType;
     }
     bool operator!=(SimulationParametersSpot const& other) const { return !operator==(other); }

--- a/source/Gui/SimulationParametersWindow.cpp
+++ b/source/Gui/SimulationParametersWindow.cpp
@@ -200,8 +200,7 @@ void _SimulationParametersWindow::processTabWidget(
                 AlienImGui::Tooltip("Add parameter zone");
             }
 
-                bool open = true;
-            if (ImGui::BeginTabItem("Base", &open, _focusBaseTab ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None)) {
+            if (ImGui::BeginTabItem("Base", nullptr, _focusBaseTab ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None)) {
                 processBase(parameters, origParameters);
                 ImGui::EndTabItem();
             }

--- a/source/Gui/SimulationParametersWindow.cpp
+++ b/source/Gui/SimulationParametersWindow.cpp
@@ -214,8 +214,8 @@ void _SimulationParametersWindow::processTabWidget(
                 SimulationParametersSpot const& origSpot = origParameters.spots[tab];
                 
                 bool open = true;
-                
-                if (ImGui::BeginTabItem(std::string(_spotNameStrings[tab] + "###" + _spotTabIDs[tab]).c_str(), &open, ImGuiTabItemFlags_None)) {
+                std::string label = std::string(_spotNameStrings[tab] + std::string("###") + _spotTabIDs[tab]);
+                if (ImGui::BeginTabItem(label.c_str(), &open, ImGuiTabItemFlags_None)) {
                     processSpot(tab,spot, origSpot, parameters);
                     ImGui::EndTabItem();
                 }
@@ -2178,7 +2178,7 @@ void _SimulationParametersWindow::onOpenParameters()
             MessageDialog::getInstance().information("Open simulation parameters", "The selected file could not be opened.");
         } else {
             for(int spot = 0; spot < parameters.numSpots; ++spot){
-                _spotNameStrings[spot] = std::string(parameters.spots[spot].name, SIM_PARAM_SPOT_NAME_LENGTH);
+                _spotNameStrings[spot] = std::string(parameters.spots[spot].name);
                 _spotTabIDs[spot] = std::to_string(_serialTabID);
                 ++_serialTabID;
             }

--- a/source/Gui/SimulationParametersWindow.cpp
+++ b/source/Gui/SimulationParametersWindow.cpp
@@ -1469,8 +1469,8 @@ void _SimulationParametersWindow::processSpot(
 
         if (AlienImGui::BeginTreeNode(AlienImGui::TreeNodeParameters().text("General"))) {
             if(AlienImGui::InputText(AlienImGui::InputTextParameters().name("Name").textWidth(RightColumnWidth), _spotNameStrings[tab])){
+                _spotNameStrings[tab] = _spotNameStrings[tab].substr(0, SIM_PARAM_SPOT_NAME_LENGTH - 1); 
                 strncpy_s(spot.name, SIM_PARAM_SPOT_NAME_LENGTH, _spotNameStrings[tab].c_str(), SIM_PARAM_SPOT_NAME_LENGTH - 1);
-                _spotNameStrings[tab] = _spotNameStrings[tab].substr(0, SIM_PARAM_SPOT_NAME_LENGTH - 1);
             }
             AlienImGui::EndTreeNode();
         }
@@ -2177,6 +2177,11 @@ void _SimulationParametersWindow::onOpenParameters()
         if (!SerializerService::deserializeSimulationParametersFromFile(parameters, firstFilename.string())) {
             MessageDialog::getInstance().information("Open simulation parameters", "The selected file could not be opened.");
         } else {
+            for(int spot = 0; spot < parameters.numSpots; ++spot){
+                _spotNameStrings[spot] = std::string(parameters.spots[spot].name, SIM_PARAM_SPOT_NAME_LENGTH);
+                _spotTabIDs[spot] = std::to_string(_serialTabID);
+                ++_serialTabID;
+            }
             _simController->setSimulationParameters(parameters);
         }
     });

--- a/source/Gui/SimulationParametersWindow.cpp
+++ b/source/Gui/SimulationParametersWindow.cpp
@@ -1,5 +1,7 @@
 #include "SimulationParametersWindow.h"
 
+#include <cstring>
+
 #include <ImFileDialog.h>
 #include <imgui.h>
 #include <Fonts/IconsFontAwesome5.h>

--- a/source/Gui/SimulationParametersWindow.cpp
+++ b/source/Gui/SimulationParametersWindow.cpp
@@ -111,7 +111,7 @@ SimulationParametersSpot _SimulationParametersWindow::createSpot(SimulationParam
 {
     SimulationParametersSpot spot;
 
-    strcpy_s(spot.name, SIM_PARAM_SPOT_NAME_LENGTH, std::string("Zone " + std::to_string(index)).c_str());
+    strncpy(spot.name, std::string("Zone " + std::to_string(index)).c_str(), SIM_PARAM_SPOT_NAME_LENGTH);
     
     auto worldSize = _simController->getWorldSize();
     
@@ -1491,8 +1491,8 @@ void _SimulationParametersWindow::processSpot(
 
         if (AlienImGui::BeginTreeNode(AlienImGui::TreeNodeParameters().text("General"))) {
             if(AlienImGui::InputText(AlienImGui::InputTextParameters().name("Name").textWidth(RightColumnWidth), _spotNameStrings[tab])){
-                _spotNameStrings[tab] = _spotNameStrings[tab].substr(0, SIM_PARAM_SPOT_NAME_LENGTH - 1); 
-                strncpy_s(spot.name, SIM_PARAM_SPOT_NAME_LENGTH, _spotNameStrings[tab].c_str(), SIM_PARAM_SPOT_NAME_LENGTH - 1);
+                _spotNameStrings[tab] = _spotNameStrings[tab].substr(0, SIM_PARAM_SPOT_NAME_LENGTH - 1); // Leave space for null byte
+                strncpy(spot.name, _spotNameStrings[tab].c_str(), SIM_PARAM_SPOT_NAME_LENGTH);
             }
             AlienImGui::EndTreeNode();
         }

--- a/source/Gui/SimulationParametersWindow.h
+++ b/source/Gui/SimulationParametersWindow.h
@@ -41,9 +41,12 @@ private:
     std::optional<int> _sessionId;
     bool _focusBaseTab = false;
     std::vector<std::string> _cellFunctionStrings;
- 
+    
     std::vector<std::string> _spotNameStrings;
     std::vector<std::string> _spotTabIDs;
+    std::vector<std::string> _copiedSpotNameStrings;
+    std::vector<std::string> _copiedSpotTabIDs;
+    
     int _serialTabID;
     
     bool _featureListOpen = false;

--- a/source/Gui/SimulationParametersWindow.h
+++ b/source/Gui/SimulationParametersWindow.h
@@ -21,7 +21,7 @@ private:
     void processToolbar();
     void processTabWidget(SimulationParameters& parameters, SimulationParameters const& lastParameters, SimulationParameters& origParameters);
     void processBase(SimulationParameters& parameters, SimulationParameters const& origParameters);
-    void processSpot(SimulationParametersSpot& spot, SimulationParametersSpot const& origSpot, SimulationParameters const& parameters);
+    void processSpot(int tab, SimulationParametersSpot& spot, SimulationParametersSpot const& origSpot, SimulationParameters const& parameters);
     void processAddonList(SimulationParameters& parameters, SimulationParameters const& lastParameters, SimulationParameters const& origParameters);
 
     void onOpenParameters();
@@ -41,6 +41,7 @@ private:
     std::optional<int> _sessionId;
     bool _focusBaseTab = false;
     std::vector<std::string> _cellFunctionStrings;
+    std::vector<std::string> _zoneNameStrings;
 
     bool _featureListOpen = false;
     float _featureListHeight = 200.0f;

--- a/source/Gui/SimulationParametersWindow.h
+++ b/source/Gui/SimulationParametersWindow.h
@@ -41,8 +41,11 @@ private:
     std::optional<int> _sessionId;
     bool _focusBaseTab = false;
     std::vector<std::string> _cellFunctionStrings;
-    std::vector<std::string> _zoneNameStrings;
-
+ 
+    std::vector<std::string> _spotNameStrings;
+    std::vector<std::string> _spotTabIDs;
+    int _serialTabID;
+    
     bool _featureListOpen = false;
     float _featureListHeight = 200.0f;
 };


### PR DESCRIPTION
Addresses `Name zones` and `Reorder zone tabs` in #92
- Add names to zones(spots) with serialization/deserialization
- Support zone tab reordering
- Disable closing and reordering Base tab
- Fix bug where closing one tab will close multiple others