### PR TITLE
Add homogeneCellType flag to gene

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -892,6 +892,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         geneDesc._shape = geneTO->shape;
         geneDesc._stiffness = geneTO->stiffness;
         geneDesc._connectionDistance = geneTO->connectionDistance;
+        geneDesc._homogeneCellType = geneTO->homogeneCellType;
 
         CHECK(geneTO->nodeArrayIndex + geneTO->numNodes <= *to.numNodes);
         for (int k = 0; k < geneTO->numNodes; ++k) {
@@ -980,6 +981,7 @@ void DescConverterService::convertGenomeToTO(
         geneTO.shape = geneDesc._shape;
         geneTO.stiffness = geneDesc._stiffness;
         geneTO.connectionDistance = geneDesc._connectionDistance;
+        geneTO.homogeneCellType = geneDesc._homogeneCellType;
         geneTO.numNodes = toInt(geneDesc._nodes.size());
 
         auto nodeArrayStartIndex = nodeTOs.size();

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -409,6 +409,7 @@ struct GeneDesc
     MEMBER(GeneDesc, ConstructorShape, shape, ConstructorShape_Segment);
     MEMBER(GeneDesc, float, stiffness, 1.0f);
     MEMBER(GeneDesc, float, connectionDistance, 1.0f);
+    MEMBER(GeneDesc, bool, homogeneCellType, false);
 };
 
 struct NeuronMutationDesc

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -525,6 +525,7 @@ struct std::hash<GeneDesc>
         hash_combine(seed, static_cast<int>(desc._shape));
         hash_combine(seed, desc._stiffness);
         hash_combine(seed, desc._connectionDistance);
+        hash_combine(seed, desc._homogeneCellType);
         return seed;
     }
 };

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -19,6 +19,7 @@ private:
         Creature* creature;
         Gene* gene;
         Node* node;
+        Node* cellTypeNode;  // Node providing cell type and its properties (first node if gene->homogeneCellType, otherwise node)
         bool isSeparation;
 
         // Construction position
@@ -225,6 +226,7 @@ __inline__ __device__ ConstructorProcessor::ConstructionData ConstructorProcesso
     result.creature = constructor.offspring;
     result.gene = ConstructorHelper::getCurrentGene(constructor, *genome);
     result.node = &result.gene->nodes[result.currentNodeIndex];
+    result.cellTypeNode = result.gene->homogeneCellType ? &result.gene->nodes[0] : result.node;
     result.isSeparation = constructor.separation;
     result.isFirstNode = result.currentNodeIndex == 0;
     auto isFirstConcatenation = result.currentConcatenation == 0;
@@ -235,7 +237,7 @@ __inline__ __device__ ConstructorProcessor::ConstructionData ConstructorProcesso
     result.lastConstructionObject = ConstructorHelper::getLastConstructedCell(object);
     result.neededUsableEnergy = cudaSimulationParameters.normalCellEnergy.value[object->color];
     result.neededReservedEnergy = result.node->constructorAvailable ? result.node->constructor.reservedEnergy : 0.0f;
-    result.neededDepotEnergy = result.node->cellType == CellType_Depot ? result.node->cellTypeData.depot.initialStoredUsableEnergy : 0.0f;
+    result.neededDepotEnergy = result.cellTypeNode->cellType == CellType_Depot ? result.cellTypeNode->cellTypeData.depot.initialStoredUsableEnergy : 0.0f;
 
     ShapeGenerator shapeGenerator;
     auto shape = result.gene->shape;
