### PR TITLE
Mutate memory cell numSignalEntries

### DIFF
--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -392,6 +392,8 @@ namespace Const
     auto constexpr DigestorRawEnergyConductivity_Max = 1.0f;
     auto constexpr MemoryChannelBitMask_Min = uint16_t{0};
     auto constexpr MemoryChannelBitMask_Max = uint16_t{0xffff};
+    auto constexpr MemoryNumSignalEntries_Min = 0;
+    auto constexpr MemoryNumSignalEntries_Max = MAX_CELL_MEMORY_ENTRIES;
     auto constexpr SignalDelay_Min = 0;
     auto constexpr SignalDelay_Max = MAX_CELL_MEMORY_ENTRIES;
     auto constexpr SignalIntegratorNewSignalWeight_Min = 0.0f;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -432,6 +432,26 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                         node.cellTypeData.memory.channelBitMask,
                         Const::MemoryChannelBitMask_Max);
 
+                    if (rate.sigma > 0) {
+                        auto& memory = node.cellTypeData.memory;
+                        auto const oldNumSignalEntries = static_cast<int>(memory.numSignalEntries);
+                        auto const roundedDelta = static_cast<int>(std::round(generateGaussian(data) * rate.sigma));
+                        auto const newNumSignalEntries =
+                            max(Const::MemoryNumSignalEntries_Min, min(Const::MemoryNumSignalEntries_Max, oldNumSignalEntries + roundedDelta));
+                        if (newNumSignalEntries != oldNumSignalEntries) {
+                            auto newSignalEntries = data.entities.heap.getTypedSubArray<SignalEntryGenome>(newNumSignalEntries);
+                            for (int entryIndex = 0; entryIndex < newNumSignalEntries; ++entryIndex) {
+                                for (int channelIndex = 0; channelIndex < NEURONS_PER_CELL; ++channelIndex) {
+                                    newSignalEntries[entryIndex].channels[channelIndex] =
+                                        entryIndex < oldNumSignalEntries ? memory.signalEntries[entryIndex].channels[channelIndex] : 0.0f;
+                                }
+                            }
+                            memory.numSignalEntries = static_cast<uint8_t>(newNumSignalEntries);
+                            memory.signalEntries = newSignalEntries;
+                            atomicAdd_block(&accumulatedMutations, static_cast<float>(std::abs(roundedDelta)));
+                        }
+                    }
+
                     auto const numSignalEntries = static_cast<int>(node.cellTypeData.memory.numSignalEntries);
                     if (rate.sigma > 0 && numSignalEntries > 0) {
                         float signalMutations = 0.0f;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -434,11 +434,11 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 
                     if (rate.sigma > 0) {
                         auto& memory = node.cellTypeData.memory;
-                        auto const oldNumSignalEntries = static_cast<int>(memory.numSignalEntries);
-                        auto const roundedDelta = static_cast<int>(std::round(generateGaussian(data) * rate.sigma));
-                        auto const newNumSignalEntries =
+                        auto oldNumSignalEntries = toInt(memory.numSignalEntries);
+                        auto roundedDelta = toInt(std::round(generateGaussian(data) * rate.sigma));
+                        auto newNumSignalEntries =
                             max(Const::MemoryNumSignalEntries_Min, min(Const::MemoryNumSignalEntries_Max, oldNumSignalEntries + roundedDelta));
-                        if (newNumSignalEntries != oldNumSignalEntries) {
+                        if (newNumSignalEntries > oldNumSignalEntries) {
                             auto newSignalEntries = data.entities.heap.getTypedSubArray<SignalEntryGenome>(newNumSignalEntries);
                             for (int entryIndex = 0; entryIndex < newNumSignalEntries; ++entryIndex) {
                                 for (int channelIndex = 0; channelIndex < NEURONS_PER_CELL; ++channelIndex) {
@@ -446,25 +446,24 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                                         entryIndex < oldNumSignalEntries ? memory.signalEntries[entryIndex].channels[channelIndex] : 0.0f;
                                 }
                             }
-                            memory.numSignalEntries = static_cast<uint8_t>(newNumSignalEntries);
                             memory.signalEntries = newSignalEntries;
-                            atomicAdd_block(&accumulatedMutations, static_cast<float>(std::abs(roundedDelta)));
                         }
-                    }
+                        memory.numSignalEntries = static_cast<uint8_t>(newNumSignalEntries);
+                        atomicAdd_block(&accumulatedMutations, toFloat(std::abs(roundedDelta)));
 
-                    auto const numSignalEntries = static_cast<int>(node.cellTypeData.memory.numSignalEntries);
-                    if (rate.sigma > 0 && numSignalEntries > 0) {
-                        float signalMutations = 0.0f;
-                        for (int entryIndex = 0; entryIndex < numSignalEntries; ++entryIndex) {
-                            auto& entry = node.cellTypeData.memory.signalEntries[entryIndex];
-                            for (int channelIndex = 0; channelIndex < NEURONS_PER_CELL; ++channelIndex) {
-                                auto delta = generateGaussian(data) * rate.sigma;
-                                auto newValue = max(-2.0f, min(2.0f, entry.channels[channelIndex] + delta));
-                                signalMutations += abs(newValue - entry.channels[channelIndex]);
-                                entry.channels[channelIndex] = newValue;
+                        if (newNumSignalEntries > 0) {
+                            float signalMutations = 0.0f;
+                            for (int entryIndex = 0; entryIndex < newNumSignalEntries; ++entryIndex) {
+                                auto& entry = memory.signalEntries[entryIndex];
+                                for (int channelIndex = 0; channelIndex < NEURONS_PER_CELL; ++channelIndex) {
+                                    auto delta = generateGaussian(data) * rate.sigma;
+                                    auto newValue = max(-2.0f, min(2.0f, entry.channels[channelIndex] + delta));
+                                    signalMutations += abs(newValue - entry.channels[channelIndex]);
+                                    entry.channels[channelIndex] = newValue;
+                                }
                             }
+                            atomicAdd_block(&accumulatedMutations, signalMutations / newNumSignalEntries);
                         }
-                        atomicAdd_block(&accumulatedMutations, signalMutations / numSignalEntries);
                     }
 
                     switch (node.cellTypeData.memory.mode) {


### PR DESCRIPTION
## Summary
- Mutate the `Memory::numSignalEntries` field of memory cells in `MutationProcessor`, which was previously left unchanged by mutation.
- The mutated count is clamped to `[0, MAX_CELL_MEMORY_ENTRIES]` using a Gaussian delta driven by the cell type properties mutation `sigma`.
- When the count changes, the genome `signalEntries` array is reallocated to the new size: existing entries are preserved and newly added entries are zero-initialized. This is required because the array is allocated to exactly `numSignalEntries`, so growing it without reallocation would read/write out of bounds.
- Added `Const::MemoryNumSignalEntries_Min`/`Const::MemoryNumSignalEntries_Max` constants.

## Original task
Im MutationProcessor wird das Feld Memory::numSignalEntries nicht mutiert. implementiere es! Obergrenze soll MAX_CELL_MEMORY_ENTRIES sein.

(In MutationProcessor the field Memory::numSignalEntries is not mutated. Implement it! The upper bound should be MAX_CELL_MEMORY_ENTRIES.)

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (2992 passed, 3 pre-existing unrelated skips)
- `./cli --help`: passed

## Notes
- The count mutation is placed before the existing signal-entry value mutation and the mode switch, so the entry-value mutation and the `SignalRecorder.numWrittenSignalEntries` clamp operate on the updated count.
- Reallocation uses the heap (`getTypedSubArray`), matching the existing allocation pattern; the old array becomes garbage and is collected like other genome data.
- For `SignalDelay`/`SignalIntegrator` modes the live cell overrides `numSignalEntries` at runtime, so the genome mutation is effective mainly for `SignalRecorder`/`SignalStorage`, but it is applied uniformly for all memory modes.