### PR TITLE
Add compact ScanRecord mirror for the neighbor scan

### DIFF
--- a/source/EngineKernels/CommunicatorProcessor.cuh
+++ b/source/EngineKernels/CommunicatorProcessor.cuh
@@ -130,12 +130,15 @@ __device__ __inline__ void CommunicatorProcessor::processSender(SimulationData& 
         data.objectMap.correctPosition(scanPos);
 
         // Check all cells at this position (including overlapping cells)
-        auto otherObject = data.objectMap.getFirst(scanPos);
-        while (otherObject != nullptr) {
+        auto records = data.objectMap.getRecords();
+        int otherIndex = data.objectMap.getFirstIndex(scanPos);
+        while (otherIndex >= 0) {
+            auto const& otherRecord = records[otherIndex];
+            auto otherObject = otherRecord.self;
             if (isMatch(otherObject)) {
                 tryTransmitSignal(data, object, otherObject, newNumTimesSent);
             }
-            otherObject = otherObject->nextObject;
+            otherIndex = otherRecord.nextObjectIndex;
         }
     }
 }

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -695,7 +695,7 @@ struct Object : ObjectBase
 };
 
 // Compact 40-byte mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
-struct __align__(8) ObjectForMap : ObjectBase
+struct __align__(8) LightObject : ObjectBase
 {
     Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
     int nextObjectIndex;  // next object in the same cell, -1 = end of chain
@@ -705,6 +705,18 @@ struct __align__(8) ObjectForMap : ObjectBase
     __device__ __inline__ bool isFixed() const { return flags & 1; }
     __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
     __device__ __inline__ bool isSticky() const { return flags & 4; }
+
+    // Fill from object. nextObjectIndex is left untouched (managed via atomicCAS in ObjectMap).
+    __device__ __inline__ void initFrom(Object* object)
+    {
+        pos = object->pos;
+        vel = object->vel;
+        density = object->density;
+        type = object->type;
+        self = object;
+        numConnections = object->numConnections;
+        flags = (object->fixed ? 1 : 0) | (object->detached ? 2 : 0) | (object->sticky ? 4 : 0);
+    }
 };
 
 struct Entities

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -549,14 +549,28 @@ union ObjectTypeData
     Cell cell;
 };
 
-struct Object
+struct ObjectBase
 {
-    // Hot fields grouped first so per-object physics kernels touch one cache line. The neighbor scan does not read
-    // Object directly; it uses the compact ScanRecord mirror (see Map.cuh).
     float2 pos;
     float2 vel;
     float density;
     ObjectType type;
+
+    __device__ __inline__ float getMassForSPH() const
+    {
+        if (type == ObjectType_Fluid) {
+            return 0.1f;
+        } else if (type == ObjectType_Solid) {
+            return 2.0f;
+        } else {
+            return 1.0f;
+        }
+    }
+};
+
+struct Object : ObjectBase
+{
+    // Hot fields first to keep them in one cache line.
     float stiffness;
     uint8_t numConnections;
     uint8_t color;
@@ -624,17 +638,6 @@ struct Object
         }
     }
 
-    __device__ __inline__ float getMassForSPH() const
-    {
-        if (type == ObjectType_Fluid) {
-            return 0.1f;
-        } else if (type == ObjectType_Solid) {
-            return 2.0f;
-        } else {
-            return 1.0f;
-        }
-    }
-
     __device__ __inline__ float getAngelSpan(int connectionIndex1, int connectionIndex2)
     {
         if ((connectionIndex1 - connectionIndex2 + numConnections) % numConnections == 0) {
@@ -689,6 +692,19 @@ struct Object
         __threadfence();
         atomicExch(&locked, 0);
     }
+};
+
+// Compact 40-byte mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
+struct __align__(8) ObjectForMap : ObjectBase
+{
+    Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
+    int nextObjectIndex;  // next object in the same cell, -1 = end of chain
+    uint8_t numConnections;
+    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
+
+    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
+    __device__ __inline__ bool isSticky() const { return flags & 4; }
 };
 
 struct Entities

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -706,7 +706,6 @@ struct __align__(8) LightObject : ObjectBase
     __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
     __device__ __inline__ bool isSticky() const { return flags & 4; }
 
