### PR TITLE
Add CellTypeModeMutation mutation type

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -880,6 +880,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._sigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma;
         result._mutationRates._cellTypePropertiesMutations[i]._probability = genomeTO.mutationRates.cellTypePropertiesMutations[i].probability;
     }
+    result._mutationRates._cellTypeModeMutation._eventProbability = genomeTO.mutationRates.cellTypeModeMutation.eventProbability;
     result._genes.reserve(genomeTO.numGenes);
 
     CHECK(genomeTO.geneArrayIndex + genomeTO.numGenes <= *to.numGenes);
@@ -967,6 +968,7 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._sigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._probability};
     }
+    genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._eventProbability};
     genomeTO.numGenes = toInt(genome._genes.size());
     genomeTO.geneArrayIndex = geneArrayStartIndex;
     genomeTO.genomeIndexOnGpu = VALUE_NOT_SET_UINT64;

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -174,6 +174,7 @@ namespace Const
     auto constexpr GeneratorValue_Max = 2.0f;
     auto constexpr GeneratorTimeOffset_Min = 0;
     auto constexpr GeneratorPeriod_Min = 1;
+    auto constexpr GeneratorPeriod_Default = 100;
 }
 
 using GeneratorMode = int;
@@ -219,10 +220,13 @@ namespace Const
     auto constexpr SensorRange_Max = 512;
     auto constexpr DetectEnergyMinDensity_Min = 0.0f;
     auto constexpr DetectEnergyMinDensity_Max = 1.0f;
+    auto constexpr DetectEnergyMinDensity_Default = 0.05f;
     auto constexpr DetectFreeCellMinDensity_Min = 0.0f;
     auto constexpr DetectFreeCellMinDensity_Max = 1.0f;
+    auto constexpr DetectFreeCellMinDensity_Default = 0.05f;
     auto constexpr RestrictToColors_Min = 0;
     auto constexpr RestrictToColors_Max = (1 << MAX_COLORS) - 1;
+    auto constexpr RestrictToColors_Default = (1 << MAX_COLORS) - 1;
     auto constexpr CreatureNumCells_Min = 0;
 }
 
@@ -262,6 +266,10 @@ namespace Const
 {
     auto constexpr MuscleModeRatio_Min = 0.0f;
     auto constexpr MuscleModeRatio_Max = 1.0f;
+    auto constexpr MuscleMaxAngleDeviation_Default = 0.2f;
+    auto constexpr MuscleForwardBackwardRatio_Default = 0.8f;
+    auto constexpr MuscleAttractionRepulsionRatio_Default = 0.8f;
+    auto constexpr MuscleMaxDistanceDeviation_Default = 0.8f;
 }
 
 using MuscleMode = int;
@@ -396,8 +404,10 @@ namespace Const
     auto constexpr MemoryNumSignalEntries_Max = MAX_CELL_MEMORY_ENTRIES;
     auto constexpr SignalDelay_Min = 0;
     auto constexpr SignalDelay_Max = MAX_CELL_MEMORY_ENTRIES;
+    auto constexpr SignalDelay_Default = 10;
     auto constexpr SignalIntegratorNewSignalWeight_Min = 0.0f;
     auto constexpr SignalIntegratorNewSignalWeight_Max = 1.0f;
+    auto constexpr SignalIntegratorNewSignalWeight_Default = 0.5f;
 }
 
 using MemoryMode = int;
@@ -434,7 +444,9 @@ namespace Const
 {
     auto constexpr CommunicatorRange_Min = 0;
     auto constexpr CommunicatorRange_Max = 20;
+    auto constexpr CommunicatorRange_Default = 15;
     auto constexpr CommunicatorMaxTimesSent_Min = 0;
+    auto constexpr CommunicatorMaxTimesSent_Default = 4;
 }
 
 using CommunicatorMode = int;

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -84,7 +84,7 @@ struct DetectEnergyDesc
 {
     auto operator<=>(DetectEnergyDesc const&) const = default;
 
-    MEMBER(DetectEnergyDesc, float, minDensity, 0.05f);
+    MEMBER(DetectEnergyDesc, float, minDensity, Const::DetectEnergyMinDensity_Default);
 };
 
 struct DetectSolidDesc
