### PR TITLE
Use flags for fixed/detached/sticky on Object, LightObject and ObjectTO

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -302,8 +302,8 @@ ObjectDesc DescConverterService::createObjectDesc(TOs const& to, int objectIndex
         connections.emplace_back(connection);
     }
     result._connections = connections;
-    result._fixed = objectTO.fixed;
-    result._sticky = objectTO.sticky;
+    result._fixed = objectTO.isFixed();
+    result._sticky = objectTO.isSticky();
     result._color = objectTO.color;
 
     // Handle object type: Solid, Fluid, FreeCell, or Cell
@@ -1245,8 +1245,9 @@ void DescConverterService::convertObjectToTO(
     objectTO.vel = {objectDesc._vel.x, objectDesc._vel.y};
     objectTO.stiffness = objectDesc._stiffness;
     objectTO.numConnections = 0;
-    objectTO.fixed = objectDesc._fixed;
-    objectTO.sticky = objectDesc._sticky;
+    objectTO.flags = 0;
+    objectTO.setFixed(objectDesc._fixed);
+    objectTO.setSticky(objectDesc._sticky);
     objectTO.color = objectDesc._color;
 
     // Set object type

--- a/source/EngineKernels/AttackerProcessor.cuh
+++ b/source/EngineKernels/AttackerProcessor.cuh
@@ -46,7 +46,7 @@ __device__ __inline__ void AttackerProcessor::process(SimulationData& data, Simu
 
 __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
-    if (object->fixed) {
+    if (object->isFixed()) {
         return;
     }
     auto const& cell = &object->typeData.cell;
@@ -67,7 +67,7 @@ __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, 
         int numSensorTargets = 0;
         if (attackerMode == AttackerMode_Creature) {
             auto creatureId = cell->creature->id;
-            data.objectMap.executeForEach(object->pos, SimulationParameters::attackerCreatureSensorRange, object->detached, [&](auto const& nearObject) {
+            data.objectMap.executeForEach(object->pos, SimulationParameters::attackerCreatureSensorRange, object->detached(), [&](auto const& nearObject) {
                 if (nearObject->type != ObjectType_Cell) {
                     return;
                 }
@@ -112,11 +112,11 @@ __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, 
 
         auto sumEnergyToTransfer = 0.0f;
         data.objectMap.executeForEach(
-            object->pos, cudaSimulationParameters.attackerRadius.value[object->color], object->detached, [&](auto const& otherObject) {
+            object->pos, cudaSimulationParameters.attackerRadius.value[object->color], object->detached(), [&](auto const& otherObject) {
                 if (otherObject->type == ObjectType_Solid || otherObject->type == ObjectType_Fluid) {
                     return;
                 }
-                if (otherObject->fixed) {
+                if (otherObject->isFixed()) {
                     return;
                 }
 
@@ -191,8 +191,7 @@ __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, 
                     }
 
                     // Calculate energy gain
-                    auto energyToTransfer =
-                        calcAttackableEnergy(otherCell) * cudaSimulationParameters.attackerStrength.value * TIMESTEPS_PER_CELL_FUNCTION;
+                    auto energyToTransfer = calcAttackableEnergy(otherCell) * cudaSimulationParameters.attackerStrength.value * TIMESTEPS_PER_CELL_FUNCTION;
 
                     auto color = calcMod(object->color, MAX_COLORS);
                     auto otherColor = calcMod(otherObject->color, MAX_COLORS);

--- a/source/EngineKernels/CellProcessor.cuh
+++ b/source/EngineKernels/CellProcessor.cuh
@@ -61,7 +61,7 @@ __inline__ __device__ void CellProcessor::aging(SimulationData& data)
     auto const partition = calcSystemThreadPartition(data.entities.objects.getNumEntries());
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = data.entities.objects.at(index);
-        if (object->fixed || object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {
+        if (object->isFixed() || object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {
             continue;
         }
         uint32_t* age = nullptr;
@@ -116,7 +116,7 @@ __inline__ __device__ void CellProcessor::cellStateTransition_calcFutureState(Si
         auto origCellState = object->typeData.cell.cellState;
         auto cellState = origCellState;
 
-        if (object->fixed) {
+        if (object->isFixed()) {
             cellState = CellState_Ready;
         } else {
             if (origCellState == CellState_Activating) {
@@ -409,7 +409,7 @@ __inline__ __device__ void CellProcessor::decay(SimulationData& data, bool isPre
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
 

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -307,7 +307,7 @@ __inline__ __device__ Object* ConstructorProcessor::startConstructionOnNewBranch
     float2 newObjectPos = hostObject->pos + newObjectDirection / 2;
 
     if (ObjectConnectionProcessor::existCrossingConnections(
-            data, hostObject->pos, newObjectPos, cudaSimulationParameters.constructorConnectingCellDistance.value[hostObject->color], hostObject->detached)) {
+            data, hostObject->pos, newObjectPos, cudaSimulationParameters.constructorConnectingCellDistance.value[hostObject->color], hostObject->detached())) {
         return nullptr;
     }
 
@@ -508,7 +508,7 @@ __inline__ __device__ void ConstructorProcessor::getObjectsToConnect(
         result[i] = nullptr;
     }
 
-    data.objectMap.executeForEach(newObjectPos, SimulationParameters::attackerCreatureSensorRange, hostObject->detached, [&](auto const& otherObject) {
+    data.objectMap.executeForEach(newObjectPos, SimulationParameters::attackerCreatureSensorRange, hostObject->detached(), [&](auto const& otherObject) {
         if (numResultCells == constructionData.shapeResult.numAdditionalConnections) {
             return;
         }

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -302,8 +302,9 @@ namespace
         objectTO.vel = object->vel;
         objectTO.stiffness = object->stiffness;
         objectTO.color = object->color;
-        objectTO.fixed = object->fixed;
-        objectTO.sticky = object->sticky;
+        objectTO.flags = 0;
+        objectTO.setFixed(object->isFixed());
+        objectTO.setSticky(object->isSticky());
         objectTO.type = object->type;
 
         for (int i = 0; i < object->numConnections; ++i) {

--- a/source/EngineKernels/DetonatorProcessor.cuh
+++ b/source/EngineKernels/DetonatorProcessor.cuh
@@ -44,11 +44,11 @@ __device__ __inline__ void DetonatorProcessor::processCell(SimulationData& data,
             detonator.countdown = 0;
             statistics.incNumDetonations(object->color);
             data.objectMap.executeForEach(
-                object->pos, cudaSimulationParameters.detonatorRadius.value[object->color], object->detached, [&](Object* const& otherObject) {
+                object->pos, cudaSimulationParameters.detonatorRadius.value[object->color], object->detached(), [&](Object* const& otherObject) {
                     if (otherObject == object) {
                         return;
                     }
-                    if (otherObject->fixed) {
+                    if (otherObject->isFixed()) {
                         return;
                     }
                     auto delta = data.objectMap.getCorrectedDirection(otherObject->pos - object->pos);

--- a/source/EngineKernels/EditKernels.cu
+++ b/source/EngineKernels/EditKernels.cu
@@ -176,7 +176,7 @@ __global__ void cudaScheduleConnectSelection(SimulationData data, bool considerW
         if (1 != object->selected) {
             continue;
         }
-        data.objectMap.executeForEach(object->pos, 1.3f, object->detached, [&](auto const& otherObject) {
+        data.objectMap.executeForEach(object->pos, 1.3f, object->detached(), [&](auto const& otherObject) {
             if (!otherObject || otherObject == object) {
                 return;
             }
@@ -349,7 +349,7 @@ __global__ void cudaMakeSticky(SimulationData data, bool includeClusters)
     for (int index = objectPartition.startIndex; index <= objectPartition.endIndex; index += objectPartition.step) {
         auto const& object = data.entities.objects.at(index);
         if (isSelected(object, includeClusters)) {
-            object->sticky = true;
+            object->setSticky(true);
         }
     }
 }
@@ -360,7 +360,7 @@ __global__ void cudaRemoveStickiness(SimulationData data, bool includeClusters)
     for (int index = objectPartition.startIndex; index <= objectPartition.endIndex; index += objectPartition.step) {
         auto const& object = data.entities.objects.at(index);
         if (isSelected(object, includeClusters)) {
-            object->sticky = false;
+            object->setSticky(false);
         }
     }
 }
@@ -371,7 +371,7 @@ __global__ void cudaSetBarrier(SimulationData data, bool value, bool includeClus
     for (int index = objectPartition.startIndex; index <= objectPartition.endIndex; index += objectPartition.step) {
         auto const& object = data.entities.objects.at(index);
         if (isSelected(object, includeClusters)) {
-            object->fixed = value;
+            object->setFixed(value);
         }
     }
 }
@@ -423,7 +423,7 @@ __global__ void cudaApplyForce(SimulationData data, ApplyForceData applyData)
             auto pos = object->pos;
             pos += data.objectMap.getCorrectionIncrement(applyData.startPos, pos);
             auto distanceToSegment = Math::calcDistanceToLineSegment(applyData.startPos, applyData.endPos, pos, applyData.radius);
-            if (distanceToSegment < applyData.radius && !object->fixed) {
+            if (distanceToSegment < applyData.radius && !object->isFixed()) {
                 auto weightedForce = applyData.force;
                 //*(actionRadius - distanceToSegment) / actionRadius;
                 object->vel = object->vel + weightedForce;
@@ -452,7 +452,7 @@ __global__ void cudaSetDetached(SimulationData data, bool value)
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto const& object = data.entities.objects.at(index);
         if (0 != object->selected) {
-            object->detached = value ? 1 : 0;
+            object->setDetached(value);
         }
     }
 }

--- a/source/EngineKernels/EnergyProcessor.cuh
+++ b/source/EngineKernels/EnergyProcessor.cuh
@@ -102,7 +102,7 @@ __inline__ __device__ void EnergyProcessor::collision(SimulationData& data)
                 if (object->type == ObjectType_Fluid) {
                     continue;
                 }
-                if (object->fixed || object->type == ObjectType_Solid) {
+                if (object->isFixed() || object->type == ObjectType_Solid) {
                     auto vr = particle->vel - object->vel;
                     auto r = data.objectMap.getCorrectedDirection(particle->pos - object->pos);
                     auto dot_vr_r = Math::dot(vr, r);

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -549,21 +549,14 @@ union ObjectTypeData
     Cell cell;
 };
 
+// Geometry data shared by Object and LightObject. Kept at exactly 24 bytes (no tail padding) so that
+// derived structs stay compact; the flags byte lives in the derived structs where it packs without padding.
 struct ObjectBase
 {
     float2 pos;
     float2 vel;
     float density;
     ObjectType type;
-    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
-
-    __device__ __inline__ bool isFixed() const { return flags & 1; }
-    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
-    __device__ __inline__ bool isSticky() const { return flags & 4; }
-
-    __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
-    __device__ __inline__ void setDetached(bool value) { flags = value ? (flags | 2) : (flags & ~2); }
-    __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 
     __device__ __inline__ float getMassForSPH() const
     {
@@ -584,11 +577,20 @@ struct Object : ObjectBase
     uint8_t numConnections;
     uint8_t color;
     uint8_t selected;  // 0 = no, 1 = selected, 2 = cluster selected
+    uint8_t flags;     // bit0 = fixed, bit1 = detached, bit2 = sticky
     int locked;        // 0 = unlocked, 1 = locked
 
     // General
     uint64_t id;
     ObjectConnection connections[MAX_OBJECT_CONNECTIONS];
+
+    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
+    __device__ __inline__ bool isSticky() const { return flags & 4; }
+
+    __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
+    __device__ __inline__ void setDetached(bool value) { flags = value ? (flags | 2) : (flags & ~2); }
+    __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 
     // Internal algorithm data
     TempValue tempValue1;
@@ -700,12 +702,17 @@ struct Object : ObjectBase
     }
 };
 
-// Compact mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
+// Compact 40-byte mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
 struct __align__(8) LightObject : ObjectBase
 {
-    Object* self;         // self first keeps the pointer 8-aligned
+    Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
     int nextObjectIndex;  // next object in the same cell, -1 = end of chain
     uint8_t numConnections;
+    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
+
+    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
+    __device__ __inline__ bool isSticky() const { return flags & 4; }
 
     __device__ __inline__ void initFrom(Object* object)
     {
@@ -718,6 +725,9 @@ struct __align__(8) LightObject : ObjectBase
         flags = object->flags;
     }
 };
+
+// Keep the neighbor-scan mirror compact: growing it directly costs memory bandwidth in the hot SPH kernels.
+static_assert(sizeof(LightObject) == 40, "LightObject must stay 40 bytes for the neighbor scan");
 
 struct Entities
 {

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -555,6 +555,15 @@ struct ObjectBase
     float2 vel;
     float density;
     ObjectType type;
+    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
+
+    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
+    __device__ __inline__ bool isSticky() const { return flags & 4; }
+
+    __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
+    __device__ __inline__ void setDetached(bool value) { flags = value ? (flags | 2) : (flags & ~2); }
+    __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 
     __device__ __inline__ float getMassForSPH() const
     {
@@ -574,10 +583,7 @@ struct Object : ObjectBase
     float stiffness;
     uint8_t numConnections;
     uint8_t color;
-    bool fixed;
-    bool sticky;
     uint8_t selected;  // 0 = no, 1 = selected, 2 = cluster selected
-    uint8_t detached;  // 0 = no, 1 = yes
     int locked;        // 0 = unlocked, 1 = locked
 
     // General
@@ -694,17 +700,12 @@ struct Object : ObjectBase
     }
 };
 
-// Compact 40-byte mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
+// Compact mirror of Object for the neighbor scan: avoids touching the full ~500-byte Object per neighbor.
 struct __align__(8) LightObject : ObjectBase
 {
-    Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
+    Object* self;         // self first keeps the pointer 8-aligned
     int nextObjectIndex;  // next object in the same cell, -1 = end of chain
     uint8_t numConnections;
-    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
-
-    __device__ __inline__ bool isFixed() const { return flags & 1; }
-    __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
-    __device__ __inline__ bool isSticky() const { return flags & 4; }
 
     __device__ __inline__ void initFrom(Object* object)
     {
@@ -714,7 +715,7 @@ struct __align__(8) LightObject : ObjectBase
         type = object->type;
         self = object;
         numConnections = object->numConnections;
-        flags = (object->fixed ? 1 : 0) | (object->detached ? 2 : 0) | (object->sticky ? 4 : 0);
+        flags = object->flags;
     }
 };
 

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -95,7 +95,8 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.neuronMutations[i].weightSigma,
             genomeTO.mutationRates.neuronMutations[i].biasSigma,
             genomeTO.mutationRates.neuronMutations[i].activationFunctionProbability};
-        genome->mutationRates.connectionMutations[i] = {genomeTO.mutationRates.connectionMutations[i].eventProbability, genomeTO.mutationRates.connectionMutations[i].sigma};
+        genome->mutationRates.connectionMutations[i] = {
+            genomeTO.mutationRates.connectionMutations[i].eventProbability, genomeTO.mutationRates.connectionMutations[i].sigma};
         genome->mutationRates.cellTypePropertiesMutations[i] = {
             genomeTO.mutationRates.cellTypePropertiesMutations[i].eventProbability,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma,
@@ -329,10 +330,10 @@ __inline__ __device__ Object* EntityFactory::createObjectFromTO(TOs const& to, i
     Object* object = objectArray + objectIndex;
     *objectPointer = object;
 
+    object->flags = 0;
     changeObjectFromTO(to, objectTO, object);
     object->id = objectTO.id;
     object->locked = 0;
-    object->detached = 0;
     object->selected = 0;
     object->numConnections = objectTO.numConnections;
     if (object->type == ObjectType_Cell) {
@@ -357,8 +358,8 @@ __inline__ __device__ void EntityFactory::changeObjectFromTO(TOs const& to, Obje
     object->vel = objectTO.vel;
     object->stiffness = objectTO.stiffness;
     object->color = objectTO.color;
-    object->fixed = objectTO.fixed;
-    object->sticky = objectTO.sticky;
+    object->setFixed(objectTO.isFixed());
+    object->setSticky(objectTO.isSticky());
     object->type = objectTO.type;
 
     if (objectTO.type == ObjectType_Solid) {
@@ -645,10 +646,8 @@ __inline__ __device__ Object* EntityFactory::createFreeCell(float energy, float2
     object->numConnections = 0;
     object->locked = 0;
     object->selected = 0;
-    object->detached = 0;
+    object->flags = 0;
     object->color = 0;
-    object->fixed = false;
-    object->sticky = false;
     object->density = 1.0f;
     object->type = ObjectType_FreeCell;
     object->typeData.freeCell.event = CellEvent_No;
@@ -716,12 +715,10 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     object->vel = vel;
     object->stiffness = gene->stiffness;
     object->color = node->color;
-    object->fixed = false;
-    object->sticky = false;
+    object->flags = 0;
     object->numConnections = 0;
     object->type = ObjectType_Cell;
     object->selected = 0;
-    object->detached = 0;
     object->locked = 0;
     object->density = 1.0f;
 

--- a/source/EngineKernels/ForceFieldKernels.cu
+++ b/source/EngineKernels/ForceFieldKernels.cu
@@ -148,7 +148,7 @@ __global__ void cudaApplyForceFields(SimulationData data)
 
         for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
             auto& object = objects.at(index);
-            if (object->fixed) {
+            if (object->isFixed()) {
                 continue;
             }
             object->vel += calcResultingAcceleration(object->pos, object->getMassForSPH());

--- a/source/EngineKernels/InjectorProcessor.cuh
+++ b/source/EngineKernels/InjectorProcessor.cuh
@@ -34,7 +34,7 @@ __inline__ __device__ void InjectorProcessor::processCell(SimulationData& data, 
         Object* injectedCell = nullptr;
         int numDefenders = 0;
         data.objectMap.executeForEach(
-            object->pos, cudaSimulationParameters.injectorRadius.value[object->color], object->detached, [&](auto const& otherObject) {
+            object->pos, cudaSimulationParameters.injectorRadius.value[object->color], object->detached(), [&](auto const& otherObject) {
                 if (injectedCell != nullptr) {
                     return;
                 }
@@ -44,7 +44,7 @@ __inline__ __device__ void InjectorProcessor::processCell(SimulationData& data, 
                 if (object->typeData.cell.isSameCreature(&otherObject->typeData.cell)) {
                     return;
                 }
-                if (otherObject->fixed) {
+                if (otherObject->isFixed()) {
                     return;
                 }
                 if (!otherObject->typeData.cell.constructorAvailable) {

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -170,7 +170,7 @@ public:
                     }
                     auto const& record = records[index];
                     auto slotObject = record.self;  // Read fields live: this runs after positions changed since the map was built
-                    if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached != 1 && matchFunc(slotObject)) {
+                    if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached() != 1 && matchFunc(slotObject)) {
                         objects[numObjects] = slotObject;
                         ++numObjects;
                     }
@@ -197,7 +197,7 @@ public:
                     }
                     auto const& record = records[index];
                     auto slotObject = record.self;  // Read fields live: this runs after positions changed since the map was built
-                    if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached != 1) {
+                    if (Math::length(slotObject->pos - pos) <= radius && detached + slotObject->detached() != 1) {
                         execFunc(slotObject);
                     }
                     index = record.nextObjectIndex;

--- a/source/EngineKernels/MuscleProcessor.cuh
+++ b/source/EngineKernels/MuscleProcessor.cuh
@@ -101,7 +101,7 @@ __device__ __inline__ void MuscleProcessor::restoreInitialAngleFromPrevious(Obje
 
 __device__ __inline__ void MuscleProcessor::processCell(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
-    if (object->fixed) {
+    if (object->isFixed()) {
         return;
     }
     object->typeData.cell.cellTypeData.muscle.lastMovementX = 0;

--- a/source/EngineKernels/ObjectConnectionProcessor.cuh
+++ b/source/EngineKernels/ObjectConnectionProcessor.cuh
@@ -617,7 +617,7 @@ ObjectConnectionProcessor::calcLargestGapReferenceAndActualAngle(SimulationData&
 __inline__ __device__ bool ObjectConnectionProcessor::existsOwnIntersectingObjectInBetween(SimulationData& data, Object* object, Object* otherObject)
 {
     auto result = false;
-    data.objectMap.executeForEach(object->pos, cudaSimulationParameters.attackerRadius.value[object->color], object->detached, [&](Object* nearObject) {
+    data.objectMap.executeForEach(object->pos, cudaSimulationParameters.attackerRadius.value[object->color], object->detached(), [&](Object* nearObject) {
         if (result) {
             return;
         }

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -188,14 +188,14 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                         adaptedDistance *= 2.0f;  // Reduce range of cell repulsion within creature by scaling distance
                     }
 
-                    if (other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached + other.detached() != 1) {
+                    if (other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached() + other.detached() != 1) {
                         auto index = atomicAdd(&numFixedObjects, 1);
                         if (index < MaxBarrierCellsForCollision) {
                             fixedCells[index] = other.self;
                         }
                     }
 
-                    if (!other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached + other.detached() != 1) {
+                    if (!other.isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached() + other.detached() != 1) {
 
                         // Calc density
                         auto otherMass = other.getMassForSPH();
@@ -204,7 +204,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                         if (object != other.self) {
 
                             // Overlap correction
-                            if (!object->fixed && origDistance < cudaSimulationParameters.minObjectDistance.value) {
+                            if (!object->isFixed() && origDistance < cudaSimulationParameters.minObjectDistance.value) {
                                 localCellPosDelta.x += posDelta.x * cudaSimulationParameters.minObjectDistance.value / 5;
                                 localCellPosDelta.y += posDelta.y * cudaSimulationParameters.minObjectDistance.value / 5;
                             }
@@ -240,7 +240,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
 
                             // Fusion
                             if (Math::length(velDelta) >= cellFusionVelocity && object->numConnections < MAX_OBJECT_CONNECTIONS
-                                && other.numConnections < MAX_OBJECT_CONNECTIONS && (object->sticky || other.isSticky()) && !object->fixed
+                                && other.numConnections < MAX_OBJECT_CONNECTIONS && (object->isSticky() || other.isSticky()) && !object->isFixed()
                                 && !other.isFixed()) {
                                 ObjectConnectionProcessor::scheduleAddConnectionPair(data, object, other.self);
                             }
@@ -378,7 +378,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
                 }
                 auto const& other = records[otherIndex];
                 auto otherObject = other.self;  // Read fields live: this runs after calcFluidForces nudged positions
-                if (other.type != ObjectType_Fluid && otherObject != object && object->detached + otherObject->detached != 1) {
+                if (other.type != ObjectType_Fluid && otherObject != object && object->detached() + otherObject->detached() != 1) {
 
                     auto posDelta = object->pos - otherObject->pos;
                     data.objectMap.correctDirection(posDelta);
@@ -430,7 +430,7 @@ __inline__ __device__ void ObjectProcessor::checkForces(SimulationData& data)
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
         object->density = object->tempValue2.as_float2.x;
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
 
@@ -450,7 +450,7 @@ __inline__ __device__ void ObjectProcessor::applyForces(SimulationData& data)
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         auto acceleration = object->tempValue1.as_float2 / max(0.05f, object->density) * 0.5f;
@@ -472,7 +472,7 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (0 == object->numConnections /* || object->fixed*/) {
+        if (0 == object->numConnections /* || object->isFixed()*/) {
             continue;
         }
         float2 force{0, 0};
@@ -538,7 +538,7 @@ __inline__ __device__ void ObjectProcessor::checkConnections(SimulationData& dat
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
 
@@ -566,7 +566,7 @@ __inline__ __device__ void ObjectProcessor::verletPositionUpdate(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             object->pos += object->vel * cudaSimulationParameters.timestepSize.value;
             data.objectMap.correctPosition(object->pos);
         } else {
@@ -586,7 +586,7 @@ __inline__ __device__ void ObjectProcessor::verletVelocityUpdate(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         auto acceleration = (object->tempValue1.as_float2 + object->tempValue2.as_float2) / 2;
@@ -602,12 +602,12 @@ __inline__ __device__ void ObjectProcessor::applyInnerFriction(SimulationData& d
     auto const innerFriction = cudaSimulationParameters.innerFriction.value;
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         for (int index = 0; index < object->numConnections; ++index) {
             auto connectedObject = object->connections[index].object;
-            if (connectedObject->fixed) {
+            if (connectedObject->isFixed()) {
                 continue;
             }
             auto posDelta = object->pos - connectedObject->pos;
@@ -634,7 +634,7 @@ __inline__ __device__ void ObjectProcessor::applyFriction(SimulationData& data)
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
 
@@ -650,7 +650,7 @@ __inline__ __device__ void ObjectProcessor::radiation(SimulationData& data)
     auto partition = calcSystemThreadPartition(objects.getNumEntries());
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         if (object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {

--- a/source/EngineKernels/ReconnectorProcessor.cuh
+++ b/source/EngineKernels/ReconnectorProcessor.cuh
@@ -49,7 +49,7 @@ __inline__ __device__ void ReconnectorProcessor::tryCreateConnection(SimulationD
     Object* closestCell = nullptr;
     float closestDistance = 0;
     data.objectMap.executeForEach(
-        object->pos, cudaSimulationParameters.reconnectorRadius.value[object->color], object->detached, [&](Object* const& otherObject) {
+        object->pos, cudaSimulationParameters.reconnectorRadius.value[object->color], object->detached(), [&](Object* const& otherObject) {
             // Skip if already connected or too closely connected
             if (ObjectConnectionProcessor::isConnectedConnected(object, otherObject)) {
                 return;

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -141,7 +141,7 @@ __inline__ __device__ void SensorProcessor::initialScan(SimulationData& data, Si
         seedAngle = data.primaryNumberGen.random(360.0f);
 
         data.objectMap.getMatchingObjects(
-            nearSameCreatureCells, MaxSameNearCreatureCells, numNearSameCreatureCells, object->pos, 4.0f, object->detached, [&](Object* const& otherObject) {
+            nearSameCreatureCells, MaxSameNearCreatureCells, numNearSameCreatureCells, object->pos, 4.0f, object->detached(), [&](Object* const& otherObject) {
                 return otherObject->type == ObjectType_Cell && object->typeData.cell.isSameCreature(&otherObject->typeData.cell);
             });
     }

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -78,7 +78,7 @@ __global__ void cudaUpdateHistogramData_substep2(SimulationData data, Simulation
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         if (object->type == ObjectType_Cell) {
@@ -97,7 +97,7 @@ __global__ void cudaUpdateHistogramData_substep3(SimulationData data, Simulation
     auto maxAge = statistics.getMaxAge();
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->fixed) {
+        if (object->isFixed()) {
             continue;
         }
         if (object->type == ObjectType_Cell) {

--- a/source/EngineKernels/TOs.cuh
+++ b/source/EngineKernels/TOs.cuh
@@ -470,13 +470,18 @@ struct ObjectTO
     float2 vel;
     float stiffness;
     uint8_t color;
-    bool fixed;
-    bool sticky;
+    uint8_t flags;  // bit0 = fixed, bit2 = sticky
     ObjectType type;
     ObjectTypeDataTO typeData;
 
     // Editing data
     uint8_t selected;
+
+    __host__ __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __host__ __device__ __inline__ bool isSticky() const { return flags & 4; }
+
+    __host__ __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
+    __host__ __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 };
 
 struct CreatureTO


### PR DESCRIPTION
## Summary
- Replace the `fixed`, `sticky` and `detached` booleans with a single `flags` byte (bit0 = fixed, bit1 = detached, bit2 = sticky) on `Object` and `LightObject`, exposed via `isFixed()` / `detached()` / `isSticky()` getters and `setFixed()` / `setDetached()` / `setSticky()` setters.
- Apply the same flags approach to `ObjectTO` (bit0 = fixed, bit2 = sticky) with host/device accessors, replacing its two booleans.
- `LightObject` no longer duplicates its own flag handling; both structs share the same encoding, and `LightObject::initFrom` just copies `object->flags`.
- `ObjectBase` stays pure 24-byte geometry (pos/vel/density/type). `ObjectDesc` is deliberately left untouched.

## Layout / performance note
An earlier revision moved `flags` into `ObjectBase`. Because `float2` forces 8-byte alignment, the single byte padded `ObjectBase` from 24 to 32 bytes, which grew the hot-path `LightObject` neighbor-scan mirror from 40 to 48 bytes and cost ~4% TPS (measured ~236 vs ~245 TPS on a reference simulation). The final version keeps `flags` in the derived structs where it packs without padding, restoring the 40-byte mirror. A `static_assert(sizeof(LightObject) == 40)` locks this in.

Benchmark (`cli -t 10000`, reference sim, RTX 4090):
- develop: ~245 TPS
- flags in `ObjectBase`: ~236 TPS
- this PR (flags in derived structs): ~247 TPS

`Object` also ends up one byte smaller than before (one flags byte instead of three separate bytes).

## Original task
LightObject uses flags for fixed, detached and sticky. do the same for Object. than the flags could be moved to ObjectBase. Use also flags for ObjectTO. But not for ObjectDesc.

## Build and tests
- `cmake --build build --config Release -j32 --clean-first --target EngineTests EngineInterfaceTests NetworkTests PersisterTests cli`: passed
- `./EngineInterfaceTests`: passed (153)
- `./NetworkTests`: passed (4)
- `./PersisterTests`: passed (64)
- `./EngineTests`: passed (2992, 3 self-skipped)
- `./cli --help` / benchmark: passed

## Notes
- A clean rebuild is required after this change: incremental CUDA builds do not reliably recompile every translation unit that includes the modified `Entities.cuh`, which can mix old/new `Object`/`LightObject` layouts and corrupt the simulation. After `--clean-first` all suites pass.