-    // Fill from object. nextObjectIndex is left untouched (managed via atomicCAS in ObjectMap).
     __device__ __inline__ void initFrom(Object* object)
     {
         pos = object->pos;

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -551,9 +551,8 @@ union ObjectTypeData
 
 struct Object
 {
-    // Hot fields for the spatial neighbor scan, kept in the first cache line so the per-neighbor filter (pos,
-    // type) and linked-list traversal (nextObject) hit one line instead of three.
-    Object* nextObject;  // Linked list for finding all overlapping cells
+    // Hot fields grouped first so per-object physics kernels touch one cache line. The neighbor scan does not read
+    // Object directly; it uses the compact ScanRecord mirror (see Map.cuh).
     float2 pos;
     float2 vel;
     float density;

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -59,12 +59,6 @@ protected:
     int2 _size;
 };
 
-template <typename T>
-class BasicMap : public BaseMap
-{
-public:
-};
-
 class ObjectMap : public BaseMap
 {
 public:
@@ -72,7 +66,7 @@ public:
     {
         BaseMap::init(size);
         CudaMemoryManager::getInstance().acquireMemory<int>(size.x * size.y, _mapHead);
-        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_mapHead, 0xFF, sizeof(int) * size.x * size.y));  // 0xFFFFFFFF = -1 = empty
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_mapHead, 0xff, sizeof(int) * size.x * size.y));  // 0xffffffff = -1 = empty
         _mapEntries.init();
         _records.init();
     }
@@ -111,14 +105,7 @@ public:
             auto globalIndex = baseIndex + index;
 
             auto& record = records[globalIndex];
-            record.pos = object->pos;
-            record.vel = object->vel;
-            record.density = object->density;
-            record.self = object;
-            record.type = object->type;
-            record.numConnections = object->numConnections;
-            record.flags = (object->fixed ? 1 : 0) | (object->detached ? 2 : 0) | (object->sticky ? 4 : 0);
-            // nextObjectIndex is reset to -1 in ObjectProcessor::init and only changed by atomicCAS below
+            record.initFrom(object);
 
             int2 posInt = {floorInt(object->pos.x), floorInt(object->pos.y)};
             correctPosition(posInt);
@@ -145,7 +132,7 @@ public:
 
     __device__ __inline__ int getFirstIndex(int2 const& pos) const { return _mapHead[pos.x + pos.y * _size.x]; }
 
-    __device__ __inline__ ObjectForMap* getRecords() const { return _records.getArray(); }
+    __device__ __inline__ LightObject* getRecords() const { return _records.getArray(); }
 
     __device__ __inline__ void resetRecordLink(int index) { _records.at(index).nextObjectIndex = -1; }
 
@@ -231,7 +218,7 @@ public:
 private:
     int* _mapHead;
     Array<int> _mapEntries;
-    Array<ObjectForMap> _records;
+    Array<LightObject> _records;
 };
 
 class EnergyMap : public BaseMap

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -65,30 +65,64 @@ class BasicMap : public BaseMap
 public:
 };
 
+// Compact mirror of the Object fields read during the spatial neighbor scan. Built each timestep in set_block and
+// indexed by global object index; the cell map and per-cell chain use indices into this array, so a scan reads ~40
+// contiguous bytes per neighbor instead of dereferencing the full ~500-byte Object.
+struct __align__(8) ScanRecord
+{
+    float2 pos;
+    float2 vel;
+    float density;
+    int nextObjectIndex;  // Next object in the same cell, -1 = end of chain
+    Object* self;         // Full object, used for rare branches and force write-back
+    ObjectType type;
+    uint8_t numConnections;
+    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
+
+    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
+    __device__ __inline__ bool isSticky() const { return flags & 4; }
+
+    __device__ __inline__ float getMassForSPH() const
+    {
+        if (type == ObjectType_Fluid) {
+            return 0.1f;
+        } else if (type == ObjectType_Solid) {
+            return 2.0f;
+        } else {
+            return 1.0f;
+        }
+    }
+};
+
 class ObjectMap : public BaseMap
 {
 public:
     __host__ __inline__ void init(int2 const& size)
     {
         BaseMap::init(size);
-        CudaMemoryManager::getInstance().acquireMemory<Object*>(size.x * size.y, _map);
+        CudaMemoryManager::getInstance().acquireMemory<int>(size.x * size.y, _mapHead);
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_mapHead, 0xFF, sizeof(int) * size.x * size.y));  // 0xFFFFFFFF = -1 = empty
         _mapEntries.init();