@@ -551,6 +553,7 @@ __inline__ __device__ Object* ConstructorProcessor::constructCellIntern(
         constructionData.creature,
         constructor.geneIndex,
         constructionData.currentNodeIndex,
+        constructionData.cellTypeNode,
         hostObject->typeData.cell.nodeIndex,
         constructionData.currentConcatenation,
         constructionData.currentBranch,

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -19,7 +19,6 @@ private:
         Creature* creature;
         Gene* gene;
         Node* node;
-        Node* cellTypeNode;  // Node providing cell type and its properties (first node if gene->homogeneCellType, otherwise node)
         bool isSeparation;
 
         // Construction position
@@ -226,7 +225,6 @@ __inline__ __device__ ConstructorProcessor::ConstructionData ConstructorProcesso
     result.creature = constructor.offspring;
     result.gene = ConstructorHelper::getCurrentGene(constructor, *genome);
     result.node = &result.gene->nodes[result.currentNodeIndex];
-    result.cellTypeNode = result.gene->homogeneCellType ? &result.gene->nodes[0] : result.node;
     result.isSeparation = constructor.separation;
     result.isFirstNode = result.currentNodeIndex == 0;
     auto isFirstConcatenation = result.currentConcatenation == 0;
@@ -237,7 +235,8 @@ __inline__ __device__ ConstructorProcessor::ConstructionData ConstructorProcesso
     result.lastConstructionObject = ConstructorHelper::getLastConstructedCell(object);
     result.neededUsableEnergy = cudaSimulationParameters.normalCellEnergy.value[object->color];
     result.neededReservedEnergy = result.node->constructorAvailable ? result.node->constructor.reservedEnergy : 0.0f;
-    result.neededDepotEnergy = result.cellTypeNode->cellType == CellType_Depot ? result.cellTypeNode->cellTypeData.depot.initialStoredUsableEnergy : 0.0f;
+    auto cellTypeNode = result.gene->homogeneCellType ? &result.gene->nodes[0] : result.node;
+    result.neededDepotEnergy = cellTypeNode->cellType == CellType_Depot ? cellTypeNode->cellTypeData.depot.initialStoredUsableEnergy : 0.0f;
 
     ShapeGenerator shapeGenerator;
     auto shape = result.gene->shape;
@@ -553,7 +552,7 @@ __inline__ __device__ Object* ConstructorProcessor::constructCellIntern(
         constructionData.creature,
         constructor.geneIndex,
         constructionData.currentNodeIndex,
-        constructionData.cellTypeNode,
+        constructionData.gene->homogeneCellType,
         hostObject->typeData.cell.nodeIndex,
         constructionData.currentConcatenation,
         constructionData.currentBranch,

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -62,6 +62,7 @@ namespace
                 geneTO.shape = gene.shape;
                 geneTO.stiffness = gene.stiffness;
                 geneTO.connectionDistance = gene.connectionDistance;
+                geneTO.homogeneCellType = gene.homogeneCellType;
                 geneTO.numNodes = gene.numNodes;
                 for (int i = 0; i < sizeof(gene.name); ++i) {
                     geneTO.name[i] = gene.name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -30,7 +30,7 @@ public:
         Creature* creature,
         int geneIndex,
         int nodeIndex,
-        Node* cellTypeNode,
+        bool homogeneousCellType,
         int parentNodeIndex,
         int concatenationIndex,
         int branchIndex,
@@ -700,7 +700,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     Creature* creature,
     int geneIndex,
     int nodeIndex,
-    Node* cellTypeNode,
+    bool homogeneousCellType,
     int parentNodeIndex,
     int concatenationIndex,
     int branchIndex,
@@ -710,6 +710,9 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
 {
     auto const& gene = &creature->genome->genes[geneIndex];
     auto const& node = &gene->nodes[nodeIndex];
+
+    // With homogeneous cell type the cell type and its properties are taken from the gene's first node
+    auto const& cellTypeNode = homogeneousCellType ? &gene->nodes[0] : node;
 
     auto object = _data->entities.heap.getTypedSubArray<Object>(1);
     auto objectPointer = _data->entities.objects.getNewElement(&objectIndex);

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -30,6 +30,7 @@ public:
         Creature* creature,
         int geneIndex,
         int nodeIndex,
+        Node* cellTypeNode,
         int parentNodeIndex,
         int concatenationIndex,
         int branchIndex,
@@ -117,6 +118,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
         gene.shape = geneTO.shape;
         gene.stiffness = geneTO.stiffness;
         gene.connectionDistance = geneTO.connectionDistance;
+        gene.homogeneCellType = geneTO.homogeneCellType;
         gene.numNodes = geneTO.numNodes;
         for (int i = 0; i < sizeof(geneTO.name); ++i) {
             gene.name[i] = geneTO.name[i];
@@ -698,6 +700,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     Creature* creature,
     int geneIndex,
     int nodeIndex,
+    Node* cellTypeNode,
     int parentNodeIndex,
     int concatenationIndex,
     int branchIndex,
@@ -760,18 +763,18 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     cell.lastUpdate = 0;
     cell.event = CellEvent_No;
 
-    switch (node->cellType) {
+    switch (cellTypeNode->cellType) {
     case CellType_Base: {
         cell.cellType = CellType_Base;
     } break;
     case CellType_Depot: {
         cell.cellType = CellType_Depot;
-        cell.cellTypeData.depot.storageLimit = node->cellTypeData.depot.storageLimit;
-        cell.cellTypeData.depot.storedUsableEnergy = node->cellTypeData.depot.initialStoredUsableEnergy;
+        cell.cellTypeData.depot.storageLimit = cellTypeNode->cellTypeData.depot.storageLimit;
+        cell.cellTypeData.depot.storedUsableEnergy = cellTypeNode->cellTypeData.depot.initialStoredUsableEnergy;
     } break;
     case CellType_Sensor: {
         cell.cellType = CellType_Sensor;
-        auto const& nodeSensor = node->cellTypeData.sensor;
+        auto const& nodeSensor = cellTypeNode->cellTypeData.sensor;
         auto& sensor = cell.cellTypeData.sensor;
         sensor.autoTrigger = nodeSensor.autoTrigger;
         sensor.tagForAttackers = nodeSensor.tagForAttackers;
@@ -795,7 +798,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Generator: {
         cell.cellType = CellType_Generator;
-        auto const& nodeGenerator = node->cellTypeData.generator;
+        auto const& nodeGenerator = cellTypeNode->cellTypeData.generator;
         auto& generator = cell.cellTypeData.generator;
         generator.additive = nodeGenerator.additive;
         generator.minValue = nodeGenerator.minValue;
@@ -811,7 +814,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Attacker: {
         cell.cellType = CellType_Attacker;
-        auto const& nodeAttacker = node->cellTypeData.attacker;
+        auto const& nodeAttacker = cellTypeNode->cellTypeData.attacker;
         auto& attacker = cell.cellTypeData.attacker;
         attacker.mode = nodeAttacker.mode;
         if (nodeAttacker.mode == AttackerMode_FreeCell) {
@@ -820,13 +823,13 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Injector: {
         cell.cellType = CellType_Injector;
-        auto const& nodeInjector = node->cellTypeData.injector;
+        auto const& nodeInjector = cellTypeNode->cellTypeData.injector;
         auto& injector = cell.cellTypeData.injector;
         injector.geneIndex = nodeInjector.geneIndex;
     } break;
     case CellType_Muscle: {
         cell.cellType = CellType_Muscle;
-        auto const& nodeMuscle = node->cellTypeData.muscle;
+        auto const& nodeMuscle = cellTypeNode->cellTypeData.muscle;
         auto& muscle = cell.cellTypeData.muscle;
         muscle.lastMovementX = 0;
         muscle.lastMovementY = 0;
@@ -869,13 +872,13 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Defender: {
         cell.cellType = CellType_Defender;
-        auto const& nodeDefender = node->cellTypeData.defender;
+        auto const& nodeDefender = cellTypeNode->cellTypeData.defender;
         auto& defender = cell.cellTypeData.defender;
         defender.mode = nodeDefender.mode;
     } break;
     case CellType_Reconnector: {
         cell.cellType = CellType_Reconnector;
-        auto const& nodeReconnector = node->cellTypeData.reconnector;
+        auto const& nodeReconnector = cellTypeNode->cellTypeData.reconnector;
         auto& reconnector = cell.cellTypeData.reconnector;
         reconnector.mode = nodeReconnector.mode;
         if (nodeReconnector.mode == ReconnectorMode_Solid) {
@@ -890,20 +893,20 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Detonator: {
         cell.cellType = CellType_Detonator;
-        auto const& nodeDetonator = node->cellTypeData.detonator;
+        auto const& nodeDetonator = cellTypeNode->cellTypeData.detonator;
         auto& detonator = cell.cellTypeData.detonator;
         detonator.state = DetonatorState_Ready;
         detonator.countdown = nodeDetonator.countdown;
     } break;
     case CellType_Digestor: {
         cell.cellType = CellType_Digestor;
-        auto const& nodeDigestor = node->cellTypeData.digestor;
+        auto const& nodeDigestor = cellTypeNode->cellTypeData.digestor;
         auto& digestor = cell.cellTypeData.digestor;
         digestor.rawEnergyConductivity = nodeDigestor.rawEnergyConductivity;
     } break;
     case CellType_Memory: {
         cell.cellType = CellType_Memory;
-        auto const& nodeMemory = node->cellTypeData.memory;
+        auto const& nodeMemory = cellTypeNode->cellTypeData.memory;
         auto& memory = cell.cellTypeData.memory;
         memory.mode = nodeMemory.mode;
         memory.numSignalEntries = nodeMemory.numSignalEntries;
@@ -931,7 +934,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
     } break;
     case CellType_Communicator: {
         cell.cellType = CellType_Communicator;
-        auto const& nodeCommunicator = node->cellTypeData.communicator;
+        auto const& nodeCommunicator = cellTypeNode->cellTypeData.communicator;
         auto& communicator = cell.cellTypeData.communicator;
         communicator.mode = nodeCommunicator.mode;
         if (nodeCommunicator.mode == CommunicatorMode_Sender) {

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -334,6 +334,7 @@ struct Gene
     ConstructorShape shape;
     float stiffness;
     float connectionDistance;
+    bool homogeneCellType;
 
     int numNodes;
     Node* nodes;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -339,6 +339,7 @@ struct GeneTO
     ConstructorShape shape;
     float stiffness;
     float connectionDistance;
+    bool homogeneCellType;
 
     int numNodes;
     uint64_t nodeArrayIndex;

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -196,6 +196,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                               .shape(ConstructorShape_Hexagon)
                               .stiffness(0.75f)
                               .connectionDistance(0.8f)
+                              .homogeneCellType(true)
                               .nodes({
                                   createNonDefaultNodeDesc(nodeParameter),
                               }),

--- a/source/EngineTests/ConstructorTests.cpp
+++ b/source/EngineTests/ConstructorTests.cpp
@@ -3380,44 +3380,6 @@ TEST_F(ConstructorTests, homogeneCellType_inheritsCellTypeFromFirstNode)
     EXPECT_TRUE(approxCompare(getEnergy(data), getEnergy(actualData)));
 }
 
-TEST_F(ConstructorTests, homogeneCellTypeDisabled_keepsOwnCellType)
-{
-    auto genome = GenomeDesc().genes({
-        GeneDesc().nodes({
-            NodeDesc().cellType(DetonatorGenomeDesc().countdown(42)),
-            NodeDesc(),
-            NodeDesc(),
-        }),
-    });
-
-    auto data = Desc().addCreature(
-        {
-            ObjectDesc()
-                .id(0)
-                .pos({10.0f, 10.0f})
-                .type(CellDesc()
-                          .usableEnergy(getConstructorEnergy())
-                          .constructor(ConstructorDesc().geneIndex(0).autoTriggerInterval(1).lastConstructedCellId(1).separation(false))),
-            ObjectDesc().id(1).pos({10.0f + getOffspringDistance(), 10.0f}).type(CellDesc().cellState(CellState_Constructing).nodeIndex(0)),
-        },
-        CreatureDesc().id(0),
-        genome);
-    data.addConnection(0, 1);
-
-    _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_calcTimestepWithCellFunctions();
-
-    auto actualData = _simulationFacade->getSimulationData();
-
-    ASSERT_EQ(1, actualData._creatures.size());
-    auto creature = actualData.getCreatureRef(0);
-    ASSERT_EQ(3, actualData.getObjectsForCreature(creature._id).size());
-
-    // Without homogeneous cell type, the constructed second node keeps its own (base) cell type
-    auto actualConstructedCell = actualData.getOtherObjectRef({0, 1});
-    EXPECT_EQ(CellType_Base, actualConstructedCell.getCellRef().getCellType());
-}
-
 TEST_F(ConstructorTests, regressionTestMassiveReplicationsWithSeeds)
 {
     auto genome = GenomeDesc().genes({

--- a/source/EngineTests/ConstructorTests.cpp
+++ b/source/EngineTests/ConstructorTests.cpp
@@ -3336,6 +3336,88 @@ TEST_P(ConstructorTests_ProvideEnergy, provideEnergy_depotWithInitialStoredEnerg
     }
 }
 
+TEST_F(ConstructorTests, homogeneCellType_inheritsCellTypeFromFirstNode)
+{
+    auto const Countdown = 42;
+
+    auto genome = GenomeDesc().genes({
+        GeneDesc().homogeneCellType(true).nodes({
+            NodeDesc().cellType(DetonatorGenomeDesc().countdown(Countdown)),
+            NodeDesc(),
+            NodeDesc(),
+        }),
+    });
+
+    auto data = Desc().addCreature(
+        {
+            ObjectDesc()
+                .id(0)
+                .pos({10.0f, 10.0f})
+                .type(CellDesc()
+                          .usableEnergy(getConstructorEnergy())
+                          .constructor(ConstructorDesc().geneIndex(0).autoTriggerInterval(1).lastConstructedCellId(1).separation(false))),
+            ObjectDesc().id(1).pos({10.0f + getOffspringDistance(), 10.0f}).type(CellDesc().cellState(CellState_Constructing).nodeIndex(0)),
+        },
+        CreatureDesc().id(0),
+        genome);
+    data.addConnection(0, 1);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_calcTimestepWithCellFunctions();
+
+    auto actualData = _simulationFacade->getSimulationData();
+
+    ASSERT_EQ(0, actualData.getNumObjectsWithoutCreature());
+    ASSERT_EQ(1, actualData._creatures.size());
+    auto creature = actualData.getCreatureRef(0);
+    ASSERT_EQ(3, actualData.getObjectsForCreature(creature._id).size());
+
+    // The second node is a base cell, but with homogeneous cell type it inherits the detonator type and properties of the first node
+    auto actualConstructedCell = actualData.getOtherObjectRef({0, 1});
+    EXPECT_EQ(CellType_Detonator, actualConstructedCell.getCellRef().getCellType());
+    auto const& detonator = std::get<DetonatorDesc>(actualConstructedCell.getCellRef()._cellType);
+    EXPECT_EQ(Countdown, detonator._countdown);
+    EXPECT_TRUE(approxCompare(getEnergy(data), getEnergy(actualData)));
+}
+
+TEST_F(ConstructorTests, homogeneCellTypeDisabled_keepsOwnCellType)
+{
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({
+            NodeDesc().cellType(DetonatorGenomeDesc().countdown(42)),
+            NodeDesc(),
+            NodeDesc(),
+        }),
+    });
+
+    auto data = Desc().addCreature(
+        {
+            ObjectDesc()
+                .id(0)
+                .pos({10.0f, 10.0f})
+                .type(CellDesc()
+                          .usableEnergy(getConstructorEnergy())
+                          .constructor(ConstructorDesc().geneIndex(0).autoTriggerInterval(1).lastConstructedCellId(1).separation(false))),
+            ObjectDesc().id(1).pos({10.0f + getOffspringDistance(), 10.0f}).type(CellDesc().cellState(CellState_Constructing).nodeIndex(0)),
+        },
+        CreatureDesc().id(0),
+        genome);
+    data.addConnection(0, 1);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_calcTimestepWithCellFunctions();
+
+    auto actualData = _simulationFacade->getSimulationData();
+
+    ASSERT_EQ(1, actualData._creatures.size());
+    auto creature = actualData.getCreatureRef(0);
+    ASSERT_EQ(3, actualData.getObjectsForCreature(creature._id).size());
+
+    // Without homogeneous cell type, the constructed second node keeps its own (base) cell type
+    auto actualConstructedCell = actualData.getOtherObjectRef({0, 1});
+    EXPECT_EQ(CellType_Base, actualConstructedCell.getCellRef().getCellType());
+}
+
 TEST_F(ConstructorTests, regressionTestMassiveReplicationsWithSeeds)
 {
     auto genome = GenomeDesc().genes({

--- a/source/Gui/GeneEditorWidget.cpp
+++ b/source/Gui/GeneEditorWidget.cpp
@@ -183,7 +183,7 @@ void _GeneEditorWidget::processNodeList()
                     // Column 1: Node type
                     ImGui::TableNextColumn();
                     {
-                        auto nodeType = node.getCellType();
+                        auto nodeType = gene._homogeneCellType ? gene._nodes.front().getCellType() : node.getCellType();
                         auto text = Const::CellTypeStrings.at(nodeType);
                         AlienGui::Text(text);
                     }

--- a/source/Gui/GeneEditorWidget.cpp
+++ b/source/Gui/GeneEditorWidget.cpp
@@ -105,6 +105,14 @@ void _GeneEditorWidget::processHeaderData()
             // Stiffness
             AlienGui::InputFloat(AlienGui::InputFloatParameters().name("Stiffness").format("%.2f").step(0.05f).textWidth(rightColumnWidth), gene._stiffness);
 
+            // Homogeneous cell type
+            AlienGui::Checkbox(
+                AlienGui::CheckboxParameters()
+                    .name("Homogeneous cell type")
+                    .textWidth(rightColumnWidth)
+                    .tooltip("If enabled, every constructed cell of this gene uses the cell type and its properties of the first node."),
+                gene._homogeneCellType);
+
             table.next();
             table.end();
         }

--- a/source/Gui/NodeEditorWidget.cpp
+++ b/source/Gui/NodeEditorWidget.cpp
@@ -205,6 +205,10 @@ void _NodeEditorWidget::processNodeAttributes()
     if (ImGui::BeginChild("NodeData", ImVec2(0, -_layoutData->neuralNetEditorHeight), 0, 0)) {
         auto& gene = _editData->getSelectedGeneRef();
         auto& node = _editData->getSelectedNodeRef();
+
+        // With homogeneous cell type the cell type and its properties of the first node are shown and edited for every node
+        auto& cellTypeNode = gene._homogeneCellType ? gene._nodes.front() : node;
+
         auto const simulationParameters = _SimulationFacade::get()->getSimulationParameters();
         auto const& customizationColors = simulationParameters.customizationColors.value;
 
@@ -232,14 +236,14 @@ void _NodeEditorWidget::processNodeAttributes()
                 AlienGui::ComboColorParameters().customizationColors(customizationColors).name("Color").textWidth(rightColumnWidth), node._color);
 
             // Type
-            auto nodeType = node.getCellType();
+            auto nodeType = cellTypeNode.getCellType();
             if (AlienGui::Combo(AlienGui::ComboParameters().name("Type").values(Const::CellTypeStrings).textWidth(rightColumnWidth), nodeType)) {
-                if (nodeIndex.value() == 0 && nodeType == CellType_Void) {
+                if (nodeType == CellType_Void && (gene._homogeneCellType || nodeIndex.value() == 0)) {
                     showMessage("Error", "The first node cannot be void.");
-                } else if (nodeIndex.value() == gene._nodes.size() - 1 && nodeType == CellType_Void) {
+                } else if (nodeType == CellType_Void && nodeIndex.value() == gene._nodes.size() - 1) {
                     showMessage("Error", "The last node cannot be void.");
                 } else {
-                    node._cellType = createCellTypeGenomeDesc(nodeType);
+                    cellTypeNode._cellType = createCellTypeGenomeDesc(nodeType);
                 }
             }
 
@@ -316,7 +320,7 @@ void _NodeEditorWidget::processNodeAttributes()
 
             if (nodeType == CellType_Base) {
             } else if (nodeType == CellType_Depot) {
-                auto& depot = std::get<DepotGenomeDesc>(node._cellType);
+                auto& depot = std::get<DepotGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::InputFloat(
                     AlienGui::InputFloatParameters().name("Max energy for storage").format("%.1f").textWidth(rightColumnWidth), depot._storageLimit);
                 AlienGui::InputFloat(
@@ -327,7 +331,7 @@ void _NodeEditorWidget::processNodeAttributes()
                 ImGui::PushID("Sensor");
 
                 // Auto activation interval
-                auto& sensor = std::get<SensorGenomeDesc>(node._cellType);
+                auto& sensor = std::get<SensorGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Auto trigger").textWidth(rightColumnWidth), sensor._autoTrigger);
                 AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Tag for attackers").textWidth(rightColumnWidth), sensor._tagForAttackers);
 
@@ -384,7 +388,7 @@ void _NodeEditorWidget::processNodeAttributes()
 
             } else if (nodeType == CellType_Generator) {
 
-                auto& generator = std::get<GeneratorGenomeDesc>(node._cellType);
+                auto& generator = std::get<GeneratorGenomeDesc>(cellTypeNode._cellType);
 
                 // Additive
                 AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Additive").textWidth(rightColumnWidth), generator._additive);
@@ -422,7 +426,7 @@ void _NodeEditorWidget::processNodeAttributes()
 
             } else if (nodeType == CellType_Attacker) {
 
-                auto& attacker = std::get<AttackerGenomeDesc>(node._cellType);
+                auto& attacker = std::get<AttackerGenomeDesc>(cellTypeNode._cellType);
                 auto mode = attacker.getMode();
                 if (AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::AttackerModeStrings).textWidth(rightColumnWidth), mode)) {
                     attacker._mode = createAttackerModeGenomeDesc(mode);
@@ -441,13 +445,13 @@ void _NodeEditorWidget::processNodeAttributes()
             } else if (nodeType == CellType_Injector) {
 
                 // Gene index
-                auto& injector = std::get<InjectorGenomeDesc>(node._cellType);
+                auto& injector = std::get<InjectorGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::InputInt(AlienGui::InputIntParameters().name("Gene index").textWidth(rightColumnWidth), injector._geneIndex);
 
             } else if (nodeType == CellType_Muscle) {
 
                 // Mode
-                auto& muscle = std::get<MuscleGenomeDesc>(node._cellType);
+                auto& muscle = std::get<MuscleGenomeDesc>(cellTypeNode._cellType);
                 auto mode = muscle.getMode();
                 if (AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::MuscleModeStrings).textWidth(rightColumnWidth), mode)) {
                     muscle._mode = createMuscleModeGenomeDesc(mode);
@@ -539,13 +543,13 @@ void _NodeEditorWidget::processNodeAttributes()
             } else if (nodeType == CellType_Defender) {
 
                 // Defender mode
-                auto& defender = std::get<DefenderGenomeDesc>(node._cellType);
+                auto& defender = std::get<DefenderGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::DefenderModeStrings).textWidth(rightColumnWidth), defender._mode);
 
             } else if (nodeType == CellType_Reconnector) {
 
                 // Mode selection
-                auto& reconnector = std::get<ReconnectorGenomeDesc>(node._cellType);
+                auto& reconnector = std::get<ReconnectorGenomeDesc>(cellTypeNode._cellType);
                 auto mode = reconnector.getMode();
                 if (AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::ReconnectorModeStrings).textWidth(rightColumnWidth), mode)) {
                     reconnector._mode = createReconnectorModeGenomeDesc(mode);
@@ -578,11 +582,11 @@ void _NodeEditorWidget::processNodeAttributes()
             } else if (nodeType == CellType_Detonator) {
 
                 // Countdown
-                auto& detonator = std::get<DetonatorGenomeDesc>(node._cellType);
+                auto& detonator = std::get<DetonatorGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::InputInt(AlienGui::InputIntParameters().name("Countdown").textWidth(rightColumnWidth), detonator._countdown);
             } else if (nodeType == CellType_Digestor) {
 
-                auto& digestor = std::get<DigestorGenomeDesc>(node._cellType);
+                auto& digestor = std::get<DigestorGenomeDesc>(cellTypeNode._cellType);
                 AlienGui::SliderFloat(
                     AlienGui::SliderFloatParameters().name("Energy conductivity").max(1.0f).format("%.2f").textWidth(rightColumnWidth),
                     &digestor._rawEnergyConductivity);
@@ -593,7 +597,7 @@ void _NodeEditorWidget::processNodeAttributes()
             } else if (nodeType == CellType_Memory) {
 
                 // Mode selection
-                auto& memory = std::get<MemoryGenomeDesc>(node._cellType);
+                auto& memory = std::get<MemoryGenomeDesc>(cellTypeNode._cellType);
                 auto mode = memory.getMode();
                 if (AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::MemoryModeStrings).textWidth(rightColumnWidth), mode)) {
                     memory._mode = createMemoryModeGenomeDesc(mode);
@@ -657,7 +661,7 @@ void _NodeEditorWidget::processNodeAttributes()
             } else if (nodeType == CellType_Communicator) {
 
                 // Mode selection
-                auto& communicator = std::get<CommunicatorGenomeDesc>(node._cellType);
+                auto& communicator = std::get<CommunicatorGenomeDesc>(cellTypeNode._cellType);
                 auto mode = communicator.getMode();
                 if (AlienGui::Combo(AlienGui::ComboParameters().name("Mode").values(Const::CommunicatorModeStrings).textWidth(rightColumnWidth), mode)) {
                     communicator._mode = createCommunicatorModeGenomeDesc(mode);

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -306,6 +306,7 @@ namespace
     auto constexpr Id_Gene_Shape = 1;
     auto constexpr Id_Gene_Stiffness = 5;
     auto constexpr Id_Gene_ConnectionDistance = 6;
+    auto constexpr Id_Gene_HomogeneCellType = 7;
 
     auto constexpr Id_Node_ReferenceAngle = 0;
     auto constexpr Id_Node_Color = 1;
@@ -859,6 +860,7 @@ namespace cereal
         scope.addMember(Id_Gene_Shape, data._shape, defaultObject._shape);
         scope.addMember(Id_Gene_Stiffness, data._stiffness, defaultObject._stiffness);
         scope.addMember(Id_Gene_ConnectionDistance, data._connectionDistance, defaultObject._connectionDistance);
+        scope.addMember(Id_Gene_HomogeneCellType, data._homogeneCellType, defaultObject._homogeneCellType);
         scope.addDesc(Id_Gene_Nodes, data._nodes);
     }
     SPLIT_SERIALIZATION(GeneDesc)


### PR DESCRIPTION
## Summary
- Add a new gene-level flag `homogeneCellType` (bool, default `false`) to `GeneDesc`/`GeneTO` and the GPU-side `Gene` struct.
- When enabled, every cell constructed from the gene inherits the cell type and all subordinate properties (mode + type-specific properties) from the gene's **first node**. Color, reference angle, neural network and constructor stay per-node.
- Construction logic lives in `ConstructorProcessor`: it selects the cell-type source node (first node when `homogeneCellType`, otherwise the current node) and passes it to `EntityFactory::createCellFromNode`. Needed depot energy is derived from the cell-type node as well.
- `NodeEditorWidget`: the cell type and the type-specific properties section now always show/edit the first node's cell type when the flag is set.
- `GeneEditorWidget`: added a "Homogeneous cell type" checkbox in the gene base properties.
- Adapted all data transfer paths: `DescConverterService` (both directions), `DataAccessKernels`, `EntityFactory` (TO->Gene), `SerializerService` (new serialization id), `GenomeDescHash`. Extended `DescTestDataFactory` non-default genome to set the flag so the round-trip is covered by `DataTransferTests`.

## Original task
Es soll ein neues Flag am Gene eingeführt werden: `homogeneCellType` (bool, default = false). Wenn gesetzt, dann
- soll, wenn ein Node in diesem Gene gebaut wird, immer den Zelltyp und alle untergeordneten Eigenschaften (Properties, Mode) vom ersten Node des Genes bekommen. Die Logik müsste im ConstructionProcessor sein.
- soll im NodeEditorWidget bei cell type immer die Eigenschaften vom ersten Node angezeigt werden.
Erweitere GeneTO und GeneDesc entsprechend. Adapt data transfer: DescConverterService, SerializerService, EntityFactory, DataAccessKernels, DescTestDataFactory, ...

## Build and tests
- `cmake --build build --config Release -j32` (clean rebuild): passed
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (2997 passed, 3 pre-existing skips, 0 failures)
- `./cli --help`: passed

## Notes
- A clean rebuild was required: the existing `build/` directory contained stale object files after a `SimulationParameters` struct change on `develop`, causing an nvlink `cudaSimulationParameters` size mismatch unrelated to this change.
- The flag only homogenizes the cell type and its mode/properties. Per-node attributes (color, reference angle, neural network, constructor) are intentionally left untouched.
- With `homogeneCellType` enabled, the type combo in the node editor disallows `Void` since the shared type comes from the first node, which cannot be void.

🤖 Generated with [Claude Code](https://claude.com/claude-code)