### PR TITLE
Profile simulation kernels and reduce neighbor-scan memory traffic

### DIFF
--- a/source/Base/CMakeLists.txt
+++ b/source/Base/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(Base
     GlobalSettings.h
     Hashes.h
     JsonParser.h
+    KernelProfiler.cpp
+    KernelProfiler.h
     LoggingService.cpp
     LoggingService.h
     Macros.h

--- a/source/Base/KernelProfiler.cpp
+++ b/source/Base/KernelProfiler.cpp
@@ -1,0 +1,59 @@
+#include "KernelProfiler.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+void KernelProfiler::record(char const* name, std::chrono::steady_clock::time_point start)
+{
+    if (!_enabled) {
+        return;
+    }
+    auto elapsed = std::chrono::duration<double, std::nano>(std::chrono::steady_clock::now() - start).count();
+
+    std::lock_guard lock(_mutex);
+    auto& entry = _entries[name];
+    ++entry.count;
+    entry.totalNanoseconds += elapsed;
+}
+
+void KernelProfiler::reset()
+{
+    std::lock_guard lock(_mutex);
+    _entries.clear();
+}
+
+std::string KernelProfiler::getReport() const
+{
+    std::lock_guard lock(_mutex);
+
+    std::vector<std::pair<std::string, Entry>> sorted(_entries.begin(), _entries.end());
+    std::ranges::sort(sorted, [](auto const& left, auto const& right) { return left.second.totalNanoseconds > right.second.totalNanoseconds; });
+
+    double totalNanoseconds = 0.0;
+    uint64_t totalCount = 0;
+    for (auto const& [name, entry] : sorted) {
+        totalNanoseconds += entry.totalNanoseconds;
+        totalCount += entry.count;
+    }
+
+    std::ostringstream stream;
+    stream << "Kernel profiling report (debug mode, wall-clock per kernel incl. launch/sync overhead)\n";
+    stream << std::left << std::setw(4) << "#" << std::setw(52) << "kernel" << std::right << std::setw(10) << "calls" << std::setw(14) << "total [ms]"
+           << std::setw(12) << "avg [us]" << std::setw(9) << "share" << "\n";
+
+    int rank = 1;
+    for (auto const& [name, entry] : sorted) {
+        auto totalMs = entry.totalNanoseconds / 1.0e6;
+        auto avgUs = entry.count != 0 ? entry.totalNanoseconds / 1.0e3 / static_cast<double>(entry.count) : 0.0;
+        auto share = totalNanoseconds != 0.0 ? 100.0 * entry.totalNanoseconds / totalNanoseconds : 0.0;
+        stream << std::left << std::setw(4) << rank << std::setw(52) << name << std::right << std::setw(10) << entry.count << std::setw(14) << std::fixed
+               << std::setprecision(3) << totalMs << std::setw(12) << std::setprecision(1) << avgUs << std::setw(8) << std::setprecision(1) << share << "%\n";
+        ++rank;
+    }
+    stream << std::left << std::setw(4) << "" << std::setw(52) << "total" << std::right << std::setw(10) << totalCount << std::setw(14) << std::fixed
+           << std::setprecision(3) << (totalNanoseconds / 1.0e6) << std::setw(12) << "" << std::setw(8) << "100.0" << "%\n";
+
+    return stream.str();
+}

--- a/source/Base/KernelProfiler.cpp
+++ b/source/Base/KernelProfiler.cpp
@@ -5,17 +5,17 @@
 #include <sstream>
 #include <vector>
 
-void KernelProfiler::record(char const* name, std::chrono::steady_clock::time_point start)
+void KernelProfiler::record(char const* name, std::chrono::steady_clock::duration duration)
 {
     if (!_enabled) {
         return;
     }
-    auto elapsed = std::chrono::duration<double, std::nano>(std::chrono::steady_clock::now() - start).count();
+    auto nanoseconds = std::chrono::duration<double, std::nano>(duration).count();
 
     std::lock_guard lock(_mutex);
     auto& entry = _entries[name];
     ++entry.count;
-    entry.totalNanoseconds += elapsed;
+    entry.totalNanoseconds += nanoseconds;
 }
 
 void KernelProfiler::reset()

--- a/source/Base/KernelProfiler.h
+++ b/source/Base/KernelProfiler.h
@@ -8,13 +8,8 @@
 
 #include "Singleton.h"
 
-// Lightweight per-kernel profiler.
-//
-// It is only active when explicitly enabled (see setEnabled). The recording is meant to be driven from the
-// stream kernel-call macros while debug mode is active: there each kernel launch is followed by a stream
-// synchronization, so the measured wall-clock interval around a launch corresponds to that kernel's execution
-// (plus a small, constant launch/sync overhead). The accumulated times therefore give a faithful ranking of
-// where the simulation spends its GPU time.
+// Accumulates per-kernel wall-clock durations. Only active when enabled; fed by the kernel-call macros in debug
+// mode, where each launch is followed by a stream sync so the recorded duration is the kernel's execution time.
 class KernelProfiler
 {
     MAKE_SINGLETON(KernelProfiler);
@@ -23,7 +18,7 @@ public:
     void setEnabled(bool value) { _enabled = value; }
     bool isEnabled() const { return _enabled; }
 
-    void record(char const* name, std::chrono::steady_clock::time_point start);
+    void record(char const* name, std::chrono::steady_clock::duration duration);
 
     void reset();
     std::string getReport() const;

--- a/source/Base/KernelProfiler.h
+++ b/source/Base/KernelProfiler.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "Singleton.h"
+
+// Lightweight per-kernel profiler.
+//
+// It is only active when explicitly enabled (see setEnabled). The recording is meant to be driven from the
+// stream kernel-call macros while debug mode is active: there each kernel launch is followed by a stream
+// synchronization, so the measured wall-clock interval around a launch corresponds to that kernel's execution
+// (plus a small, constant launch/sync overhead). The accumulated times therefore give a faithful ranking of
+// where the simulation spends its GPU time.
+class KernelProfiler
+{
+    MAKE_SINGLETON(KernelProfiler);
+
+public:
+    void setEnabled(bool value) { _enabled = value; }
+    bool isEnabled() const { return _enabled; }
+
+    void record(char const* name, std::chrono::steady_clock::time_point start);
+
+    void reset();
+    std::string getReport() const;
+
+private:
+    struct Entry
+    {
+        uint64_t count = 0;
+        double totalNanoseconds = 0.0;
+    };
+
+    bool _enabled = false;
+    mutable std::mutex _mutex;
+    std::unordered_map<std::string, Entry> _entries;
+};

--- a/source/Cli/Main.cpp
+++ b/source/Cli/Main.cpp
@@ -6,6 +6,7 @@
 #include <Base/AlienExceptions.h>
 #include <Base/FileLogger.h>
 #include <Base/GlobalSettings.h>
+#include <Base/KernelProfiler.h>
 #include <Base/LoggingService.h>
 #include <Base/Resources.h>
 #include <Base/StringHelper.h>
@@ -29,6 +30,7 @@ int main(int argc, char** argv)
         std::string outputFilename;
         std::string statisticsFilename;
         int timesteps = 0;
+        bool profile = false;
         app.add_option(
             "-i", inputFilename, "Specifies the name of the input file for the simulation to run. The corresponding *.settings.json should also be available.");
         app.add_option(
@@ -36,7 +38,17 @@ int main(int argc, char** argv)
             outputFilename,
             "Specifies the name of the output file for the simulation. The *.settings.json and *.statistics.csv file will also be saved.");
         app.add_option("-t", timesteps, "The number of time steps to be calculated.");
+        app.add_flag(
+            "-p,--profile",
+            profile,
+            "Enables debug mode and measures the wall-clock time of each simulation kernel. A profiling report is printed after the run. This bypasses CUDA "
+            "graphs and synchronizes after every kernel, so the absolute timings are slower than normal but reveal where the time is spent.");
         CLI11_PARSE(app, argc, argv);
+
+        if (profile) {
+            GlobalSettings::get().setDebugMode(true);
+            KernelProfiler::get().setEnabled(true);
+        }
 
         //read input
         std::cout << "Reading input" << std::endl;
@@ -67,6 +79,10 @@ int main(int argc, char** argv)
         auto tps = ms != 0 ? 1000.0f * toFloat(timesteps) / toFloat(ms) : 0.0f;
         std::cout << "Simulation finished: " << StringHelper::format(timesteps) << " time steps, " << StringHelper::format(ms) << " ms, "
                   << StringHelper::format(tps, 1) << " TPS" << std::endl;
+
+        if (profile) {
+            std::cout << std::endl << KernelProfiler::get().getReport() << std::endl;
+        }
 
 
         //write output simulation file

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -551,9 +551,8 @@ union ObjectTypeData
 
 struct Object
 {
-    // Hot fields read while scanning the spatial object map (SPH fluid forces, connection/verlet/cell-state kernels).
-    // They are grouped at the front so that the per-neighbor filter (type, pos) and the linked-list traversal
-    // (nextObject) hit a single cache line instead of being spread across the large struct.
+    // Hot fields for the spatial neighbor scan, kept in the first cache line so the per-neighbor filter (pos,
+    // type) and linked-list traversal (nextObject) hit one line instead of three.
     Object* nextObject;  // Linked list for finding all overlapping cells
     float2 pos;
     float2 vel;

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -551,30 +551,32 @@ union ObjectTypeData
 
 struct Object
 {
-    // General
-    uint64_t id;
-    uint8_t numConnections;
-    ObjectConnection connections[MAX_OBJECT_CONNECTIONS];
+    // Hot fields read while scanning the spatial object map (SPH fluid forces, connection/verlet/cell-state kernels).
+    // They are grouped at the front so that the per-neighbor filter (type, pos) and the linked-list traversal
+    // (nextObject) hit a single cache line instead of being spread across the large struct.
+    Object* nextObject;  // Linked list for finding all overlapping cells
     float2 pos;
     float2 vel;
+    float density;
+    ObjectType type;
     float stiffness;
+    uint8_t numConnections;
     uint8_t color;
     bool fixed;
     bool sticky;
-    ObjectType type;
-    ObjectTypeData typeData;
-
-    // Editing data
     uint8_t selected;  // 0 = no, 1 = selected, 2 = cluster selected
     uint8_t detached;  // 0 = no, 1 = yes
+    int locked;        // 0 = unlocked, 1 = locked
+
+    // General
+    uint64_t id;
+    ObjectConnection connections[MAX_OBJECT_CONNECTIONS];
 
     // Internal algorithm data
-    int locked;  // 0 = unlocked, 1 = locked
     TempValue tempValue1;
     TempValue tempValue2;
 
-    float density;
-    Object* nextObject;  // Linked list for finding all overlapping cells
+    ObjectTypeData typeData;
 
     __device__ __inline__ float& getRefDistance(Object* connectedObject)
     {

--- a/source/EngineKernels/Macros.cuh
+++ b/source/EngineKernels/Macros.cuh
@@ -94,63 +94,63 @@ void checkAndThrowError(T result)
 
 #define KERNEL_CALL(func, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<gpuSettings.numBlocks, 8>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<gpuSettings.numBlocks, 8>>>(__VA_ARGS__); \
     }
 
 #define KERNEL_CALL_1_1(func, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<1, 1>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<1, 1>>>(__VA_ARGS__); \
     }
 
 #define KERNEL_CALL_MOD(func, threadsPerBlock, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<gpuSettings.numBlocks, threadsPerBlock>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<gpuSettings.numBlocks, threadsPerBlock>>>(__VA_ARGS__); \
     }
 
-// Stream-based kernel launch macros for CUDA Graph capture
-// In debug mode, synchronize after each kernel for precise crash information and record its wall-clock time for
-// profiling. On the regular (graph-captured) path no synchronization or timing code is generated.
+// Stream-based kernel launch macros for CUDA Graph capture.
+// In debug mode, synchronize after each kernel (precise crash info) and record its duration; the regular
+// graph-captured path generates no synchronization or timing code.
 #define STREAM_KERNEL_CALL(func, stream, numBlocks, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<numBlocks, 8, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<numBlocks, 8, 0, stream>>>(__VA_ARGS__); \
     }
 
 #define STREAM_KERNEL_CALL_1_1(func, stream, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<1, 1, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<1, 1, 0, stream>>>(__VA_ARGS__); \
     }
 
 #define STREAM_KERNEL_CALL_MOD(func, stream, numBlocks, threadsPerBlock, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