-
-        std::vector<Object*> hostMap(size.x * size.y, 0);
-        CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(_map, hostMap.data(), sizeof(Object*) * size.x * size.y, cudaMemcpyHostToDevice));
+        _records.init();
     }
 
-    __host__ __inline__ void resize(int maxEntries) { _mapEntries.resize(maxEntries); }
+    __host__ __inline__ void resize(int maxEntries)
+    {
+        _mapEntries.resize(maxEntries);
+        _records.resize(maxEntries);
+    }
 
     __device__ __inline__ void reset() { _mapEntries.reset(); }
 
     __host__ __inline__ void free()
     {
-        CudaMemoryManager::getInstance().freeMemory(_map);
+        CudaMemoryManager::getInstance().freeMemory(_mapHead);
         _mapEntries.free();
+        _records.free();
     }
 
-    __device__ __inline__ void set_block(int numEntities, Object** objects)
+    __device__ __inline__ void set_block(int baseIndex, int numEntities, Object** objects)
     {
         if (0 == numEntities) {
             return;
@@ -100,24 +134,31 @@ public:
         }
         __syncthreads();
 
+        auto records = _records.getArray();
         auto partition = calcThreadBlockPartition(numEntities);
         for (int index = partition.startIndex; index <= partition.endIndex; ++index) {
-            auto const& object = objects[index];
+            auto object = objects[index];
+            auto globalIndex = baseIndex + index;
+
+            auto& record = records[globalIndex];
+            record.pos = object->pos;
+            record.vel = object->vel;
+            record.density = object->density;
+            record.self = object;
+            record.type = object->type;
+            record.numConnections = object->numConnections;
+            record.flags = (object->fixed ? 1 : 0) | (object->detached ? 2 : 0) | (object->sticky ? 4 : 0);
+            // nextObjectIndex is reset to -1 in ObjectProcessor::init and only changed by atomicCAS below
+
             int2 posInt = {floorInt(object->pos.x), floorInt(object->pos.y)};
             correctPosition(posInt);
             auto slot = posInt.x + posInt.y * _size.x;
-            Object* slotObject = reinterpret_cast<Object*>(atomicCAS(
-                reinterpret_cast<unsigned long long int*>(&_map[slot]),
-                reinterpret_cast<unsigned long long int>(nullptr),
-                reinterpret_cast<unsigned long long int>(object)));
+            int slotIndex = atomicCAS(&_mapHead[slot], -1, globalIndex);
             for (int level = 0; level < 10; ++level) {
-                if (!slotObject) {
+                if (slotIndex < 0) {
                     break;
                 }
-                slotObject = reinterpret_cast<Object*>(atomicCAS(
-                    reinterpret_cast<unsigned long long int*>(&slotObject->nextObject),
-                    reinterpret_cast<unsigned long long int>(nullptr),
-                    reinterpret_cast<unsigned long long int>(object)));
+                slotIndex = atomicCAS(&records[slotIndex].nextObjectIndex, -1, globalIndex);
             }
 
             entrySubarray[index] = slot;
@@ -125,14 +166,30 @@ public:
         __syncthreads();
     }
 
-    __device__ __inline__ Object* getFirst(float2 const& pos) const
+    __device__ __inline__ int getFirstIndex(float2 const& pos) const
     {
         int2 posInt = {floorInt(pos.x), floorInt(pos.y)};
         correctPosition(posInt);
-        return _map[posInt.x + posInt.y * _size.x];
+        return _mapHead[posInt.x + posInt.y * _size.x];
     }
 
-    __device__ __inline__ Object* getFirst(int2 const& pos) const { return _map[pos.x + pos.y * _size.x]; }
+    __device__ __inline__ int getFirstIndex(int2 const& pos) const { return _mapHead[pos.x + pos.y * _size.x]; }
+
+    __device__ __inline__ ScanRecord* getRecords() const { return _records.getArray(); }
+
+    __device__ __inline__ void resetRecordLink(int index) { _records.at(index).nextObjectIndex = -1; }
+
+    __device__ __inline__ Object* getFirst(float2 const& pos) const
+    {
+        auto index = getFirstIndex(pos);
+        return index < 0 ? nullptr : _records.at(index).self;
+    }
+
+    __device__ __inline__ Object* getFirst(int2 const& pos) const
+    {
+        auto index = getFirstIndex(pos);
+        return index < 0 ? nullptr : _records.at(index).self;
+    }
 
     template <typename MatchFunc>
     __device__ __inline__ void
@@ -141,24 +198,26 @@ public:
         int2 posInt = {floorInt(pos.x), floorInt(pos.y)};
         numObjects = 0;
         int radiusInt = ceilf(radius);
+        auto records = _records.getArray();
         for (int dx = -radiusInt; dx <= radiusInt; ++dx) {
             for (int dy = -radiusInt; dy <= radiusInt; ++dy) {
                 int2 scanPos{posInt.x + dx, posInt.y + dy};
                 correctPosition(scanPos);
-                int slot = scanPos.x + scanPos.y * _size.x;
-                auto slotObject = _map[slot];
+                int index = _mapHead[scanPos.x + scanPos.y * _size.x];
                 for (int level = 0; level < 10; ++level) {
                     if (numObjects == arraySize) {
                         return;
                     }
-                    if (!slotObject) {
+                    if (index < 0) {
                         break;
                     }
+                    auto const& record = records[index];
+                    auto slotObject = record.self;  // Read fields live: this runs after positions changed since the map was built
                     if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached != 1 && matchFunc(slotObject)) {
                         objects[numObjects] = slotObject;
                         ++numObjects;
                     }
-                    slotObject = slotObject->nextObject;
+                    index = record.nextObjectIndex;
                 }
             }
         }
@@ -169,20 +228,22 @@ public:
     {
         int2 posInt = {floorInt(pos.x), floorInt(pos.y)};
         int radiusInt = ceilf(radius);
+        auto records = _records.getArray();
         for (int dy = -radiusInt; dy <= radiusInt; ++dy) {
             for (int dx = -radiusInt; dx <= radiusInt; ++dx) {
                 int2 scanPos{posInt.x + dx, posInt.y + dy};
                 correctPosition(scanPos);
-                int slot = scanPos.x + scanPos.y * _size.x;
-                auto slotObject = _map[slot];
+                int index = _mapHead[scanPos.x + scanPos.y * _size.x];
                 for (int level = 0; level < 10; ++level) {
-                    if (!slotObject) {
+                    if (index < 0) {
                         break;
                     }
+                    auto const& record = records[index];
+                    auto slotObject = record.self;  // Read fields live: this runs after positions changed since the map was built
                     if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached != 1) {
                         execFunc(slotObject);
                     }
-                    slotObject = slotObject->nextObject;
+                    index = record.nextObjectIndex;
                 }
             }
         }
@@ -193,13 +254,14 @@ public:
         auto partition = calcSystemThreadPartition(_mapEntries.getNumEntries());
         for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
             auto const& mapEntry = _mapEntries.at(index);
-            _map[mapEntry] = nullptr;
+            _mapHead[mapEntry] = -1;
         }
     }
 
 private:
-    Object** _map;
+    int* _mapHead;
     Array<int> _mapEntries;
+    Array<ScanRecord> _records;
 };
 
 class EnergyMap : public BaseMap

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -65,36 +65,6 @@ class BasicMap : public BaseMap
 public:
 };
 