@@ -96,8 +96,8 @@ struct DetectFreeCellDesc
 {
     auto operator<=>(DetectFreeCellDesc const&) const = default;
 
-    MEMBER(DetectFreeCellDesc, float, minDensity, 0.05f);
-    MEMBER(DetectFreeCellDesc, int, restrictToColors, 0x3ff);
+    MEMBER(DetectFreeCellDesc, float, minDensity, Const::DetectFreeCellMinDensity_Default);
+    MEMBER(DetectFreeCellDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct DetectCreatureDesc
@@ -106,7 +106,7 @@ struct DetectCreatureDesc
 
     MEMBER(DetectCreatureDesc, std::optional<int>, minNumCells, std::nullopt);
     MEMBER(DetectCreatureDesc, std::optional<int>, maxNumCells, std::nullopt);
-    MEMBER(DetectCreatureDesc, int, restrictToColors, 0x3ff);
+    MEMBER(DetectCreatureDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(DetectCreatureDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 
@@ -139,13 +139,13 @@ struct SensorDesc
 struct SquareSignalDesc
 {
     auto operator<=>(SquareSignalDesc const&) const = default;
-    MEMBER(SquareSignalDesc, int, period, 100);
+    MEMBER(SquareSignalDesc, int, period, Const::GeneratorPeriod_Default);
 };
 
 struct SawtoothSignalDesc
 {
     auto operator<=>(SawtoothSignalDesc const&) const = default;
-    MEMBER(SawtoothSignalDesc, int, period, 100);
+    MEMBER(SawtoothSignalDesc, int, period, Const::GeneratorPeriod_Default);
 };
 
 using GeneratorModeDesc = std::variant<SquareSignalDesc, SawtoothSignalDesc>;
@@ -171,7 +171,7 @@ struct AttackFreeCellDesc
 {
     auto operator<=>(AttackFreeCellDesc const&) const = default;
 
-    MEMBER(AttackFreeCellDesc, int, restrictToColors, 0x3ff);
+    MEMBER(AttackFreeCellDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct AttackCreatureDesc
@@ -203,8 +203,8 @@ struct AutoBendingDesc
     auto operator<=>(AutoBendingDesc const&) const = default;
 
     // Fixed data
-    MEMBER(AutoBendingDesc, float, maxAngleDeviation, 0.2f);     // Between 0 and 1
-    MEMBER(AutoBendingDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AutoBendingDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);        // Between 0 and 1
+    MEMBER(AutoBendingDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 
     // Process data
     MEMBER(AutoBendingDesc, std::optional<float>, initialAngle, std::nullopt);
@@ -216,8 +216,8 @@ struct ManualBendingDesc
     auto operator<=>(ManualBendingDesc const&) const = default;
 
     // Fixed data
-    MEMBER(ManualBendingDesc, float, maxAngleDeviation, 0.2f);     // Between 0 and 1
-    MEMBER(ManualBendingDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(ManualBendingDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);        // Between 0 and 1
+    MEMBER(ManualBendingDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 
     // Process data
     MEMBER(ManualBendingDesc, std::optional<float>, initialAngle, std::nullopt);
@@ -229,8 +229,8 @@ struct AngleBendingDesc
     auto operator<=>(AngleBendingDesc const&) const = default;
 
     // Fixed data
-    MEMBER(AngleBendingDesc, float, maxAngleDeviation, 0.2f);         // Between 0 and 1
-    MEMBER(AngleBendingDesc, float, attractionRepulsionRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AngleBendingDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);              // Between 0 and 1
+    MEMBER(AngleBendingDesc, float, attractionRepulsionRatio, Const::MuscleAttractionRepulsionRatio_Default);  // Between 0 and 1
 
     // Process data
     MEMBER(AngleBendingDesc, std::optional<float>, initialAngle, std::nullopt);
@@ -241,8 +241,8 @@ struct AutoCrawlingDesc
     auto operator<=>(AutoCrawlingDesc const&) const = default;
 
     // Fixed data
-    MEMBER(AutoCrawlingDesc, float, maxDistanceDeviation, 0.8f);  // Between 0 and 1
-    MEMBER(AutoCrawlingDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AutoCrawlingDesc, float, maxDistanceDeviation, Const::MuscleMaxDistanceDeviation_Default);  // Between 0 and 1
+    MEMBER(AutoCrawlingDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 
     // Process data
     MEMBER(AutoCrawlingDesc, std::optional<float>, initialDistance, std::nullopt);
@@ -255,8 +255,8 @@ struct ManualCrawlingDesc
     auto operator<=>(ManualCrawlingDesc const&) const = default;
 
     // Fixed data
-    MEMBER(ManualCrawlingDesc, float, maxDistanceDeviation, 0.8f);  // Between 0 and 1
-    MEMBER(ManualCrawlingDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(ManualCrawlingDesc, float, maxDistanceDeviation, Const::MuscleMaxDistanceDeviation_Default);  // Between 0 and 1
+    MEMBER(ManualCrawlingDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 
     // Process data
     MEMBER(ManualCrawlingDesc, std::optional<float>, initialDistance, std::nullopt);
@@ -300,7 +300,7 @@ struct ReconnectFreeCellDesc
 {
     auto operator<=>(ReconnectFreeCellDesc const&) const = default;
 
-    MEMBER(ReconnectFreeCellDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReconnectFreeCellDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct ReconnectCreatureDesc
@@ -309,7 +309,7 @@ struct ReconnectCreatureDesc
 
     MEMBER(ReconnectCreatureDesc, std::optional<int>, minNumCells, std::nullopt);
     MEMBER(ReconnectCreatureDesc, std::optional<int>, maxNumCells, std::nullopt);
-    MEMBER(ReconnectCreatureDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReconnectCreatureDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(ReconnectCreatureDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 
@@ -358,7 +358,7 @@ struct SignalDelayDesc
 {
     auto operator<=>(SignalDelayDesc const&) const = default;
 
-    MEMBER(SignalDelayDesc, int, delay, 10);
+    MEMBER(SignalDelayDesc, int, delay, Const::SignalDelay_Default);
     MEMBER(SignalDelayDesc, int, numSignalEntriesInitialized, 0);
     MEMBER(SignalDelayDesc, int, ringBufferIndex, 0);
 };
@@ -384,7 +384,7 @@ struct SignalIntegratorDesc
 {
     auto operator<=>(SignalIntegratorDesc const&) const = default;
 
-    MEMBER(SignalIntegratorDesc, float, newSignalWeight, 0.5f);  // Between 0 and 1
+    MEMBER(SignalIntegratorDesc, float, newSignalWeight, Const::SignalIntegratorNewSignalWeight_Default);  // Between 0 and 1
 };
 
 using MemoryModeDesc = std::variant<SignalDelayDesc, SignalRecorderDesc, SignalStorageDesc, SignalIntegratorDesc>;
@@ -404,15 +404,15 @@ struct SenderDesc
 {
     auto operator<=>(SenderDesc const&) const = default;
 
-    MEMBER(SenderDesc, int, range, 15);
-    MEMBER(SenderDesc, int, maxTimesSent, 4);
+    MEMBER(SenderDesc, int, range, Const::CommunicatorRange_Default);
+    MEMBER(SenderDesc, int, maxTimesSent, Const::CommunicatorMaxTimesSent_Default);
 };
 
 struct ReceiverDesc
 {
     auto operator<=>(ReceiverDesc const&) const = default;
 
-    MEMBER(ReceiverDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReceiverDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(ReceiverDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -37,6 +37,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
     }
+    genome._mutationRates._cellTypeModeMutation._eventProbability =
+        std::clamp(genome._mutationRates._cellTypeModeMutation._eventProbability, 0.0f, 1.0f);
 
     // Validate each gene
     for (auto& gene : genome._genes) {

--- a/source/EngineInterface/GenomeDesc.cpp
+++ b/source/EngineInterface/GenomeDesc.cpp
@@ -62,6 +62,9 @@ std::vector<std::string> MutationRatesDesc::getActiveMutationTypes() const
     if (_cellTypePropertiesMutations[0]._eventProbability > 0.0f || _cellTypePropertiesMutations[1]._eventProbability > 0.0f) {
         activeMutations.push_back("Cell type property mutations");
     }
+    if (_cellTypeModeMutation._eventProbability > 0.0f) {
+        activeMutations.push_back("Cell type mode mutations");
+    }
     return activeMutations;
 }
 

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -438,6 +438,13 @@ struct CellTypePropertiesMutationDesc
     MEMBER(CellTypePropertiesMutationDesc, float, probability, 0.0f);
 };
 
+struct CellTypeModeMutationDesc
+{
+    auto operator<=>(CellTypeModeMutationDesc const&) const = default;
+
+    MEMBER(CellTypeModeMutationDesc, float, eventProbability, 0.0f);
+};
+
 struct MutationRatesDesc
 {
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
@@ -449,6 +456,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, NeuronMutationArray, neuronMutations, NeuronMutationArray());
     MEMBER(MutationRatesDesc, ConnectionMutationArray, connectionMutations, ConnectionMutationArray());
     MEMBER(MutationRatesDesc, CellTypePropertiesMutationArray, cellTypePropertiesMutations, CellTypePropertiesMutationArray());
+    MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
 
     std::vector<std::string> getActiveMutationTypes() const;
 };

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -70,7 +70,7 @@ struct DetectEnergyGenomeDesc
 {
     auto operator<=>(DetectEnergyGenomeDesc const&) const = default;
 
-    MEMBER(DetectEnergyGenomeDesc, float, minDensity, 1.0f);
+    MEMBER(DetectEnergyGenomeDesc, float, minDensity, Const::DetectEnergyMinDensity_Default);
 };
 
 struct DetectSolidGenomeDesc
@@ -82,8 +82,8 @@ struct DetectFreeCellGenomeDesc
 {
     auto operator<=>(DetectFreeCellGenomeDesc const&) const = default;
 
-    MEMBER(DetectFreeCellGenomeDesc, float, minDensity, 0.5f);
-    MEMBER(DetectFreeCellGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(DetectFreeCellGenomeDesc, float, minDensity, Const::DetectFreeCellMinDensity_Default);
+    MEMBER(DetectFreeCellGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct DetectCreatureGenomeDesc
@@ -92,7 +92,7 @@ struct DetectCreatureGenomeDesc
 
     MEMBER(DetectCreatureGenomeDesc, std::optional<int>, minNumCells, std::nullopt);
     MEMBER(DetectCreatureGenomeDesc, std::optional<int>, maxNumCells, std::nullopt);
-    MEMBER(DetectCreatureGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(DetectCreatureGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(DetectCreatureGenomeDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 
@@ -115,13 +115,13 @@ struct SensorGenomeDesc
 struct SquareSignalGenomeDesc
 {
     auto operator<=>(SquareSignalGenomeDesc const&) const = default;
-    MEMBER(SquareSignalGenomeDesc, int, period, 100);
+    MEMBER(SquareSignalGenomeDesc, int, period, Const::GeneratorPeriod_Default);
 };
 
 struct SawtoothSignalGenomeDesc
 {
     auto operator<=>(SawtoothSignalGenomeDesc const&) const = default;
-    MEMBER(SawtoothSignalGenomeDesc, int, period, 100);
+    MEMBER(SawtoothSignalGenomeDesc, int, period, Const::GeneratorPeriod_Default);
 };
 
 using GeneratorModeGenomeDesc = std::variant<SquareSignalGenomeDesc, SawtoothSignalGenomeDesc>;
@@ -143,7 +143,7 @@ struct AttackFreeCellGenomeDesc
 {
     auto operator<=>(AttackFreeCellGenomeDesc const&) const = default;
 
-    MEMBER(AttackFreeCellGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(AttackFreeCellGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct AttackCreatureGenomeDesc
@@ -174,40 +174,40 @@ struct AutoBendingGenomeDesc
 {
     auto operator<=>(AutoBendingGenomeDesc const&) const = default;
 
-    MEMBER(AutoBendingGenomeDesc, float, maxAngleDeviation, 0.2f);     // Between 0 and 1
-    MEMBER(AutoBendingGenomeDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AutoBendingGenomeDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);        // Between 0 and 1
+    MEMBER(AutoBendingGenomeDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 };
 
 struct ManualBendingGenomeDesc
 {
     auto operator<=>(ManualBendingGenomeDesc const&) const = default;
 
-    MEMBER(ManualBendingGenomeDesc, float, maxAngleDeviation, 0.2f);     // Between 0 and 1
-    MEMBER(ManualBendingGenomeDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(ManualBendingGenomeDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);        // Between 0 and 1
+    MEMBER(ManualBendingGenomeDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 };
 
 struct AngleBendingGenomeDesc
 {
     auto operator<=>(AngleBendingGenomeDesc const&) const = default;
 
-    MEMBER(AngleBendingGenomeDesc, float, maxAngleDeviation, 0.2f);         // Between 0 and 1
-    MEMBER(AngleBendingGenomeDesc, float, attractionRepulsionRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AngleBendingGenomeDesc, float, maxAngleDeviation, Const::MuscleMaxAngleDeviation_Default);              // Between 0 and 1
+    MEMBER(AngleBendingGenomeDesc, float, attractionRepulsionRatio, Const::MuscleAttractionRepulsionRatio_Default);  // Between 0 and 1
 };
 
 struct AutoCrawlingGenomeDesc
 {
     auto operator<=>(AutoCrawlingGenomeDesc const&) const = default;
 
-    MEMBER(AutoCrawlingGenomeDesc, float, maxDistanceDeviation, 0.8f);  // Between 0 and 1
-    MEMBER(AutoCrawlingGenomeDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(AutoCrawlingGenomeDesc, float, maxDistanceDeviation, Const::MuscleMaxDistanceDeviation_Default);  // Between 0 and 1
+    MEMBER(AutoCrawlingGenomeDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 };
 
 struct ManualCrawlingGenomeDesc
 {
     auto operator<=>(ManualCrawlingGenomeDesc const&) const = default;
 
-    MEMBER(ManualCrawlingGenomeDesc, float, maxDistanceDeviation, 0.8f);  // Between 0 and 1
-    MEMBER(ManualCrawlingGenomeDesc, float, forwardBackwardRatio, 0.8f);  // Between 0 and 1
+    MEMBER(ManualCrawlingGenomeDesc, float, maxDistanceDeviation, Const::MuscleMaxDistanceDeviation_Default);  // Between 0 and 1
+    MEMBER(ManualCrawlingGenomeDesc, float, forwardBackwardRatio, Const::MuscleForwardBackwardRatio_Default);  // Between 0 and 1
 };
 
 struct DirectMovementGenomeDesc
@@ -243,7 +243,7 @@ struct ReconnectFreeCellGenomeDesc
 {
     auto operator<=>(ReconnectFreeCellGenomeDesc const&) const = default;
 
-    MEMBER(ReconnectFreeCellGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReconnectFreeCellGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
 };
 
 struct ReconnectCreatureGenomeDesc
@@ -252,7 +252,7 @@ struct ReconnectCreatureGenomeDesc
 
     MEMBER(ReconnectCreatureGenomeDesc, std::optional<int>, minNumCells, std::nullopt);
     MEMBER(ReconnectCreatureGenomeDesc, std::optional<int>, maxNumCells, std::nullopt);
-    MEMBER(ReconnectCreatureGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReconnectCreatureGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(ReconnectCreatureGenomeDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 
@@ -300,7 +300,7 @@ struct SignalDelayGenomeDesc
 {
     auto operator<=>(SignalDelayGenomeDesc const&) const = default;
 
-    MEMBER(SignalDelayGenomeDesc, int, delay, 10);
+    MEMBER(SignalDelayGenomeDesc, int, delay, Const::SignalDelay_Default);
 };
 
 struct SignalRecorderGenomeDesc
@@ -322,7 +322,7 @@ struct SignalIntegratorGenomeDesc
 {
     auto operator<=>(SignalIntegratorGenomeDesc const&) const = default;
 
-    MEMBER(SignalIntegratorGenomeDesc, float, newSignalWeight, 0.5f);  // Between 0 and 1
+    MEMBER(SignalIntegratorGenomeDesc, float, newSignalWeight, Const::SignalIntegratorNewSignalWeight_Default);  // Between 0 and 1
 };
 
 using MemoryModeGenomeDesc = std::variant<SignalDelayGenomeDesc, SignalRecorderGenomeDesc, SignalStorageGenomeDesc, SignalIntegratorGenomeDesc>;
@@ -342,15 +342,15 @@ struct SenderGenomeDesc
 {
     auto operator<=>(SenderGenomeDesc const&) const = default;
 
-    MEMBER(SenderGenomeDesc, int, range, 10);
-    MEMBER(SenderGenomeDesc, int, maxTimesSent, 4);
+    MEMBER(SenderGenomeDesc, int, range, Const::CommunicatorRange_Default);
+    MEMBER(SenderGenomeDesc, int, maxTimesSent, Const::CommunicatorMaxTimesSent_Default);
 };
 
 struct ReceiverGenomeDesc
 {
     auto operator<=>(ReceiverGenomeDesc const&) const = default;
 
-    MEMBER(ReceiverGenomeDesc, int, restrictToColors, 0x3ff);
+    MEMBER(ReceiverGenomeDesc, int, restrictToColors, Const::RestrictToColors_Default);
     MEMBER(ReceiverGenomeDesc, LineageRestriction, restrictToLineage, LineageRestriction_No);
 };
 

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,6 +552,7 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._sigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._probability);
         }
+        hash_combine(seed, desc._mutationRates._cellTypeModeMutation._eventProbability);
         return seed;
     }
 };

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -467,6 +467,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::metaMutationCellTypePropertiesSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Cell type mode mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationCellTypeModeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("New lineage threshold")
                         .reference(
                             FloatSpec().member(&SimulationParameters::newLineageThreshold).min(0.0f).max(10000.0f).infinity(true).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -109,6 +109,7 @@ struct SimulationParameters
     BaseParameter<float> metaMutationNeuronsSigma = {0};
     BaseParameter<float> metaMutationConnectionsSigma = {0};
     BaseParameter<float> metaMutationCellTypePropertiesSigma = {0};
+    BaseParameter<float> metaMutationCellTypeModeSigma = {0};
     BaseParameter<float> newLineageThreshold = {Infinity<float>::value};
 
     // Cell type: Attacker

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -48,6 +48,7 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].sigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].probability};
             }
+            genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.eventProbability};
             genomeTO.numGenes = genome->numGenes;
             for (int i = 0; i < sizeof(genomeTO.name); ++i) {
                 genomeTO.name[i] = genome->name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -102,6 +102,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].probability};
     }
+    genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.eventProbability};
     genome->numGenes = genomeTO.numGenes;
     for (int i = 0; i < sizeof(genomeTO.name); ++i) {
         genome->name[i] = genomeTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -360,11 +360,17 @@ struct CellTypePropertiesMutation
     float probability;
 };
 
+struct CellTypeModeMutation
+{
+    float eventProbability;
+};
+
 struct MutationRates
 {
     NeuronMutation neuronMutations[2];
     ConnectionMutation connectionMutations[2];
     CellTypePropertiesMutation cellTypePropertiesMutations[2];
+    CellTypeModeMutation cellTypeModeMutation;
 };
 
 struct Genome

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -365,11 +365,17 @@ struct CellTypePropertiesMutationTO
     float probability;
 };
 
+struct CellTypeModeMutationTO
+{
+    float eventProbability;
+};
+
 struct MutationRatesTO
 {
     NeuronMutationTO neuronMutations[2];
     ConnectionMutationTO connectionMutations[2];
     CellTypePropertiesMutationTO cellTypePropertiesMutations[2];
+    CellTypeModeMutationTO cellTypeModeMutation;
 };
 
 struct GenomeTO

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -25,6 +25,7 @@ private:
     __inline__ __device__ static void applyMutations_neurons(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_connections(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeProperties(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
     __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static float generateGaussian(SimulationData& data);
@@ -102,6 +103,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_neurons(data, genome, accumulatedMutations);
     applyMutations_connections(data, genome, accumulatedMutations);
     applyMutations_cellTypeProperties(data, genome, accumulatedMutations);
+    applyMutations_cellTypeMode(data, genome, accumulatedMutations);
 
     block.sync();
     updateAccumulatedMutationsAndLineageId(data, genome, accumulatedMutations);
@@ -517,6 +519,165 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
     }
 }
 
+__inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.cellTypeModeMutation;
+
+    if (rate.eventProbability <= 0) {
+        return;
+    }
+
+    // Picks a random mode index different from the current one (uniform over the remaining modes).
+    auto pickNewMode = [&](int currentMode, int count) {
+        auto newMode = data.primaryNumberGen.random(count - 2);
+        if (newMode >= currentMode) {
+            ++newMode;
+        }
+        return newMode;
+    };
+
+    for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
+        auto& gene = genome->genes[geneIndex];
+        for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
+            if (data.primaryNumberGen.random() >= rate.eventProbability) {
+                continue;
+            }
+            auto& node = gene.nodes[nodeIndex];
+
+            // The new mode is initialized with the same default attribute values as the host-side genome descriptions (see GenomeDesc.h).
+            bool changed = true;
+            switch (node.cellType) {
+            case CellType_Sensor: {
+                auto& sensor = node.cellTypeData.sensor;
+                sensor.mode = static_cast<SensorMode>(pickNewMode(sensor.mode, SensorMode_Count));
+                switch (sensor.mode) {
+                case SensorMode_Telemetry:
+                    sensor.modeData.telemetry = {};
+                    break;
+                case SensorMode_DetectEnergy:
+                    sensor.modeData.detectEnergy = {1.0f};
+                    break;
+                case SensorMode_DetectSolid:
+                    sensor.modeData.detectSolid = {};
+                    break;
+                case SensorMode_DetectFreeCell:
+                    sensor.modeData.detectFreeCell = {0.5f, 0x3ff};
+                    break;
+                case SensorMode_DetectCreature:
+                    sensor.modeData.detectCreature = {0, 0, 0x3ff, LineageRestriction_No};
+                    break;
+                }
+            } break;
+            case CellType_Generator: {
+                auto& generator = node.cellTypeData.generator;
+                generator.mode = static_cast<GeneratorMode>(pickNewMode(generator.mode, GeneratorMode_Count));
+                switch (generator.mode) {
+                case GeneratorMode_SquareSignal:
+                    generator.modeData.squareSignal = {100};
+                    break;
+                case GeneratorMode_SawtoothSignal:
+                    generator.modeData.sawtoothSignal = {100};
+                    break;
+                }
+            } break;
+            case CellType_Attacker: {
+                auto& attacker = node.cellTypeData.attacker;
+                attacker.mode = static_cast<AttackerMode>(pickNewMode(attacker.mode, AttackerMode_Count));
+                switch (attacker.mode) {
+                case AttackerMode_FreeCell:
+                    attacker.modeData.attackFreeCell = {0x3ff};
+                    break;
+                case AttackerMode_Creature:
+                    attacker.modeData.attackCreature = {};
+                    break;
+                }
+            } break;
+            case CellType_Muscle: {
+                auto& muscle = node.cellTypeData.muscle;
+                muscle.mode = static_cast<MuscleMode>(pickNewMode(muscle.mode, MuscleMode_Count));
+                switch (muscle.mode) {
+                case MuscleMode_AutoBending:
+                    muscle.modeData.autoBending = {0.2f, 0.8f};
+                    break;
+                case MuscleMode_ManualBending:
+                    muscle.modeData.manualBending = {0.2f, 0.8f};
+                    break;
+                case MuscleMode_AngleBending:
+                    muscle.modeData.angleBending = {0.2f, 0.8f};
+                    break;
+                case MuscleMode_AutoCrawling:
+                    muscle.modeData.autoCrawling = {0.8f, 0.8f};
+                    break;
+                case MuscleMode_ManualCrawling:
+                    muscle.modeData.manualCrawling = {0.8f, 0.8f};
+                    break;
+                case MuscleMode_DirectMovement:
+                    muscle.modeData.directMovement = {};
+                    break;
+                }
+            } break;
+            case CellType_Defender:
+                node.cellTypeData.defender.mode = static_cast<DefenderMode>(pickNewMode(node.cellTypeData.defender.mode, DefenderMode_Count));
+                break;
+            case CellType_Reconnector: {
+                auto& reconnector = node.cellTypeData.reconnector;
+                reconnector.mode = static_cast<ReconnectorMode>(pickNewMode(reconnector.mode, ReconnectorMode_Count));
+                switch (reconnector.mode) {
+                case ReconnectorMode_Solid:
+                    reconnector.modeData.reconnectSolid = {};
+                    break;
+                case ReconnectorMode_FreeCell:
+                    reconnector.modeData.reconnectFreeCell = {0x3ff};
+                    break;
+                case ReconnectorMode_Creature:
+                    reconnector.modeData.reconnectCreature = {0, 0, 0x3ff, LineageRestriction_No};
+                    break;
+                }
+            } break;
+            case CellType_Memory: {
+                auto& memory = node.cellTypeData.memory;
+                memory.mode = static_cast<MemoryMode>(pickNewMode(memory.mode, MemoryMode_Count));
+                switch (memory.mode) {
+                case MemoryMode_SignalDelay:
+                    memory.modeData.signalDelay = {10};
+                    break;
+                case MemoryMode_SignalRecorder:
+                    memory.modeData.signalRecorder = {true, 0};
+                    break;
+                case MemoryMode_SignalStorage:
+                    memory.modeData.signalStorage = {true};
+                    break;
+                case MemoryMode_SignalIntegrator:
+                    memory.modeData.signalIntegrator = {0.5f};
+                    break;
+                }
+            } break;
+            case CellType_Communicator: {
+                auto& communicator = node.cellTypeData.communicator;
+                communicator.mode = static_cast<CommunicatorMode>(pickNewMode(communicator.mode, CommunicatorMode_Count));
+                switch (communicator.mode) {
+                case CommunicatorMode_Sender:
+                    communicator.modeData.sender = {10, 4};
+                    break;
+                case CommunicatorMode_Receiver:
+                    communicator.modeData.receiver = {0x3ff, LineageRestriction_No};
+                    break;
+                }
+            } break;
+            default:
+                // Cell types without a mode field are not affected.
+                changed = false;
+                break;
+            }
+
+            if (changed) {
+                atomicAdd_block(&accumulatedMutations, 1.0f);
+            }
+        }
+    }
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData& data, Genome* genome)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
@@ -552,6 +713,12 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
                 mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].sigma);
                 mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].probability);
             }
+        }
+
+        float cellTypeModeSigma = cudaSimulationParameters.metaMutationCellTypeModeSigma.value;
+        if (cellTypeModeSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeModeSigma)); };
+            mutateFloat(genome->mutationRates.cellTypeModeMutation.eventProbability);
         }
     }
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -545,7 +545,8 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
             }
             auto& node = gene.nodes[nodeIndex];
 
-            // The new mode is initialized with the same default attribute values as the host-side genome descriptions (see GenomeDesc.h).
+            // The new mode is initialized with the shared default attribute values (see the *_Default constants in CellTypeConstants.h),
+            // matching the host-side genome and runtime descriptions.
             bool changed = true;
             switch (node.cellType) {
             case CellType_Sensor: {
@@ -556,16 +557,16 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                     sensor.modeData.telemetry = {};
                     break;
                 case SensorMode_DetectEnergy:
-                    sensor.modeData.detectEnergy = {1.0f};
+                    sensor.modeData.detectEnergy = {Const::DetectEnergyMinDensity_Default};
                     break;
                 case SensorMode_DetectSolid:
                     sensor.modeData.detectSolid = {};
                     break;
                 case SensorMode_DetectFreeCell:
-                    sensor.modeData.detectFreeCell = {0.5f, 0x3ff};
+                    sensor.modeData.detectFreeCell = {Const::DetectFreeCellMinDensity_Default, Const::RestrictToColors_Default};
                     break;
                 case SensorMode_DetectCreature:
-                    sensor.modeData.detectCreature = {0, 0, 0x3ff, LineageRestriction_No};
+                    sensor.modeData.detectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
                     break;
                 }
             } break;
@@ -574,10 +575,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                 generator.mode = static_cast<GeneratorMode>(pickNewMode(generator.mode, GeneratorMode_Count));
                 switch (generator.mode) {
                 case GeneratorMode_SquareSignal:
-                    generator.modeData.squareSignal = {100};
+                    generator.modeData.squareSignal = {Const::GeneratorPeriod_Default};
                     break;
                 case GeneratorMode_SawtoothSignal:
-                    generator.modeData.sawtoothSignal = {100};
+                    generator.modeData.sawtoothSignal = {Const::GeneratorPeriod_Default};
                     break;
                 }
             } break;
@@ -586,7 +587,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                 attacker.mode = static_cast<AttackerMode>(pickNewMode(attacker.mode, AttackerMode_Count));
                 switch (attacker.mode) {
                 case AttackerMode_FreeCell:
-                    attacker.modeData.attackFreeCell = {0x3ff};
+                    attacker.modeData.attackFreeCell = {Const::RestrictToColors_Default};
                     break;
                 case AttackerMode_Creature:
                     attacker.modeData.attackCreature = {};
@@ -598,19 +599,19 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                 muscle.mode = static_cast<MuscleMode>(pickNewMode(muscle.mode, MuscleMode_Count));
                 switch (muscle.mode) {
                 case MuscleMode_AutoBending:
-                    muscle.modeData.autoBending = {0.2f, 0.8f};
+                    muscle.modeData.autoBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
                     break;
                 case MuscleMode_ManualBending:
-                    muscle.modeData.manualBending = {0.2f, 0.8f};
+                    muscle.modeData.manualBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
                     break;
                 case MuscleMode_AngleBending:
-                    muscle.modeData.angleBending = {0.2f, 0.8f};
+                    muscle.modeData.angleBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleAttractionRepulsionRatio_Default};
                     break;
                 case MuscleMode_AutoCrawling:
-                    muscle.modeData.autoCrawling = {0.8f, 0.8f};
+                    muscle.modeData.autoCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
                     break;
                 case MuscleMode_ManualCrawling:
-                    muscle.modeData.manualCrawling = {0.8f, 0.8f};
+                    muscle.modeData.manualCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
                     break;
                 case MuscleMode_DirectMovement:
                     muscle.modeData.directMovement = {};
@@ -628,10 +629,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                     reconnector.modeData.reconnectSolid = {};
                     break;
                 case ReconnectorMode_FreeCell:
-                    reconnector.modeData.reconnectFreeCell = {0x3ff};
+                    reconnector.modeData.reconnectFreeCell = {Const::RestrictToColors_Default};
                     break;
                 case ReconnectorMode_Creature:
-                    reconnector.modeData.reconnectCreature = {0, 0, 0x3ff, LineageRestriction_No};
+                    reconnector.modeData.reconnectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
                     break;
                 }
             } break;
@@ -640,7 +641,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                 memory.mode = static_cast<MemoryMode>(pickNewMode(memory.mode, MemoryMode_Count));
                 switch (memory.mode) {
                 case MemoryMode_SignalDelay:
-                    memory.modeData.signalDelay = {10};
+                    memory.modeData.signalDelay = {Const::SignalDelay_Default};
                     break;
                 case MemoryMode_SignalRecorder:
                     memory.modeData.signalRecorder = {true, 0};
@@ -649,7 +650,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                     memory.modeData.signalStorage = {true};
                     break;
                 case MemoryMode_SignalIntegrator:
-                    memory.modeData.signalIntegrator = {0.5f};
+                    memory.modeData.signalIntegrator = {Const::SignalIntegratorNewSignalWeight_Default};
                     break;
                 }
             } break;
@@ -658,10 +659,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
                 communicator.mode = static_cast<CommunicatorMode>(pickNewMode(communicator.mode, CommunicatorMode_Count));
                 switch (communicator.mode) {
                 case CommunicatorMode_Sender:
-                    communicator.modeData.sender = {10, 4};
+                    communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorMaxTimesSent_Default};
                     break;
                 case CommunicatorMode_Receiver:
-                    communicator.modeData.receiver = {0x3ff, LineageRestriction_No};
+                    communicator.modeData.receiver = {Const::RestrictToColors_Default, LineageRestriction_No};
                     break;
                 }
             } break;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -27,6 +27,7 @@ private:
     __inline__ __device__ static void applyMutations_cellTypeProperties(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
+
     __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static float generateGaussian(SimulationData& data);
     __inline__ __device__ static bool isRandomEvent(SimulationData& data, float probability);

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -180,7 +180,8 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                             {ConnectionMutationDesc().eventProbability(0.6f).sigma(0.7f), ConnectionMutationDesc().eventProbability(0.8f).sigma(0.9f)})
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().eventProbability(0.45f).sigma(0.55f).probability(0.65f),
-                             CellTypePropertiesMutationDesc().eventProbability(0.75f).sigma(0.85f).probability(0.95f)});
+                             CellTypePropertiesMutationDesc().eventProbability(0.75f).sigma(0.85f).probability(0.95f)})
+                        .cellTypeModeMutation(CellTypeModeMutationDesc().eventProbability(0.33f));
 
     auto genome = GenomeDesc()
                       .name("Test Genome")

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -13,7 +13,8 @@ enum class MutationType
 {
     Neuron,
     Connection,
-    CellTypeProperties
+    CellTypeProperties,
+    CellTypeMode
 };
 
 class AccumulatedMutationTests_AllTypes