-        auto _profStart = std::chrono::steady_clock::now(); \
+        auto profStart = std::chrono::steady_clock::now(); \
         func<<<numBlocks, threadsPerBlock, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
-        KernelProfiler::get().record(#func, _profStart); \
+        KernelProfiler::get().record(#func, std::chrono::steady_clock::now() - profStart); \
     } else { \
         func<<<numBlocks, threadsPerBlock, 0, stream>>>(__VA_ARGS__); \
     }

--- a/source/EngineKernels/Macros.cuh
+++ b/source/EngineKernels/Macros.cuh
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include <Base/AlienExceptions.h>
 #include <Base/GlobalSettings.h>
+#include <Base/KernelProfiler.h>
 #include <Base/LoggingService.h>
 #include <Base/Singleton.h>
 
@@ -92,44 +94,63 @@ void checkAndThrowError(T result)
 
 #define KERNEL_CALL(func, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
         func<<<gpuSettings.numBlocks, 8>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
+        KernelProfiler::get().record(#func, _profStart); \
     } else { \
         func<<<gpuSettings.numBlocks, 8>>>(__VA_ARGS__); \
     }
 
 #define KERNEL_CALL_1_1(func, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
         func<<<1, 1>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
+        KernelProfiler::get().record(#func, _profStart); \
     } else { \
         func<<<1, 1>>>(__VA_ARGS__); \
     }
 
 #define KERNEL_CALL_MOD(func, threadsPerBlock, ...) \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
         func<<<gpuSettings.numBlocks, threadsPerBlock>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaDeviceSynchronize()); \
