### PR TITLE
Decouple EngineGpuKernels from Gui

### DIFF
--- a/source/EngineGpuKernels/CellProcessor.cuh
+++ b/source/EngineGpuKernels/CellProcessor.cuh
@@ -14,7 +14,6 @@
 #include "GenomeDecoder.cuh"
 #include "RadiationProcessor.cuh"
 #include "SpotCalculator.cuh"
-#include "Gui/HelpStrings.h"
 
 class CellProcessor
 {


### PR DESCRIPTION
The `#include "Gui/HelpStrings.h"` in `EngineGpuKernels\CellProcessor.cuh` coupled `EngineGpuKernels `with `Gui`. 

This lead that the CUDA compiler must receive parameters from C++ compiler, and if the parameters received is not avaliable for CUDA compiler, compiler error will be occured. The CUDA compiler error I mentioned at [Discord](https://discord.com/channels/977972356721021058/981324261165764718/1313135587556982784) is an example of that.

By removing `#include "Gui/HelpStrings.h"` in `EngineGpuKernels\CellProcessor.cuh`, the problem I mentioned upon could be fixed. And the context of `"Gui/HelpStrings.h"` is not be used in `EngineGpuKernels\CellProcessor.cuh`, it is ok to be removed.