@@ -25,7 +26,7 @@ class AccumulatedMutationTests_AllTypes
 INSTANTIATE_TEST_SUITE_P(
     AccumulatedMutationTests,
     AccumulatedMutationTests_AllTypes,
-    ::testing::Values(MutationType::Neuron, MutationType::Connection, MutationType::CellTypeProperties));
+    ::testing::Values(MutationType::Neuron, MutationType::Connection, MutationType::CellTypeProperties, MutationType::CellTypeMode));
 
 TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
 {
@@ -40,6 +41,9 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::CellTypeProperties:
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
+        break;
+    case MutationType::CellTypeMode:
+        genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);
         break;
     }
 
@@ -67,6 +71,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.metaMutationNeuronsSigma.value = 1.0f;
     _parameters.metaMutationConnectionsSigma.value = 1.0f;
     _parameters.metaMutationCellTypePropertiesSigma.value = 1.0f;
+    _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -4,6 +4,7 @@ PUBLIC
     AttackerTests.cpp
     BalanceTests.cpp
     CellStateTransitionTests.cpp
+    CellTypeModeMutationTests.cpp
     CellTypeMutationCoverageGuard.cpp
     CellTypePropertiesMutationTests.cpp
     CommunicatorTests.cpp

--- a/source/EngineTests/CellTypeModeMutationTests.cpp
+++ b/source/EngineTests/CellTypeModeMutationTests.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <type_traits>
 #include <variant>
 