+        KernelProfiler::get().record(#func, _profStart); \
     } else { \
         func<<<gpuSettings.numBlocks, threadsPerBlock>>>(__VA_ARGS__); \
     }
 
 // Stream-based kernel launch macros for CUDA Graph capture
-// In debug mode, synchronize after each kernel for precise crash information
+// In debug mode, synchronize after each kernel for precise crash information and record its wall-clock time for
+// profiling. On the regular (graph-captured) path no synchronization or timing code is generated.
 #define STREAM_KERNEL_CALL(func, stream, numBlocks, ...) \
-    func<<<numBlocks, 8, 0, stream>>>(__VA_ARGS__); \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
+        func<<<numBlocks, 8, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
+        KernelProfiler::get().record(#func, _profStart); \
+    } else { \
+        func<<<numBlocks, 8, 0, stream>>>(__VA_ARGS__); \
     }
 
 #define STREAM_KERNEL_CALL_1_1(func, stream, ...) \
-    func<<<1, 1, 0, stream>>>(__VA_ARGS__); \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
+        func<<<1, 1, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
+        KernelProfiler::get().record(#func, _profStart); \
+    } else { \
+        func<<<1, 1, 0, stream>>>(__VA_ARGS__); \
     }
 
 #define STREAM_KERNEL_CALL_MOD(func, stream, numBlocks, threadsPerBlock, ...) \
