### PR TITLE
Guard number of modes per cell type in mutation coverage check

### DIFF
--- a/source/EngineTests/CellTypeMutationCoverageGuard.cpp
+++ b/source/EngineTests/CellTypeMutationCoverageGuard.cpp
@@ -11,11 +11,8 @@
 // count. The point is to force a conscious decision so newly added cell-type
 // attributes are never silently left out of the mutation.
 //
-// The mode counts at the bottom pin the number of modes per cell type. Modes
-// themselves are not mutated by this mutation type, but a newly added mode
-// brings its own description struct whose fields must be reviewed. When a mode
-// is added or removed, the corresponding assert fails - extend the field-count
-// list above and the mutation switch for the new mode, then bump the count here.
+// The mode counts at the bottom pin the number of modes per cell type, so adding
+// a mode also trips the check (its new description struct still needs review).
 
 
 #include <variant>
@@ -97,7 +94,7 @@ ALIEN_MUTATION_MODE_COUNT(ReconnectorModeGenomeDesc, 3);
 ALIEN_MUTATION_MODE_COUNT(MemoryModeGenomeDesc, 4);
 ALIEN_MUTATION_MODE_COUNT(CommunicatorModeGenomeDesc, 2);
 
-// Defender uses a plain enum for its mode instead of a variant.
+// Defender's mode is a plain enum, not a variant.
 static_assert(
     DefenderMode_Count == 2,
     "DefenderMode count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count");

--- a/source/EngineTests/CellTypeMutationCoverageGuard.cpp
+++ b/source/EngineTests/CellTypeMutationCoverageGuard.cpp
@@ -1,6 +1,6 @@
 // Compile-time guard for cell-type property mutation coverage.
 //
-// Each static_assert below pins the number of data members of 
+// Each static_assert below pins the number of data members of
 // cell-type or mode description. The matching list of mutated attributes
 // lives in MutationProcessor::applyMutations_cellTypeProperties().
 //
@@ -10,7 +10,15 @@
 // count here - or, if the field is intentionally never mutated, just bump the
 // count. The point is to force a conscious decision so newly added cell-type
 // attributes are never silently left out of the mutation.
+//
+// The mode counts at the bottom pin the number of modes per cell type. Modes
+// themselves are not mutated by this mutation type, but a newly added mode
+// brings its own description struct whose fields must be reviewed. When a mode
+// is added or removed, the corresponding assert fails - extend the field-count
+// list above and the mutation switch for the new mode, then bump the count here.
 
+
+#include <variant>
 
 #include <boost/pfr.hpp>
 
@@ -20,6 +28,11 @@
     static_assert( \
         boost::pfr::tuple_size_v<Type> == (Count), \
         #Type " field count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count")
+
+#define ALIEN_MUTATION_MODE_COUNT(Type, Count) \
+    static_assert( \
+        std::variant_size_v<Type> == (Count), \
+        #Type " mode count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count")
 
 // --- Cell types (switch (node.cellType)) ---
 ALIEN_MUTATION_FIELD_COUNT(BaseGenomeDesc, 0);
@@ -75,4 +88,19 @@ ALIEN_MUTATION_FIELD_COUNT(SignalIntegratorGenomeDesc, 1);
 ALIEN_MUTATION_FIELD_COUNT(SenderGenomeDesc, 2);
 ALIEN_MUTATION_FIELD_COUNT(ReceiverGenomeDesc, 2);
 
+// --- Number of modes per cell type ---
+ALIEN_MUTATION_MODE_COUNT(SensorModeGenomeDesc, 5);
+ALIEN_MUTATION_MODE_COUNT(GeneratorModeGenomeDesc, 2);
+ALIEN_MUTATION_MODE_COUNT(AttackerModeGenomeDesc, 2);
+ALIEN_MUTATION_MODE_COUNT(MuscleModeGenomeDesc, 6);
+ALIEN_MUTATION_MODE_COUNT(ReconnectorModeGenomeDesc, 3);
+ALIEN_MUTATION_MODE_COUNT(MemoryModeGenomeDesc, 4);
+ALIEN_MUTATION_MODE_COUNT(CommunicatorModeGenomeDesc, 2);
+
+// Defender uses a plain enum for its mode instead of a variant.
+static_assert(
+    DefenderMode_Count == 2,
+    "DefenderMode count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count");
+
+#undef ALIEN_MUTATION_MODE_COUNT
 #undef ALIEN_MUTATION_FIELD_COUNT


### PR DESCRIPTION
## Summary
- Extend `CellTypeMutationCoverageGuard.cpp` to pin the number of modes per cell type, so the compile-time check also trips when a new mode is added (not just when a struct field changes).
- Add an `ALIEN_MUTATION_MODE_COUNT` macro based on `std::variant_size_v` and assert the mode count for every variant-based cell type: Sensor (5), Generator (2), Attacker (2), Muscle (6), Reconnector (3), Memory (4), Communicator (2).
- Add a separate `static_assert(DefenderMode_Count == 2, ...)` for Defender, whose mode is a plain enum instead of a variant.
- Modes themselves are intentionally not mutated by this mutation type; the guard exists so a newly added mode forces a conscious review of its description struct fields in `applyMutations_cellTypeProperties()`.

## Original task
Erweitere CellTypeMutationCoverageGuard.cpp um statische Asserts für die Anzahl der Modes pro Zelltyp (variant_size_v für die Mode-Varianten, DefenderMode_Count für Defender), damit der Check auch beim Hinzufügen neuer Modes auslöst.

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (2992 passed, 3 pre-existing skips, 0 failed)
- `./cli --help`: not run (no CLI change)

## Notes
- Pure compile-time guard change in the EngineTests target; no runtime behavior is affected. A successful build already proves all asserts hold for the current struct/variant/enum definitions.
- The 3 skipped EngineTests are pre-existing and unrelated to this change.