@@ -10,7 +11,37 @@
 #include "MutationTestsBase.h"
 
 class CellTypeModeMutationTests : public MutationTestsBase
-{};
+{
+protected:
+    // Resets the active cell type mode (selected mode and its data) to a canonical value while preserving all other attributes.
+    static void resetCellTypeMode(CellTypeGenomeDesc& cellType)
+    {
+        std::visit(
+            [](auto& cellTypeData) {
+                if constexpr (requires { cellTypeData._mode; }) {
+                    cellTypeData._mode = std::decay_t<decltype(cellTypeData._mode)>{};
+                }
+            },
+            cellType);
+    }
+
+    bool compareAllExceptCellTypeMode(GenomeDesc expected, GenomeDesc actual)
+    {
+        auto reset = [](GenomeDesc& genome) {
+            genome._lineageId = 0;
+            genome._prevLineageId = std::nullopt;
+            genome._accumulatedMutations = 0.0f;
+            for (auto& gene : genome._genes) {
+                for (auto& node : gene._nodes) {
+                    resetCellTypeMode(node._cellType);
+                }
+            }
+        };
+        reset(expected);
+        reset(actual);
+        return expected == actual;
+    }
+};
 
 TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_changesModeToDefaults)
 {
@@ -34,7 +65,7 @@ TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_changesModeToDefaults)
 
 TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_doesNotChangeCellTypeWithoutMode)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(DepotGenomeDesc().storageLimit(350.0f).initialStoredUsableEnergy(100.0f))})});