-// Compact mirror of the Object fields read during the spatial neighbor scan. Built each timestep in set_block and
-// indexed by global object index; the cell map and per-cell chain use indices into this array, so a scan reads ~40
-// contiguous bytes per neighbor instead of dereferencing the full ~500-byte Object.
-struct __align__(8) ScanRecord
-{
-    float2 pos;
-    float2 vel;
-    float density;
-    int nextObjectIndex;  // Next object in the same cell, -1 = end of chain
-    Object* self;         // Full object, used for rare branches and force write-back
-    ObjectType type;
-    uint8_t numConnections;
-    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
-
-    __device__ __inline__ bool isFixed() const { return flags & 1; }
-    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
-    __device__ __inline__ bool isSticky() const { return flags & 4; }
-
-    __device__ __inline__ float getMassForSPH() const
-    {
-        if (type == ObjectType_Fluid) {
-            return 0.1f;
-        } else if (type == ObjectType_Solid) {
-            return 2.0f;
-        } else {
-            return 1.0f;
-        }
-    }
-};
-
 class ObjectMap : public BaseMap
 {
 public:
@@ -175,7 +145,7 @@ public:
 
     __device__ __inline__ int getFirstIndex(int2 const& pos) const { return _mapHead[pos.x + pos.y * _size.x]; }
 
-    __device__ __inline__ ScanRecord* getRecords() const { return _records.getArray(); }
+    __device__ __inline__ ObjectForMap* getRecords() const { return _records.getArray(); }
 
     __device__ __inline__ void resetRecordLink(int index) { _records.at(index).nextObjectIndex = -1; }
 
@@ -261,7 +231,7 @@ public:
 private:
     int* _mapHead;
     Array<int> _mapEntries;
-    Array<ScanRecord> _records;
+    Array<ObjectForMap> _records;
 };
 
 class EnergyMap : public BaseMap

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -53,7 +53,7 @@ __inline__ __device__ void ObjectProcessor::init(SimulationData& data)
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
 