-    func<<<numBlocks, threadsPerBlock, 0, stream>>>(__VA_ARGS__); \
     if (GlobalSettings::get().isDebugMode()) { \
+        auto _profStart = std::chrono::steady_clock::now(); \
+        func<<<numBlocks, threadsPerBlock, 0, stream>>>(__VA_ARGS__); \
         CHECK_FOR_DEVICE_ERRORS(cudaStreamSynchronize(stream)); \
+        KernelProfiler::get().record(#func, _profStart); \
+    } else { \
+        func<<<numBlocks, threadsPerBlock, 0, stream>>>(__VA_ARGS__); \
     }


### PR DESCRIPTION
## Summary
Two commits:
1. **Per-kernel profiling** for the simulation kernels (`KernelProfiler` + `cli --profile`), used to find the hotspots. Zero overhead on the normal CUDA-graph path.
2. **A memory-layout optimization** of the `Object` struct that cuts memory traffic in the memory-bound neighbor-scan kernels, giving **+11.3% TPS** on the test simulation.

## Original task
Improve simulation performance: enable debug mode, profile `D:\test.sim` with the `cli` tool by adding per-kernel timing in `SimulationKernelsService`, find where the time goes (mod-3 / every-3rd-step kernels), then optimize the hot kernels. Follow-up: pursue memory-bound savings.

## Profiling
`cli -i <sim> -o <out> -t <steps> --profile` enables debug mode and prints a per-kernel wall-clock report (debug mode bypasses CUDA graphs and synchronizes after each kernel, so absolute times are slow but the ranking is faithful).

Hotspots on `D:\test.sim` (RTX 4090): `cudaNextTimestep_physics_calcFluidForces` ~24.5%, then `calcConnectionForces`, `cellType_sensor`, `fillMaps`, `calcFluidBoundaryForces`, verlet/applyForces.

Profiling showed the simulation is **memory-bound**: the object array holds pointers to heap-allocated `Object` structs, so neighbor/per-cell access is scattered. ALU and occupancy/block-size tuning made no measurable difference (verified with a warm A/B); only reducing memory traffic helped.

## Optimization
The `Object` struct (~500 bytes) had `pos`, `type` and `nextObject` spread across three cache lines, so the SPH neighbor scan touched ~3 lines per neighbor just to filter and advance the linked list. Reordering the struct so the hot scan fields (`nextObject`, `pos`, `vel`, `type`, `density`) sit in the first cache line lets the per-neighbor filter + traversal hit one line. This is a behavior-preserving field reorder (no serialization change — connections use heap byte-offsets, not field offsets).

### Results
Per-kernel (debug, isolated, same input):

| kernel | before | after | change |
|---|---:|---:|---:|
| `calcFluidForces` | 1222.7 us | 809.0 us | **-34%** |
| `verletPositionUpdate` | 230.0 us | 193.5 us | -16% |
| `calcConnectionForces` | 186.4 us | 164.3 us | -12% |
| `calcFluidBoundaryForces` | 306.9 us | 272.0 us | -11% |

Release throughput (interleaved warm A/B, 3x3000 steps each, clean builds):

| build | TPS |
|---|---:|
| original | 195.4 |
| reordered | **217.4** |

**= +11.3% TPS.**

## Correctness
The simulation is non-deterministic (float `atomicAdd` ordering differs run-to-run, confirmed by running the same binary twice), so output files are not bit-identical even without changes. Correctness is validated by the engine test suite, which compares with tolerances.

## Build and tests (on the reordered build)
- `cmake --build build --config Release -j32`: passed (clean rebuild; note: incremental builds may miss the `Entities.cuh` transitive dependency for CUDA TUs, so a clean build is needed after struct changes)
- `./EngineInterfaceTests`: passed (153)
- `./NetworkTests`: passed (4)
- `./PersisterTests`: passed (64)
- `./EngineTests`: passed (2992; 3 skipped, 2 disabled - pre-existing)
- `./cli --profile`: works

## Notes
- The pre-existing non-zero process exit code at teardown on the CUDA-graph path is unrelated to these changes (the `--profile` path, which bypasses graphs, exits 0).
- The profiler remains as the basis for further memory-traffic work (e.g. SoA for additional hot fields).