+    auto genome = createTestGenome();
     genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -45,8 +76,6 @@ TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_doesNotChangeCellTypeWith
     }
 
     auto actualGenome = getMutatedGenome();
-    auto const& depot = std::get<DepotGenomeDesc>(actualGenome._genes.at(0)._nodes.at(0)._cellType);
 
-    EXPECT_EQ(depot._storageLimit, 350.0f);
-    EXPECT_EQ(depot._initialStoredUsableEnergy, 100.0f);
+    EXPECT_TRUE(compareAllExceptCellTypeMode(genome, actualGenome));
 }

--- a/source/EngineTests/CellTypeModeMutationTests.cpp
+++ b/source/EngineTests/CellTypeModeMutationTests.cpp
@@ -63,7 +63,7 @@ TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_changesModeToDefaults)
     std::visit([](auto const& modeData) { EXPECT_EQ(modeData, std::decay_t<decltype(modeData)>{}); }, muscle._mode);
 }
 
-TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_doesNotChangeCellTypeWithoutMode)
+TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_doesNotChangeExceptMode)
 {
     auto genome = createTestGenome();
     genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);

--- a/source/EngineTests/CellTypeModeMutationTests.cpp
+++ b/source/EngineTests/CellTypeModeMutationTests.cpp
@@ -1,0 +1,52 @@
+#include <type_traits>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class CellTypeModeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_changesModeToDefaults)
+{
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().cellType(MuscleGenomeDesc().mode(AutoBendingGenomeDesc().maxAngleDeviation(0.55f).forwardBackwardRatio(0.25f)))})});
+    genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    auto const& muscle = std::get<MuscleGenomeDesc>(actualGenome._genes.at(0)._nodes.at(0)._cellType);
+
+    EXPECT_NE(muscle.getMode(), MuscleMode_AutoBending);
+
+    // The new mode must be initialized with default attribute values.
+    std::visit([](auto const& modeData) { EXPECT_EQ(modeData, std::decay_t<decltype(modeData)>{}); }, muscle._mode);
+}
+
+TEST_F(CellTypeModeMutationTests, cellTypeModeMutation_doesNotChangeCellTypeWithoutMode)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(DepotGenomeDesc().storageLimit(350.0f).initialStoredUsableEnergy(100.0f))})});
+    genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    auto const& depot = std::get<DepotGenomeDesc>(actualGenome._genes.at(0)._nodes.at(0)._cellType);
+
+    EXPECT_EQ(depot._storageLimit, 350.0f);
+    EXPECT_EQ(depot._initialStoredUsableEnergy, 100.0f);
+}