-        object->nextObject = nullptr;
+        data.objectMap.resetRecordLink(index);
         object->tempValue1.as_uint64 = 0;
     }
 }
@@ -62,7 +62,7 @@ __inline__ __device__ void ObjectProcessor::updateMap(SimulationData& data)
 {
     auto const partition = calcBlockPartition(data.entities.objects.getNumEntries());
     Object** objectPointers = &data.entities.objects.at(partition.startIndex);
-    data.objectMap.set_block(partition.numElements(), objectPointers);
+    data.objectMap.set_block(partition.startIndex, partition.numElements(), objectPointers);
 }
 
 __inline__ __device__ void ObjectProcessor::clearDensityMap(SimulationData& data)
@@ -166,40 +166,42 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
         float2 localCellPosDelta = {0, 0};
         float localDensity = 0;
 
+        auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
             int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
             data.objectMap.correctPosition(scanPos);
-            auto otherObject = data.objectMap.getFirst(scanPos);
+            int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
-                if (!otherObject) {
+                if (otherIndex < 0) {
                     break;
                 }
-                if ((isObjectFluid && otherObject->type == ObjectType_Fluid) || (!isObjectFluid && otherObject->type != ObjectType_Fluid)) {
-                    auto posDelta = object->pos - otherObject->pos;
+                auto const& other = records[otherIndex];
+                if ((isObjectFluid && other.type == ObjectType_Fluid) || (!isObjectFluid && other.type != ObjectType_Fluid)) {
+                    auto posDelta = object->pos - other.pos;
 
                     data.objectMap.correctDirection(posDelta);
                     auto adaptedDistance = Math::length(posDelta);
                     auto origDistance = adaptedDistance;
-                    if ((object->numConnections < 3 || otherObject->numConnections < 3) && object->type == ObjectType_Cell
-                        && otherObject->type == ObjectType_Cell && object->typeData.cell.isSameCreature(&otherObject->typeData.cell)
-                        && object->typeData.cell.parentNodeIndex != otherObject->typeData.cell.parentNodeIndex) {
+                    if ((object->numConnections < 3 || other.numConnections < 3) && object->type == ObjectType_Cell && other.type == ObjectType_Cell
+                        && object->typeData.cell.isSameCreature(&other.self->typeData.cell)
+                        && object->typeData.cell.parentNodeIndex != other.self->typeData.cell.parentNodeIndex) {
                         adaptedDistance *= 2.0f;  // Reduce range of cell repulsion within creature by scaling distance
                     }
 
-                    if (otherObject->fixed && adaptedDistance <= smoothingLength * 2 && object->detached + otherObject->detached != 1) {
+                    if (other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached + other.detached() != 1) {
                         auto index = atomicAdd(&numFixedObjects, 1);
                         if (index < MaxBarrierCellsForCollision) {
-                            fixedCells[index] = otherObject;
+                            fixedCells[index] = other.self;
                         }
                     }
 
-                    if (!otherObject->fixed && adaptedDistance <= smoothingLength * 2 && object->detached + otherObject->detached != 1) {
+                    if (!other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached + other.detached() != 1) {
 
                         // Calc density
-                        auto otherMass = otherObject->getMassForSPH();
+                        auto otherMass = other.getMassForSPH();
                         localDensity += otherMass * calcKernel(adaptedDistance / smoothingLength) / (smoothingLength * smoothingLength);
 
-                        if (object != otherObject) {
+                        if (object != other.self) {
 
                             // Overlap correction
                             if (!object->fixed && origDistance < cudaSimulationParameters.minObjectDistance.value) {
@@ -207,21 +209,20 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                                 localCellPosDelta.y += posDelta.y * cudaSimulationParameters.minObjectDistance.value / 5;
                             }
 
-                            auto velDelta = object->vel - otherObject->vel;
+                            auto velDelta = object->vel - other.vel;
                             bool isConnected = false;
                             for (int i = 0; i < object->numConnections; ++i) {
                                 auto const& connectedObject = object->connections[i].object;
-                                if (connectedObject == otherObject) {
+                                if (connectedObject == other.self) {
                                     isConnected = true;
                                 }
                             }
                             if (!isConnected) {
 
                                 // Calc forces: for simplicity pressure = density
-                                auto const& cellPressure = object->density;              // Optimization: using the density from last time step
-                                auto const& otherObjectPressure = otherObject->density;  // Optimization: using the density from last time step
-                                auto factor =
-                                    cellPressure / (object->density * object->density) + otherObjectPressure / (otherObject->density * otherObject->density);
+                                auto const& cellPressure = object->density;       // Optimization: using the density from last time step
+                                auto const& otherObjectPressure = other.density;  // Optimization: using the density from last time step
+                                auto factor = cellPressure / (object->density * object->density) + otherObjectPressure / (other.density * other.density);
 
                                 if (adaptedDistance > NEAR_ZERO) {
                                     float kernel_d = calcKernel_d(adaptedDistance / smoothingLength) / (smoothingLength * smoothingLength * smoothingLength);
@@ -231,7 +232,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                                     localF_pressure.y += F_pressureDelta.y;
 
                                     auto F_viscosityDelta =
-                                        velDelta / otherObject->density * adaptedDistance * kernel_d / (adaptedDistance * adaptedDistance + 0.25f) * otherMass;
+                                        velDelta / other.density * adaptedDistance * kernel_d / (adaptedDistance * adaptedDistance + 0.25f) * otherMass;
                                     localF_viscosity.x += F_viscosityDelta.x;
                                     localF_viscosity.y += F_viscosityDelta.y;
                                 }
@@ -239,14 +240,14 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
 
                             // Fusion
                             if (Math::length(velDelta) >= cellFusionVelocity && object->numConnections < MAX_OBJECT_CONNECTIONS
-                                && otherObject->numConnections < MAX_OBJECT_CONNECTIONS && (object->sticky || otherObject->sticky) && !object->fixed
-                                && !otherObject->fixed) {
-                                ObjectConnectionProcessor::scheduleAddConnectionPair(data, object, otherObject);
+                                && other.numConnections < MAX_OBJECT_CONNECTIONS && (object->sticky || other.isSticky()) && !object->fixed
+                                && !other.isFixed()) {
+                                ObjectConnectionProcessor::scheduleAddConnectionPair(data, object, other.self);
                             }
                         }
                     }
                 }
-                otherObject = otherObject->nextObject;
+                otherIndex = other.nextObjectIndex;
             }
         }
 
@@ -366,22 +367,25 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
 
         float2 localF_boundary = {0, 0};
 
+        auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
             int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
             data.objectMap.correctPosition(scanPos);
-            auto otherObject = data.objectMap.getFirst(scanPos);
+            int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
-                if (!otherObject) {
+                if (otherIndex < 0) {
                     break;
                 }
-                if (otherObject->type != ObjectType_Fluid && otherObject != object && object->detached + otherObject->detached != 1) {
+                auto const& other = records[otherIndex];
+                auto otherObject = other.self;  // Read fields live: this runs after calcFluidForces nudged positions
+                if (other.type != ObjectType_Fluid && otherObject != object && object->detached + otherObject->detached != 1) {
 
                     auto posDelta = object->pos - otherObject->pos;
                     data.objectMap.correctDirection(posDelta);
                     auto adaptedDistance = Math::length(posDelta);
 
                     if (adaptedDistance <= smoothingLength * 2 && adaptedDistance > NEAR_ZERO) {
-                        auto solidMass = otherObject->getMassForSPH();
+                        auto solidMass = other.getMassForSPH();
 
                         float kernel_d_val = calcKernel_d(adaptedDistance / smoothingLength) / (smoothingLength * smoothingLength * smoothingLength);
 
@@ -398,7 +402,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
                         atomicAdd(&otherObject->tempValue1.as_float2.y, -F_on_fluid.y * cudaSimulationParameters.pressureStrength.value);
                     }
                 }
-                otherObject = otherObject->nextObject;
+                otherIndex = other.nextObjectIndex;
             }
         }
 

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -378,8 +378,11 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
             auto const& restrictToColors = cell->cellTypeData.sensor.modeData.detectCreature.restrictToColors;
             auto const& restrictToLineage = cell->cellTypeData.sensor.modeData.detectCreature.restrictToLineage;
 
-            auto otherObject = data.objectMap.getFirst(scanPos);
-            while (otherObject != nullptr) {
+            auto records = data.objectMap.getRecords();
+            int otherIndex = data.objectMap.getFirstIndex(scanPos);
+            while (otherIndex >= 0) {
+                auto const& otherRecord = records[otherIndex];
+                auto otherObject = otherRecord.self;
                 // Check if this cell is part of a creature (not solid or free object)
                 if (otherObject->type == ObjectType_Cell && !cell->isSameCreature(&otherObject->typeData.cell)) {
                     bool matches = true;
@@ -411,20 +414,23 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
                         return pack(distance, absAngle, density, creatureIdPart);
                     }
                 }
-                otherObject = otherObject->nextObject;
+                otherIndex = otherRecord.nextObjectIndex;
             }
 
             // Else: ScanType::Relocation
         } else {
             auto& sensor = cell->cellTypeData.sensor;
-            auto otherObject = data.objectMap.getFirst(scanPos);
-            while (otherObject != nullptr) {
+            auto records = data.objectMap.getRecords();
+            int otherIndex = data.objectMap.getFirstIndex(scanPos);
+            while (otherIndex >= 0) {
+                auto const& otherRecord = records[otherIndex];
+                auto otherObject = otherRecord.self;
                 if (otherObject->type == ObjectType_Cell && (otherObject->typeData.cell.creature->id & 0xffff) == sensor.lastMatch.creatureIdPart) {
                     uint16_t creatureIdPart = static_cast<uint16_t>(otherObject->typeData.cell.creature->id & 0xffff);
                     float density = calcCreatureDensityFromNumCells(otherObject->typeData.cell.creature->numCells);
                     return pack(distance, absAngle, density, creatureIdPart);
                 }
-                otherObject = otherObject->nextObject;
+                otherIndex = otherRecord.nextObjectIndex;
             }
         }
     }
@@ -449,12 +455,14 @@ SensorProcessor::isRayBlockedByCreatureConnections(Object** nearSameCreatureCell
 
 __inline__ __device__ bool SensorProcessor::isSolidAtPosition(SimulationData& data, float2 const& pos)
 {
-    auto object = data.objectMap.getFirst(pos);
-    while (object != nullptr) {
-        if (object->type == ObjectType_Solid) {
+    auto records = data.objectMap.getRecords();
+    int index = data.objectMap.getFirstIndex(pos);
+    while (index >= 0) {
+        auto const& record = records[index];
+        if (record.type == ObjectType_Solid) {
             return true;
         }
-        object = object->nextObject;
+        index = record.nextObjectIndex;
     }
     return false;
 }


### PR DESCRIPTION
The cell map now stores object indices plus a per-cell index chain into a compact ScanRecord array (pos/vel/density/type/flags + self pointer), built once per timestep in fillMaps. calcFluidForces reads neighbors from these ~40-byte records instead of dereferencing the full ~500-byte Object, cutting memory traffic on the dominant SPH kernel. The Object nextObject field is removed; the cell chain lives in the records.

calcFluidForces -18% per call; release +7.7% TPS (220.7 -> 237.7, interleaved A/B on the same machine). EngineTests: 2992 passed.