--- a/source/EngineTests/CellTypeMutationCoverageGuard.cpp
+++ b/source/EngineTests/CellTypeMutationCoverageGuard.cpp
@@ -13,6 +13,8 @@
 //
 // The mode counts at the bottom pin the number of modes per cell type, so adding
 // a mode also trips the check (its new description struct still needs review).
+// Switching modes itself lives in MutationProcessor::applyMutations_cellTypeMode(),
+// which also needs a default-initialized branch for every new mode.
 
 
 #include <variant>
@@ -29,7 +31,8 @@
 #define ALIEN_MUTATION_MODE_COUNT(Type, Count) \
     static_assert( \
         std::variant_size_v<Type> == (Count), \
-        #Type " mode count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count")
+        #Type \
+        " mode count changed - review applyMutations_cellTypeProperties() and applyMutations_cellTypeMode() in MutationProcessor.cuh and update this count")
 
 // --- Cell types (switch (node.cellType)) ---
 ALIEN_MUTATION_FIELD_COUNT(BaseGenomeDesc, 0);

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -194,3 +194,43 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
     EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._sigma, 0.4f);
     EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._probability, 0.4f);
 }
+
+TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_NE(actualGenome._mutationRates._cellTypeModeMutation._eventProbability, 0.5f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypeModeMutation._eventProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._cellTypeModeMutation._eventProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationCellTypeModeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._cellTypeModeMutation._eventProbability, 0.5f);
+}

--- a/source/Gui/MutationRateDialog.cpp
+++ b/source/Gui/MutationRateDialog.cpp
@@ -89,6 +89,23 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    void processCellTypeModeMutationRate(std::string const& name, std::string const& id, CellTypeModeMutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Event probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._eventProbability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     template <typename Func>
     void processConcreteMutationRates(Func&& processMutationRates)
     {
@@ -146,6 +163,8 @@ void MutationRateDialog::loadSettings(MutationRatesDesc& mutationRates, std::str
         settings.getValue(settingsPrefix + "cell type property mutation 2.sigma", mutationRates._cellTypePropertiesMutations[1]._sigma);
     mutationRates._cellTypePropertiesMutations[1]._probability =
         settings.getValue(settingsPrefix + "cell type property mutation 2.value probability", mutationRates._cellTypePropertiesMutations[1]._probability);
+    mutationRates._cellTypeModeMutation._eventProbability =
+        settings.getValue(settingsPrefix + "cell type mode mutation.probability", mutationRates._cellTypeModeMutation._eventProbability);
 }
 
 void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, std::string const& settingsPrefix) const
@@ -172,6 +191,7 @@ void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, st
     settings.setValue(settingsPrefix + "cell type property mutation 2.probability", mutationRates._cellTypePropertiesMutations[1]._eventProbability);
     settings.setValue(settingsPrefix + "cell type property mutation 2.sigma", mutationRates._cellTypePropertiesMutations[1]._sigma);
     settings.setValue(settingsPrefix + "cell type property mutation 2.value probability", mutationRates._cellTypePropertiesMutations[1]._probability);
+    settings.setValue(settingsPrefix + "cell type mode mutation.probability", mutationRates._cellTypeModeMutation._eventProbability);
 }
 
 void MutationRateDialog::processIntern()
@@ -206,6 +226,14 @@ void MutationRateDialog::processIntern()
                 processCellTypePropertiesMutationRate("Cell type property mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], rightColumnWidth);
                 table.next();
                 processCellTypePropertiesMutationRate("Cell type property mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mode mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processCellTypeModeMutationRate("Cell type mode mutation rate", "CTMM", _mutation._cellTypeModeMutation, rightColumnWidth);
                 table.next();
             });
         }

--- a/source/Gui/MutationRateDialog.cpp
+++ b/source/Gui/MutationRateDialog.cpp
@@ -201,11 +201,11 @@ void MutationRateDialog::processIntern()
     if (ImGui::BeginChild("MutationRateContent", ImVec2(0, -buttonAreaHeight), false)) {
         auto rightColumnWidth = std::max(HeaderMinRightColumnWidth, scaleInverse(ImGui::GetContentRegionAvail().x - scale(HeaderMaxLeftColumnWidth)));
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Connection mutations").rank(AlienGui::TreeNodeRank::High))) {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Connection weight mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processConnectionMutationRate("Connection weight mutation rate 1", "CMR1", _mutation._connectionMutations[0], rightColumnWidth);
+                processConnectionMutationRate("Mutation rate 1", "CMR1", _mutation._connectionMutations[0], rightColumnWidth);
                 table.next();
-                processConnectionMutationRate("Connection weight mutation rate 2", "CMR2", _mutation._connectionMutations[1], rightColumnWidth);
+                processConnectionMutationRate("Mutation rate 2", "CMR2", _mutation._connectionMutations[1], rightColumnWidth);
                 table.next();
             });
         }
@@ -213,9 +213,9 @@ void MutationRateDialog::processIntern()
 
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Neuron mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processNeuronMutationRate("Neuron weight mutation rate 1", "NMR1", _mutation._neuronMutations[0], rightColumnWidth);
+                processNeuronMutationRate("Mutation rate 1", "NMR1", _mutation._neuronMutations[0], rightColumnWidth);
                 table.next();
-                processNeuronMutationRate("Neuron weight mutation rate 2", "NMR2", _mutation._neuronMutations[1], rightColumnWidth);
+                processNeuronMutationRate("Mutation rate 2", "NMR2", _mutation._neuronMutations[1], rightColumnWidth);
                 table.next();
             });
         }
@@ -223,9 +223,9 @@ void MutationRateDialog::processIntern()
 
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type property mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processCellTypePropertiesMutationRate("Cell type property mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], rightColumnWidth);
+                processCellTypePropertiesMutationRate("Mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], rightColumnWidth);
                 table.next();
-                processCellTypePropertiesMutationRate("Cell type property mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], rightColumnWidth);
+                processCellTypePropertiesMutationRate("Mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], rightColumnWidth);
                 table.next();
             });
         }
@@ -233,7 +233,7 @@ void MutationRateDialog::processIntern()
 
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mode mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processCellTypeModeMutationRate("Cell type mode mutation rate", "CTMM", _mutation._cellTypeModeMutation, rightColumnWidth);
+                processCellTypeModeMutationRate("Mutation rate", "CTMM", _mutation._cellTypeModeMutation, rightColumnWidth);
                 table.next();
             });
         }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -300,6 +300,8 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_Sigma = 1;
     auto constexpr Id_CellTypePropertiesMutation_Probability = 2;
 
+    auto constexpr Id_CellTypeModeMutation_EventProbability = 0;
+
     auto constexpr Id_Gene_Name = 0;
     auto constexpr Id_Gene_Shape = 1;
     auto constexpr Id_Gene_Stiffness = 5;
@@ -421,6 +423,7 @@ namespace
     auto constexpr Id_MutationRates_ConnectionMutation2 = 4;
     auto constexpr Id_MutationRates_CellTypePropertiesMutation1 = 5;
     auto constexpr Id_MutationRates_CellTypePropertiesMutation2 = 6;
+    auto constexpr Id_MutationRates_CellTypeModeMutation = 7;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -894,6 +897,15 @@ namespace cereal
     SPLIT_SERIALIZATION(CellTypePropertiesMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, CellTypeModeMutationDesc& data)
+    {
+        CellTypeModeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_CellTypeModeMutation_EventProbability, data._eventProbability, defaultObject._eventProbability);
+    }
+    SPLIT_SERIALIZATION(CellTypeModeMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, MutationRatesDesc& data)
     {
         MutationRatesDesc defaultObject;
@@ -904,6 +916,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_ConnectionMutation2, data._connectionMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation1, data._cellTypePropertiesMutations[0]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation2, data._cellTypePropertiesMutations[1]);
+        scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
     }
     SPLIT_SERIALIZATION(MutationRatesDesc)
 


### PR DESCRIPTION
## Summary
- Add a new mutation type `CellTypeModeMutation` (single instance, field `eventProbability`) alongside the existing `NeuronMutation`, `ConnectionMutation` and `CellTypeProperties` mutations.
- Wire it through `MutationRates`/`MutationRatesTO`/`MutationRatesDesc` and the full data-transfer path (DescConverterService, SerializerService, EntityFactory, DataAccessKernels, DescTestDataFactory, GenomeDescHash, DescValidationService).
- Add it to the `MutationRateDialog` GUI and `MutationRatesDesc::getActiveMutationTypes()`.
- Add simulation parameter `metaMutationCellTypeModeSigma` (Meta mutations group).
- Implement the mutation logic in `MutationProcessor`:
  - `applyMutations_cellTypeMode`: for every node whose cell type has a `mode` field (Sensor, Generator, Attacker, Muscle, Defender, Reconnector, Memory, Communicator), randomly switch the mode to a different one (e.g. AutoBending -> ManualBending). The new mode is initialized with the same default attribute values as the host-side genome descriptions, so the genome stays valid. `accumulatedMutations` is increased per change.
  - `applyMutations_meta`: extended to meta-mutate `cellTypeModeMutation.eventProbability` via `metaMutationCellTypeModeSigma`.
- Updated the compile-time coverage guard to point new-mode reviews at `applyMutations_cellTypeMode` as well.
- Tests: new `CellTypeModeMutationTests` (mode changes to defaults; cell types without a mode are untouched), plus `CellTypeMode` added to `AccumulatedMutationTests` and new `MetaMutationTests` cases for the sigma.

## Original task
There are currently 3 types of mutations (see MutationRates): NeuronMutation, ConnectionMutation and CellTypeProperties. The task is to add a new mutation type called `CellTypeModeMutation`. It should contain the field `eventProbability`.
- Extend MutationRates, MutationRatesTO and MutationRatesDesc (in contrast to other mutation types, only 1 instance instead of 2).
- Adapt data transfer: DescConverterService, SerializerService, EntityFactory, DataAccessKernels, DescTestDataFactory
- MutationRateDialog
- Add simulation parameter `metaMutationCellTypeModeSigma`
- Implement the main mutation logic to MutationProcessor: for CellTypeModeMutation and for the meta mutation (governed by metaMutationCellTypeModeSigma)
  - for CellTypeModeMutation: the cells whose cell type contain a `mode` field should be changed by random (e.g. AutoBending to ManualBending). The new (mutated) mode should have default values for all attributes. The genome must be validated and corrected after mutations. Try to reuse existing code. The accumulatedMutations must also be increased.
  - for meta mutations: extend MutationProcessor::applyMutations_meta by evaluating the new parameter metaMutationCellTypeModeSigma

## Build and tests
- `cmake --build build --config Release -j32`: passed (all targets including alien, cli, EngineTests, EngineInterfaceTests, NetworkTests, PersisterTests)
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests, includes genome serialization round-trip with the new field)
- `./EngineTests`: passed (3000 tests, 2997 passed, 3 pre-existing unrelated skips)
- `./cli --help`: passed

## Notes
- `CellTypeModeMutation` is a single instance in `MutationRates`, unlike the paired (array-of-2) mutation types, as requested.
- "Default values for all attributes" mirror the defaults in `GenomeDesc.h`; since they are always valid, no separate correction pass is needed beyond initializing the new mode. Mode selection reuses the same "pick a different enum value" approach used elsewhere.
- The serialization round-trip tests (`SerializerServiceTests`, `DataTransferTests`) exercise the new field via `DescTestDataFactory`.