### PR TITLE
Add CellTypeMutation mutation type

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -881,6 +881,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._probability = genomeTO.mutationRates.cellTypePropertiesMutations[i].probability;
     }
     result._mutationRates._cellTypeModeMutation._eventProbability = genomeTO.mutationRates.cellTypeModeMutation.eventProbability;
+    result._mutationRates._cellTypeMutation._eventProbability = genomeTO.mutationRates.cellTypeMutation.eventProbability;
     result._genes.reserve(genomeTO.numGenes);
 
     CHECK(genomeTO.geneArrayIndex + genomeTO.numGenes <= *to.numGenes);
@@ -970,6 +971,7 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._probability};
     }
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._eventProbability};
+    genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._eventProbability};
     genomeTO.numGenes = toInt(genome._genes.size());
     genomeTO.geneArrayIndex = geneArrayStartIndex;
     genomeTO.genomeIndexOnGpu = VALUE_NOT_SET_UINT64;

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -345,6 +345,10 @@ namespace Channels
 {
     auto constexpr InjectorSuccess = 1;
 }
+namespace Const
+{
+    auto constexpr InjectorGeneIndex_Default = 0;
+}
 
 using InjectorMode = int;
 enum InjectorMode_
@@ -356,7 +360,6 @@ enum InjectorMode_
 
 namespace Const
 {
-    auto constexpr InjectorGeneIndex_Default = 0;
     std::vector<std::string> const InjectorModeStrings = {"Only empty cells", "All cells"};
 }
 

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -172,7 +172,11 @@ namespace Const
 {
     auto constexpr GeneratorValue_Min = -2.0f;
     auto constexpr GeneratorValue_Max = 2.0f;
+    auto constexpr GeneratorMinValue_Default = -1.0f;
+    auto constexpr GeneratorMaxValue_Default = 1.0f;
+    auto constexpr GeneratorAdditive_Default = false;
     auto constexpr GeneratorTimeOffset_Min = 0;
+    auto constexpr GeneratorTimeOffset_Default = 0;
     auto constexpr GeneratorPeriod_Min = 1;
     auto constexpr GeneratorPeriod_Default = 100;
 }
@@ -197,7 +201,9 @@ namespace Const
 {
     auto constexpr DepotStorageLimit_Min = 0.0f;
     auto constexpr DepotStorageLimit_Max = 1000.0f;
+    auto constexpr DepotStorageLimit_Default = 200.0f;
     auto constexpr DepotInitialStoredUsableEnergy_Min = 0.0f;
+    auto constexpr DepotInitialStoredUsableEnergy_Default = 0.0f;
 }
 
 //********************
@@ -218,6 +224,10 @@ namespace Const
 {
     auto constexpr SensorRange_Min = 0;
     auto constexpr SensorRange_Max = 512;
+    auto constexpr SensorMinRange_Default = 0;
+    auto constexpr SensorMaxRange_Default = 255;
+    auto constexpr SensorAutoTrigger_Default = true;
+    auto constexpr SensorTagForAttackers_Default = true;
     auto constexpr DetectEnergyMinDensity_Min = 0.0f;
     auto constexpr DetectEnergyMinDensity_Max = 1.0f;
     auto constexpr DetectEnergyMinDensity_Default = 0.05f;
@@ -346,6 +356,7 @@ enum InjectorMode_
 
 namespace Const
 {
+    auto constexpr InjectorGeneIndex_Default = 0;
     std::vector<std::string> const InjectorModeStrings = {"Only empty cells", "All cells"};
 }
 
@@ -355,6 +366,7 @@ namespace Const
 namespace Const
 {
     auto constexpr DetonatorCountdown_Min = 1;
+    auto constexpr DetonatorCountdown_Default = 10;
 }
 
 using DetonatorState = int;
@@ -398,6 +410,7 @@ namespace Const
 {
     auto constexpr DigestorRawEnergyConductivity_Min = 0.0f;
     auto constexpr DigestorRawEnergyConductivity_Max = 1.0f;
+    auto constexpr DigestorRawEnergyConductivity_Default = 0.5f;
     auto constexpr MemoryChannelBitMask_Min = uint16_t{0};
     auto constexpr MemoryChannelBitMask_Max = uint16_t{0xffff};
     auto constexpr MemoryNumSignalEntries_Min = 0;

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -47,8 +47,8 @@ struct DepotDesc
 {
     auto operator<=>(DepotDesc const&) const = default;
 
-    MEMBER(DepotDesc, float, storageLimit, 200.0f);
-    MEMBER(DepotDesc, float, storedUsableEnergy, 0.0f);
+    MEMBER(DepotDesc, float, storageLimit, Const::DepotStorageLimit_Default);
+    MEMBER(DepotDesc, float, storedUsableEnergy, Const::DepotInitialStoredUsableEnergy_Default);
 };
 
 struct ConstructorDesc
@@ -124,11 +124,11 @@ struct SensorDesc
 {
     auto operator<=>(SensorDesc const&) const = default;
 
-    MEMBER(SensorDesc, bool, autoTrigger, true);
-    MEMBER(SensorDesc, bool, tagForAttackers, true);
+    MEMBER(SensorDesc, bool, autoTrigger, Const::SensorAutoTrigger_Default);
+    MEMBER(SensorDesc, bool, tagForAttackers, Const::SensorTagForAttackers_Default);
     MEMBER(SensorDesc, SensorModeDesc, mode, DetectCreatureDesc());
-    MEMBER(SensorDesc, int, minRange, 0);
-    MEMBER(SensorDesc, int, maxRange, 255);
+    MEMBER(SensorDesc, int, minRange, Const::SensorMinRange_Default);
+    MEMBER(SensorDesc, int, maxRange, Const::SensorMaxRange_Default);
 
     // Process data
     MEMBER(SensorDesc, std::optional<SensorLastMatchDesc>, lastMatch, std::nullopt);
@@ -155,10 +155,10 @@ struct GeneratorDesc
     auto operator<=>(GeneratorDesc const&) const = default;
 
     // Fixed data
-    MEMBER(GeneratorDesc, bool, additive, false);
-    MEMBER(GeneratorDesc, float, minValue, -1.0f);
-    MEMBER(GeneratorDesc, float, maxValue, 1.0f);
-    MEMBER(GeneratorDesc, int, timeOffset, 0);
+    MEMBER(GeneratorDesc, bool, additive, Const::GeneratorAdditive_Default);
+    MEMBER(GeneratorDesc, float, minValue, Const::GeneratorMinValue_Default);
+    MEMBER(GeneratorDesc, float, maxValue, Const::GeneratorMaxValue_Default);
+    MEMBER(GeneratorDesc, int, timeOffset, Const::GeneratorTimeOffset_Default);
     MEMBER(GeneratorDesc, GeneratorModeDesc, mode, SquareSignalDesc());
 
     // Process data
@@ -195,7 +195,7 @@ struct InjectorDesc
     InjectorDesc();
     auto operator<=>(InjectorDesc const&) const = default;
 
-    MEMBER(InjectorDesc, int, geneIndex, 0);
+    MEMBER(InjectorDesc, int, geneIndex, Const::InjectorGeneIndex_Default);
 };
 
 struct AutoBendingDesc
@@ -336,7 +336,7 @@ struct DigestorDesc
 {
     auto operator<=>(DigestorDesc const&) const = default;
 
-    MEMBER(DigestorDesc, float, rawEnergyConductivity, 0.5f);  // Between 0 and 1
+    MEMBER(DigestorDesc, float, rawEnergyConductivity, Const::DigestorRawEnergyConductivity_Default);  // Between 0 and 1
 
     float getRawEnergyConversionRate() const { return 1 - _rawEnergyConductivity; }
     DigestorDesc& setRawEnergyConversionRate(float value)

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -39,6 +39,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
     }
     genome._mutationRates._cellTypeModeMutation._eventProbability =
         std::clamp(genome._mutationRates._cellTypeModeMutation._eventProbability, 0.0f, 1.0f);
+    genome._mutationRates._cellTypeMutation._eventProbability =
+        std::clamp(genome._mutationRates._cellTypeMutation._eventProbability, 0.0f, 1.0f);
 
     // Validate each gene
     for (auto& gene : genome._genes) {

--- a/source/EngineInterface/GenomeDesc.cpp
+++ b/source/EngineInterface/GenomeDesc.cpp
@@ -65,6 +65,9 @@ std::vector<std::string> MutationRatesDesc::getActiveMutationTypes() const
     if (_cellTypeModeMutation._eventProbability > 0.0f) {
         activeMutations.push_back("Cell type mode mutations");
     }
+    if (_cellTypeMutation._eventProbability > 0.0f) {
+        activeMutations.push_back("Cell type mutations");
+    }
     return activeMutations;
 }
 

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -42,8 +42,8 @@ struct DepotGenomeDesc
 {
     auto operator<=>(DepotGenomeDesc const&) const = default;
 
-    MEMBER(DepotGenomeDesc, float, storageLimit, 200.0f);
-    MEMBER(DepotGenomeDesc, float, initialStoredUsableEnergy, 0.0f);
+    MEMBER(DepotGenomeDesc, float, storageLimit, Const::DepotStorageLimit_Default);
+    MEMBER(DepotGenomeDesc, float, initialStoredUsableEnergy, Const::DepotInitialStoredUsableEnergy_Default);
 };
 
 struct ConstructorGenomeDesc
@@ -103,11 +103,11 @@ struct SensorGenomeDesc
 {
     auto operator<=>(SensorGenomeDesc const&) const = default;
 
-    MEMBER(SensorGenomeDesc, bool, autoTrigger, true);
-    MEMBER(SensorGenomeDesc, bool, tagForAttackers, true);
+    MEMBER(SensorGenomeDesc, bool, autoTrigger, Const::SensorAutoTrigger_Default);
+    MEMBER(SensorGenomeDesc, bool, tagForAttackers, Const::SensorTagForAttackers_Default);
     MEMBER(SensorGenomeDesc, SensorModeGenomeDesc, mode, DetectCreatureGenomeDesc());
-    MEMBER(SensorGenomeDesc, int, minRange, 0);
-    MEMBER(SensorGenomeDesc, int, maxRange, 255);
+    MEMBER(SensorGenomeDesc, int, minRange, Const::SensorMinRange_Default);
+    MEMBER(SensorGenomeDesc, int, maxRange, Const::SensorMaxRange_Default);
 
     SensorMode getMode() const;
 };
@@ -130,10 +130,10 @@ struct GeneratorGenomeDesc
 {
     auto operator<=>(GeneratorGenomeDesc const&) const = default;
 
-    MEMBER(GeneratorGenomeDesc, bool, additive, false);
-    MEMBER(GeneratorGenomeDesc, float, minValue, -1.0f);
-    MEMBER(GeneratorGenomeDesc, float, maxValue, 1.0f);
-    MEMBER(GeneratorGenomeDesc, int, timeOffset, 0);
+    MEMBER(GeneratorGenomeDesc, bool, additive, Const::GeneratorAdditive_Default);
+    MEMBER(GeneratorGenomeDesc, float, minValue, Const::GeneratorMinValue_Default);
+    MEMBER(GeneratorGenomeDesc, float, maxValue, Const::GeneratorMaxValue_Default);
+    MEMBER(GeneratorGenomeDesc, int, timeOffset, Const::GeneratorTimeOffset_Default);
     MEMBER(GeneratorGenomeDesc, GeneratorModeGenomeDesc, mode, SquareSignalGenomeDesc());
 
     GeneratorMode getMode() const;
@@ -166,7 +166,7 @@ struct InjectorGenomeDesc
 {
     auto operator<=>(InjectorGenomeDesc const&) const = default;
 
-    MEMBER(InjectorGenomeDesc, int, geneIndex, 0);
+    MEMBER(InjectorGenomeDesc, int, geneIndex, Const::InjectorGeneIndex_Default);
 };
 
 
@@ -271,14 +271,14 @@ struct DetonatorGenomeDesc
 {
     auto operator<=>(DetonatorGenomeDesc const&) const = default;
 
-    MEMBER(DetonatorGenomeDesc, int, countdown, 10);
+    MEMBER(DetonatorGenomeDesc, int, countdown, Const::DetonatorCountdown_Default);
 };
 
 struct DigestorGenomeDesc
 {
     auto operator<=>(DigestorGenomeDesc const&) const = default;
 
-    MEMBER(DigestorGenomeDesc, float, rawEnergyConductivity, 0.5f);  // Between 0 and 1
+    MEMBER(DigestorGenomeDesc, float, rawEnergyConductivity, Const::DigestorRawEnergyConductivity_Default);  // Between 0 and 1
 
     float getRawEnergyConversionRate() const { return 1 - _rawEnergyConductivity; }
     DigestorGenomeDesc& setRawEnergyConversionRate(float value)

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -446,6 +446,13 @@ struct CellTypeModeMutationDesc
     MEMBER(CellTypeModeMutationDesc, float, eventProbability, 0.0f);
 };
 
+struct CellTypeMutationDesc
+{
+    auto operator<=>(CellTypeMutationDesc const&) const = default;
+
+    MEMBER(CellTypeMutationDesc, float, eventProbability, 0.0f);
+};
+
 struct MutationRatesDesc
 {
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
@@ -458,6 +465,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, ConnectionMutationArray, connectionMutations, ConnectionMutationArray());
     MEMBER(MutationRatesDesc, CellTypePropertiesMutationArray, cellTypePropertiesMutations, CellTypePropertiesMutationArray());
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
+    MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
 
     std::vector<std::string> getActiveMutationTypes() const;
 };

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -554,6 +554,7 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._probability);
         }
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._eventProbability);
+        hash_combine(seed, desc._mutationRates._cellTypeMutation._eventProbability);
         return seed;
     }
 };

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -471,6 +471,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::metaMutationCellTypeModeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Cell type mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationCellTypeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("New lineage threshold")
                         .reference(
                             FloatSpec().member(&SimulationParameters::newLineageThreshold).min(0.0f).max(10000.0f).infinity(true).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -110,6 +110,7 @@ struct SimulationParameters
     BaseParameter<float> metaMutationConnectionsSigma = {0};
     BaseParameter<float> metaMutationCellTypePropertiesSigma = {0};
     BaseParameter<float> metaMutationCellTypeModeSigma = {0};
+    BaseParameter<float> metaMutationCellTypeSigma = {0};
     BaseParameter<float> newLineageThreshold = {Infinity<float>::value};
 
     // Cell type: Attacker

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -49,6 +49,7 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].probability};
             }
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.eventProbability};
+            genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.eventProbability};
             genomeTO.numGenes = genome->numGenes;
             for (int i = 0; i < sizeof(genomeTO.name); ++i) {
                 genomeTO.name[i] = genome->name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -104,6 +104,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].probability};
     }
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.eventProbability};
+    genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.eventProbability};
     genome->numGenes = genomeTO.numGenes;
     for (int i = 0; i < sizeof(genomeTO.name); ++i) {
         genome->name[i] = genomeTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -366,12 +366,18 @@ struct CellTypeModeMutation
     float eventProbability;
 };
 
+struct CellTypeMutation
+{
+    float eventProbability;
+};
+
 struct MutationRates
 {
     NeuronMutation neuronMutations[2];
     ConnectionMutation connectionMutations[2];
     CellTypePropertiesMutation cellTypePropertiesMutations[2];
     CellTypeModeMutation cellTypeModeMutation;
+    CellTypeMutation cellTypeMutation;
 };
 
 struct Genome

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -371,12 +371,18 @@ struct CellTypeModeMutationTO
     float eventProbability;
 };
 
+struct CellTypeMutationTO
+{
+    float eventProbability;
+};
+
 struct MutationRatesTO
 {
     NeuronMutationTO neuronMutations[2];
     ConnectionMutationTO connectionMutations[2];
     CellTypePropertiesMutationTO cellTypePropertiesMutations[2];
     CellTypeModeMutationTO cellTypeModeMutation;
+    CellTypeMutationTO cellTypeMutation;
 };
 
 struct GenomeTO

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -26,6 +26,7 @@ private:
     __inline__ __device__ static void applyMutations_connections(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeProperties(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
 
     __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -105,6 +106,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_connections(data, genome, accumulatedMutations);
     applyMutations_cellTypeProperties(data, genome, accumulatedMutations);
     applyMutations_cellTypeMode(data, genome, accumulatedMutations);
+    applyMutations_cellType(data, genome, accumulatedMutations);
 
     block.sync();
     updateAccumulatedMutationsAndLineageId(data, genome, accumulatedMutations);
@@ -680,6 +682,112 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
     }
 }
 
+__inline__ __device__ void MutationProcessor::applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.cellTypeMutation;
+
+    if (rate.eventProbability <= 0) {
+        return;
+    }
+
+    // Picks a random cell type different from the current one (uniform over the remaining types).
+    auto pickNewCellType = [&](int currentCellType) {
+        auto newCellType = data.primaryNumberGen.random(CellType_Count - 2);
+        if (newCellType >= currentCellType) {
+            ++newCellType;
+        }
+        return newCellType;
+    };
+
+    for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
+        auto& gene = genome->genes[geneIndex];
+        for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
+            if (data.primaryNumberGen.random() >= rate.eventProbability) {
+                continue;
+            }
+            auto& node = gene.nodes[nodeIndex];
+
+            node.cellType = pickNewCellType(node.cellType);
+
+            // The new cell type is initialized with the shared default attribute values (see the *_Default constants in CellTypeConstants.h
+            // and the host-side defaults in GenomeDesc.h). Using defaults keeps the mutated genome valid and corrected by construction.
+            auto& cellTypeData = node.cellTypeData;
+            switch (node.cellType) {
+            case CellType_Base:
+                cellTypeData.base = {};
+                break;
+            case CellType_Depot:
+                cellTypeData.depot = {200.0f, 0.0f};
+                break;
+            case CellType_Sensor: {
+                auto& sensor = cellTypeData.sensor;
+                sensor.autoTrigger = true;
+                sensor.tagForAttackers = true;
+                sensor.mode = SensorMode_DetectCreature;
+                sensor.modeData.detectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
+                sensor.minRange = 0;
+                sensor.maxRange = 255;
+            } break;
+            case CellType_Generator: {
+                auto& generator = cellTypeData.generator;
+                generator.additive = false;
+                generator.minValue = -1.0f;
+                generator.maxValue = 1.0f;
+                generator.timeOffset = 0;
+                generator.mode = GeneratorMode_SquareSignal;
+                generator.modeData.squareSignal = {Const::GeneratorPeriod_Default};
+            } break;
+            case CellType_Attacker: {
+                auto& attacker = cellTypeData.attacker;
+                attacker.mode = AttackerMode_Creature;
+                attacker.modeData.attackCreature = {};
+            } break;
+            case CellType_Injector:
+                cellTypeData.injector = {0};
+                break;
+            case CellType_Muscle: {
+                auto& muscle = cellTypeData.muscle;
+                muscle.mode = MuscleMode_AutoBending;
+                muscle.modeData.autoBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
+            } break;
+            case CellType_Defender:
+                cellTypeData.defender = {DefenderMode_DefendAgainstAttacker};
+                break;
+            case CellType_Reconnector: {
+                auto& reconnector = cellTypeData.reconnector;
+                reconnector.mode = ReconnectorMode_Creature;
+                reconnector.modeData.reconnectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
+            } break;
+            case CellType_Detonator:
+                cellTypeData.detonator = {10};
+                break;
+            case CellType_Digestor:
+                cellTypeData.digestor = {0.5f};
+                break;
+            case CellType_Memory: {
+                auto& memory = cellTypeData.memory;
+                memory.mode = MemoryMode_SignalDelay;
+                memory.modeData.signalDelay = {Const::SignalDelay_Default};
+                memory.numSignalEntries = 0;
+                memory.channelBitMask = Const::MemoryChannelBitMask_Max;
+                memory.signalEntries = nullptr;
+            } break;
+            case CellType_Communicator: {
+                auto& communicator = cellTypeData.communicator;
+                communicator.mode = CommunicatorMode_Sender;
+                communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorMaxTimesSent_Default};
+            } break;
+            case CellType_Void:
+                cellTypeData.voidCell = {};
+                break;
+            }
+
+            atomicAdd_block(&accumulatedMutations, 1.0f);
+        }
+    }
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData& data, Genome* genome)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
@@ -721,6 +829,12 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (cellTypeModeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeModeSigma)); };
             mutateFloat(genome->mutationRates.cellTypeModeMutation.eventProbability);
+        }
+
+        float cellTypeMutationSigma = cudaSimulationParameters.metaMutationCellTypeSigma.value;
+        if (cellTypeMutationSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeMutationSigma)); };
+            mutateFloat(genome->mutationRates.cellTypeMutation.eventProbability);
         }
     }
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -650,7 +650,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
         return;
     }
 
-    // Picks a random mode index different from the current one (uniform over the remaining modes).
     auto pickNewMode = [&](int currentMode, int count) {
         auto newMode = data.primaryNumberGen.random(count - 2);
         if (newMode >= currentMode) {
@@ -717,7 +716,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         return;
     }
 
-    // Picks a random cell type different from the current one (uniform over the remaining types).
     auto pickNewCellType = [&](int currentCellType) {
         auto newCellType = data.primaryNumberGen.random(CellType_Count - 2);
         if (newCellType >= currentCellType) {
@@ -736,9 +734,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
 
             node.cellType = pickNewCellType(node.cellType);
 
-            // Set the new cell type's non-mode attributes to their host-side defaults (see GenomeDesc.h) and select the default mode.
-            // The selected mode's data is then filled in by resetCellTypeModeToDefault(), shared with applyMutations_cellTypeMode().
-            // Using defaults keeps the mutated genome valid and corrected by construction.
             auto& cellTypeData = node.cellTypeData;
             switch (node.cellType) {
             case CellType_Base:

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -745,29 +745,29 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
                 cellTypeData.base = {};
                 break;
             case CellType_Depot:
-                cellTypeData.depot = {200.0f, 0.0f};
+                cellTypeData.depot = {Const::DepotStorageLimit_Default, Const::DepotInitialStoredUsableEnergy_Default};
                 break;
             case CellType_Sensor: {
                 auto& sensor = cellTypeData.sensor;
-                sensor.autoTrigger = true;
-                sensor.tagForAttackers = true;
+                sensor.autoTrigger = Const::SensorAutoTrigger_Default;
+                sensor.tagForAttackers = Const::SensorTagForAttackers_Default;
                 sensor.mode = SensorMode_DetectCreature;
-                sensor.minRange = 0;
-                sensor.maxRange = 255;
+                sensor.minRange = Const::SensorMinRange_Default;
+                sensor.maxRange = Const::SensorMaxRange_Default;
             } break;
             case CellType_Generator: {
                 auto& generator = cellTypeData.generator;
-                generator.additive = false;
-                generator.minValue = -1.0f;
-                generator.maxValue = 1.0f;
-                generator.timeOffset = 0;
+                generator.additive = Const::GeneratorAdditive_Default;
+                generator.minValue = Const::GeneratorMinValue_Default;
+                generator.maxValue = Const::GeneratorMaxValue_Default;
+                generator.timeOffset = Const::GeneratorTimeOffset_Default;
                 generator.mode = GeneratorMode_SquareSignal;
             } break;
             case CellType_Attacker:
                 cellTypeData.attacker.mode = AttackerMode_Creature;
                 break;
             case CellType_Injector:
-                cellTypeData.injector = {0};
+                cellTypeData.injector = {Const::InjectorGeneIndex_Default};
                 break;
             case CellType_Muscle:
                 cellTypeData.muscle.mode = MuscleMode_AutoBending;
@@ -779,10 +779,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
                 cellTypeData.reconnector.mode = ReconnectorMode_Creature;
                 break;
             case CellType_Detonator:
-                cellTypeData.detonator = {10};
+                cellTypeData.detonator = {Const::DetonatorCountdown_Default};
                 break;
             case CellType_Digestor:
-                cellTypeData.digestor = {0.5f};
+                cellTypeData.digestor = {Const::DigestorRawEnergyConductivity_Default};
                 break;
             case CellType_Memory: {
                 auto& memory = cellTypeData.memory;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -28,6 +28,7 @@ private:
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
+    __inline__ __device__ static void resetCellTypeModeToDefault(Node& node);
 
     __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static float generateGaussian(SimulationData& data);
@@ -522,6 +523,124 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
     }
 }
 
+__inline__ __device__ void MutationProcessor::resetCellTypeModeToDefault(Node& node)
+{
+    // Initializes the data of the currently selected mode with the shared default attribute values
+    // (see the *_Default constants in CellTypeConstants.h and the host-side defaults in GenomeDesc.h).
+    switch (node.cellType) {
+    case CellType_Sensor: {
+        auto& sensor = node.cellTypeData.sensor;
+        switch (sensor.mode) {
+        case SensorMode_Telemetry:
+            sensor.modeData.telemetry = {};
+            break;
+        case SensorMode_DetectEnergy:
+            sensor.modeData.detectEnergy = {Const::DetectEnergyMinDensity_Default};
+            break;
+        case SensorMode_DetectSolid:
+            sensor.modeData.detectSolid = {};
+            break;
+        case SensorMode_DetectFreeCell:
+            sensor.modeData.detectFreeCell = {Const::DetectFreeCellMinDensity_Default, Const::RestrictToColors_Default};
+            break;
+        case SensorMode_DetectCreature:
+            sensor.modeData.detectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
+            break;
+        }
+    } break;
+    case CellType_Generator: {
+        auto& generator = node.cellTypeData.generator;
+        switch (generator.mode) {
+        case GeneratorMode_SquareSignal:
+            generator.modeData.squareSignal = {Const::GeneratorPeriod_Default};
+            break;
+        case GeneratorMode_SawtoothSignal:
+            generator.modeData.sawtoothSignal = {Const::GeneratorPeriod_Default};
+            break;
+        }
+    } break;
+    case CellType_Attacker: {
+        auto& attacker = node.cellTypeData.attacker;
+        switch (attacker.mode) {
+        case AttackerMode_FreeCell:
+            attacker.modeData.attackFreeCell = {Const::RestrictToColors_Default};
+            break;
+        case AttackerMode_Creature:
+            attacker.modeData.attackCreature = {};
+            break;
+        }
+    } break;
+    case CellType_Muscle: {
+        auto& muscle = node.cellTypeData.muscle;
+        switch (muscle.mode) {
+        case MuscleMode_AutoBending:
+            muscle.modeData.autoBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
+            break;
+        case MuscleMode_ManualBending:
+            muscle.modeData.manualBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
+            break;
+        case MuscleMode_AngleBending:
+            muscle.modeData.angleBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleAttractionRepulsionRatio_Default};
+            break;
+        case MuscleMode_AutoCrawling:
+            muscle.modeData.autoCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
+            break;
+        case MuscleMode_ManualCrawling:
+            muscle.modeData.manualCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
+            break;
+        case MuscleMode_DirectMovement:
+            muscle.modeData.directMovement = {};
+            break;
+        }
+    } break;
+    case CellType_Reconnector: {
+        auto& reconnector = node.cellTypeData.reconnector;
+        switch (reconnector.mode) {
+        case ReconnectorMode_Solid:
+            reconnector.modeData.reconnectSolid = {};
+            break;
+        case ReconnectorMode_FreeCell:
+            reconnector.modeData.reconnectFreeCell = {Const::RestrictToColors_Default};
+            break;
+        case ReconnectorMode_Creature:
+            reconnector.modeData.reconnectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
+            break;
+        }
+    } break;
+    case CellType_Memory: {
+        auto& memory = node.cellTypeData.memory;
+        switch (memory.mode) {
+        case MemoryMode_SignalDelay:
+            memory.modeData.signalDelay = {Const::SignalDelay_Default};
+            break;
+        case MemoryMode_SignalRecorder:
+            memory.modeData.signalRecorder = {true, 0};
+            break;
+        case MemoryMode_SignalStorage:
+            memory.modeData.signalStorage = {true};
+            break;
+        case MemoryMode_SignalIntegrator:
+            memory.modeData.signalIntegrator = {Const::SignalIntegratorNewSignalWeight_Default};
+            break;
+        }
+    } break;
+    case CellType_Communicator: {
+        auto& communicator = node.cellTypeData.communicator;
+        switch (communicator.mode) {
+        case CommunicatorMode_Sender:
+            communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorMaxTimesSent_Default};
+            break;
+        case CommunicatorMode_Receiver:
+            communicator.modeData.receiver = {Const::RestrictToColors_Default, LineageRestriction_No};
+            break;
+        }
+    } break;
+    default:
+        // Cell types without mode-specific data (or without a mode) need no reset.
+        break;
+    }
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
@@ -548,127 +667,33 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
             }
             auto& node = gene.nodes[nodeIndex];
 
-            // The new mode is initialized with the shared default attribute values (see the *_Default constants in CellTypeConstants.h),
-            // matching the host-side genome and runtime descriptions.
+            // Pick a new mode for the node's cell type; the new mode's data is then reset to its defaults below.
             bool changed = true;
             switch (node.cellType) {
-            case CellType_Sensor: {
-                auto& sensor = node.cellTypeData.sensor;
-                sensor.mode = static_cast<SensorMode>(pickNewMode(sensor.mode, SensorMode_Count));
-                switch (sensor.mode) {
-                case SensorMode_Telemetry:
-                    sensor.modeData.telemetry = {};
-                    break;
-                case SensorMode_DetectEnergy:
-                    sensor.modeData.detectEnergy = {Const::DetectEnergyMinDensity_Default};
-                    break;
-                case SensorMode_DetectSolid:
-                    sensor.modeData.detectSolid = {};
-                    break;
-                case SensorMode_DetectFreeCell:
-                    sensor.modeData.detectFreeCell = {Const::DetectFreeCellMinDensity_Default, Const::RestrictToColors_Default};
-                    break;
-                case SensorMode_DetectCreature:
-                    sensor.modeData.detectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
-                    break;
-                }
-            } break;
-            case CellType_Generator: {
-                auto& generator = node.cellTypeData.generator;
-                generator.mode = static_cast<GeneratorMode>(pickNewMode(generator.mode, GeneratorMode_Count));
-                switch (generator.mode) {
-                case GeneratorMode_SquareSignal:
-                    generator.modeData.squareSignal = {Const::GeneratorPeriod_Default};
-                    break;
-                case GeneratorMode_SawtoothSignal:
-                    generator.modeData.sawtoothSignal = {Const::GeneratorPeriod_Default};
-                    break;
-                }
-            } break;
-            case CellType_Attacker: {
-                auto& attacker = node.cellTypeData.attacker;
-                attacker.mode = static_cast<AttackerMode>(pickNewMode(attacker.mode, AttackerMode_Count));
-                switch (attacker.mode) {
-                case AttackerMode_FreeCell:
-                    attacker.modeData.attackFreeCell = {Const::RestrictToColors_Default};
-                    break;
-                case AttackerMode_Creature:
-                    attacker.modeData.attackCreature = {};
-                    break;
-                }
-            } break;
-            case CellType_Muscle: {
-                auto& muscle = node.cellTypeData.muscle;
-                muscle.mode = static_cast<MuscleMode>(pickNewMode(muscle.mode, MuscleMode_Count));
-                switch (muscle.mode) {
-                case MuscleMode_AutoBending:
-                    muscle.modeData.autoBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
-                    break;
-                case MuscleMode_ManualBending:
-                    muscle.modeData.manualBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
-                    break;
-                case MuscleMode_AngleBending:
-                    muscle.modeData.angleBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleAttractionRepulsionRatio_Default};
-                    break;
-                case MuscleMode_AutoCrawling:
-                    muscle.modeData.autoCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
-                    break;
-                case MuscleMode_ManualCrawling:
-                    muscle.modeData.manualCrawling = {Const::MuscleMaxDistanceDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
-                    break;
-                case MuscleMode_DirectMovement:
-                    muscle.modeData.directMovement = {};
-                    break;
-                }
-            } break;
+            case CellType_Sensor:
+                node.cellTypeData.sensor.mode = static_cast<SensorMode>(pickNewMode(node.cellTypeData.sensor.mode, SensorMode_Count));
+                break;
+            case CellType_Generator:
+                node.cellTypeData.generator.mode = static_cast<GeneratorMode>(pickNewMode(node.cellTypeData.generator.mode, GeneratorMode_Count));
+                break;
+            case CellType_Attacker:
+                node.cellTypeData.attacker.mode = static_cast<AttackerMode>(pickNewMode(node.cellTypeData.attacker.mode, AttackerMode_Count));
+                break;
+            case CellType_Muscle:
+                node.cellTypeData.muscle.mode = static_cast<MuscleMode>(pickNewMode(node.cellTypeData.muscle.mode, MuscleMode_Count));
+                break;
             case CellType_Defender:
                 node.cellTypeData.defender.mode = static_cast<DefenderMode>(pickNewMode(node.cellTypeData.defender.mode, DefenderMode_Count));
                 break;
-            case CellType_Reconnector: {
-                auto& reconnector = node.cellTypeData.reconnector;
-                reconnector.mode = static_cast<ReconnectorMode>(pickNewMode(reconnector.mode, ReconnectorMode_Count));
-                switch (reconnector.mode) {
-                case ReconnectorMode_Solid:
-                    reconnector.modeData.reconnectSolid = {};
-                    break;
-                case ReconnectorMode_FreeCell:
-                    reconnector.modeData.reconnectFreeCell = {Const::RestrictToColors_Default};
-                    break;
-                case ReconnectorMode_Creature:
-                    reconnector.modeData.reconnectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
-                    break;
-                }
-            } break;
-            case CellType_Memory: {
-                auto& memory = node.cellTypeData.memory;
-                memory.mode = static_cast<MemoryMode>(pickNewMode(memory.mode, MemoryMode_Count));
-                switch (memory.mode) {
-                case MemoryMode_SignalDelay:
-                    memory.modeData.signalDelay = {Const::SignalDelay_Default};
-                    break;
-                case MemoryMode_SignalRecorder:
-                    memory.modeData.signalRecorder = {true, 0};
-                    break;
-                case MemoryMode_SignalStorage:
-                    memory.modeData.signalStorage = {true};
-                    break;
-                case MemoryMode_SignalIntegrator:
-                    memory.modeData.signalIntegrator = {Const::SignalIntegratorNewSignalWeight_Default};
-                    break;
-                }
-            } break;
-            case CellType_Communicator: {
-                auto& communicator = node.cellTypeData.communicator;
-                communicator.mode = static_cast<CommunicatorMode>(pickNewMode(communicator.mode, CommunicatorMode_Count));
-                switch (communicator.mode) {
-                case CommunicatorMode_Sender:
-                    communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorMaxTimesSent_Default};
-                    break;
-                case CommunicatorMode_Receiver:
-                    communicator.modeData.receiver = {Const::RestrictToColors_Default, LineageRestriction_No};
-                    break;
-                }
-            } break;
+            case CellType_Reconnector:
+                node.cellTypeData.reconnector.mode = static_cast<ReconnectorMode>(pickNewMode(node.cellTypeData.reconnector.mode, ReconnectorMode_Count));
+                break;
+            case CellType_Memory:
+                node.cellTypeData.memory.mode = static_cast<MemoryMode>(pickNewMode(node.cellTypeData.memory.mode, MemoryMode_Count));
+                break;
+            case CellType_Communicator:
+                node.cellTypeData.communicator.mode = static_cast<CommunicatorMode>(pickNewMode(node.cellTypeData.communicator.mode, CommunicatorMode_Count));
+                break;
             default:
                 // Cell types without a mode field are not affected.
                 changed = false;
@@ -676,6 +701,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
             }
 
             if (changed) {
+                resetCellTypeModeToDefault(node);
                 atomicAdd_block(&accumulatedMutations, 1.0f);
             }
         }
@@ -710,8 +736,9 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
 
             node.cellType = pickNewCellType(node.cellType);
 
-            // The new cell type is initialized with the shared default attribute values (see the *_Default constants in CellTypeConstants.h
-            // and the host-side defaults in GenomeDesc.h). Using defaults keeps the mutated genome valid and corrected by construction.
+            // Set the new cell type's non-mode attributes to their host-side defaults (see GenomeDesc.h) and select the default mode.
+            // The selected mode's data is then filled in by resetCellTypeModeToDefault(), shared with applyMutations_cellTypeMode().
+            // Using defaults keeps the mutated genome valid and corrected by construction.
             auto& cellTypeData = node.cellTypeData;
             switch (node.cellType) {
             case CellType_Base:
@@ -725,7 +752,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
                 sensor.autoTrigger = true;
                 sensor.tagForAttackers = true;
                 sensor.mode = SensorMode_DetectCreature;
-                sensor.modeData.detectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
                 sensor.minRange = 0;
                 sensor.maxRange = 255;
             } break;
@@ -736,29 +762,22 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
                 generator.maxValue = 1.0f;
                 generator.timeOffset = 0;
                 generator.mode = GeneratorMode_SquareSignal;
-                generator.modeData.squareSignal = {Const::GeneratorPeriod_Default};
             } break;
-            case CellType_Attacker: {
-                auto& attacker = cellTypeData.attacker;
-                attacker.mode = AttackerMode_Creature;
-                attacker.modeData.attackCreature = {};
-            } break;
+            case CellType_Attacker:
+                cellTypeData.attacker.mode = AttackerMode_Creature;
+                break;
             case CellType_Injector:
                 cellTypeData.injector = {0};
                 break;
-            case CellType_Muscle: {
-                auto& muscle = cellTypeData.muscle;
-                muscle.mode = MuscleMode_AutoBending;
-                muscle.modeData.autoBending = {Const::MuscleMaxAngleDeviation_Default, Const::MuscleForwardBackwardRatio_Default};
-            } break;
+            case CellType_Muscle:
+                cellTypeData.muscle.mode = MuscleMode_AutoBending;
+                break;
             case CellType_Defender:
                 cellTypeData.defender = {DefenderMode_DefendAgainstAttacker};
                 break;
-            case CellType_Reconnector: {
-                auto& reconnector = cellTypeData.reconnector;
-                reconnector.mode = ReconnectorMode_Creature;
-                reconnector.modeData.reconnectCreature = {0, 0, Const::RestrictToColors_Default, LineageRestriction_No};
-            } break;
+            case CellType_Reconnector:
+                cellTypeData.reconnector.mode = ReconnectorMode_Creature;
+                break;
             case CellType_Detonator:
                 cellTypeData.detonator = {10};
                 break;
@@ -768,21 +787,19 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
             case CellType_Memory: {
                 auto& memory = cellTypeData.memory;
                 memory.mode = MemoryMode_SignalDelay;
-                memory.modeData.signalDelay = {Const::SignalDelay_Default};
                 memory.numSignalEntries = 0;
                 memory.channelBitMask = Const::MemoryChannelBitMask_Max;
                 memory.signalEntries = nullptr;
             } break;
-            case CellType_Communicator: {
-                auto& communicator = cellTypeData.communicator;
-                communicator.mode = CommunicatorMode_Sender;
-                communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorMaxTimesSent_Default};
-            } break;
+            case CellType_Communicator:
+                cellTypeData.communicator.mode = CommunicatorMode_Sender;
+                break;
             case CellType_Void:
                 cellTypeData.voidCell = {};
                 break;
             }
 
+            resetCellTypeModeToDefault(node);
             atomicAdd_block(&accumulatedMutations, 1.0f);
         }
     }

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -181,7 +181,8 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().eventProbability(0.45f).sigma(0.55f).probability(0.65f),
                              CellTypePropertiesMutationDesc().eventProbability(0.75f).sigma(0.85f).probability(0.95f)})
-                        .cellTypeModeMutation(CellTypeModeMutationDesc().eventProbability(0.33f));
+                        .cellTypeModeMutation(CellTypeModeMutationDesc().eventProbability(0.33f))
+                        .cellTypeMutation(CellTypeMutationDesc().eventProbability(0.22f));
 
     auto genome = GenomeDesc()
                       .name("Test Genome")

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -14,7 +14,8 @@ enum class MutationType
     Neuron,
     Connection,
     CellTypeProperties,
-    CellTypeMode
+    CellTypeMode,
+    CellType
 };
 
 class AccumulatedMutationTests_AllTypes
@@ -26,7 +27,7 @@ class AccumulatedMutationTests_AllTypes
 INSTANTIATE_TEST_SUITE_P(
     AccumulatedMutationTests,
     AccumulatedMutationTests_AllTypes,
-    ::testing::Values(MutationType::Neuron, MutationType::Connection, MutationType::CellTypeProperties, MutationType::CellTypeMode));
+    ::testing::Values(MutationType::Neuron, MutationType::Connection, MutationType::CellTypeProperties, MutationType::CellTypeMode, MutationType::CellType));
 
 TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
 {
@@ -44,6 +45,9 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().eventProbability(1.0f);
+        break;
+    case MutationType::CellType:
+        genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
         break;
     }
 
@@ -72,6 +76,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.metaMutationConnectionsSigma.value = 1.0f;
     _parameters.metaMutationCellTypePropertiesSigma.value = 1.0f;
     _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
+    _parameters.metaMutationCellTypeSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -6,6 +6,7 @@ PUBLIC
     CellStateTransitionTests.cpp
     CellTypeModeMutationTests.cpp
     CellTypeMutationCoverageGuard.cpp
+    CellTypeMutationTests.cpp
     CellTypePropertiesMutationTests.cpp
     CommunicatorTests.cpp
     ConnectionMutationTests.cpp

--- a/source/EngineTests/CellTypeMutationCoverageGuard.cpp
+++ b/source/EngineTests/CellTypeMutationCoverageGuard.cpp
@@ -1,20 +1,14 @@
 // Compile-time guard for cell-type property mutation coverage.
 //
-// Each static_assert below pins the number of data members of
-// cell-type or mode description. The matching list of mutated attributes
-// lives in MutationProcessor::applyMutations_cellTypeProperties().
-//
-// When a field is added to or removed from one of these structs, the
-// corresponding assert fails to compile. Treat that failure as a checklist:
-// either extend the mutation switch for the new attribute and then bump the
-// count here - or, if the field is intentionally never mutated, just bump the
-// count. The point is to force a conscious decision so newly added cell-type
-// attributes are never silently left out of the mutation.
+// Each static_assert pins the field count of a cell-type or mode struct. When a
+// field is added or removed the matching assert fails to compile - treat it as a
+// checklist: either handle the new field in MutationProcessor.cuh (see the
+// function named in the message) or, if it is intentionally never mutated, just
+// bump the count. This forces a conscious decision so new attributes are never
+// silently left out of the mutation.
 //
 // The mode counts at the bottom pin the number of modes per cell type, so adding
-// a mode also trips the check (its new description struct still needs review).
-// Switching modes itself lives in MutationProcessor::applyMutations_cellTypeMode(),
-// which also needs a default-initialized branch for every new mode.
+// a mode trips the check too (its new description struct still needs review).
 
 
 #include <variant>
@@ -26,7 +20,7 @@
 #define ALIEN_MUTATION_FIELD_COUNT(Type, Count) \
     static_assert( \
         boost::pfr::tuple_size_v<Type> == (Count), \
-        #Type " field count changed - review applyMutations_cellTypeProperties() in MutationProcessor.cuh and update this count")
+        #Type " field count changed - review applyMutations_cellTypeProperties() and applyMutations_cellType() in MutationProcessor.cuh and update this count")
 
 #define ALIEN_MUTATION_MODE_COUNT(Type, Count) \
     static_assert( \

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -12,9 +12,6 @@
 class CellTypeMutationTests : public MutationTestsBase
 {
 protected:
-    // Resets the cell type (selected type and its data) to a canonical value while preserving all other node attributes.
-    static void resetCellType(CellTypeGenomeDesc& cellType) { cellType = BaseGenomeDesc{}; }
-
     bool compareAllExceptCellType(GenomeDesc expected, GenomeDesc actual)
     {
         auto reset = [](GenomeDesc& genome) {
@@ -23,7 +20,7 @@ protected:
             genome._accumulatedMutations = 0.0f;
             for (auto& gene : genome._genes) {
                 for (auto& node : gene._nodes) {
-                    resetCellType(node._cellType);
+                    node._cellType = BaseGenomeDesc{};  // canonicalize so everything except the cell type is compared
                 }
             }
         };

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -10,7 +10,28 @@
 #include "MutationTestsBase.h"
 
 class CellTypeMutationTests : public MutationTestsBase
-{};
+{
+protected:
+    // Resets the cell type (selected type and its data) to a canonical value while preserving all other node attributes.
+    static void resetCellType(CellTypeGenomeDesc& cellType) { cellType = BaseGenomeDesc{}; }
+
+    bool compareAllExceptCellType(GenomeDesc expected, GenomeDesc actual)
+    {
+        auto reset = [](GenomeDesc& genome) {
+            genome._lineageId = 0;
+            genome._prevLineageId = std::nullopt;
+            genome._accumulatedMutations = 0.0f;
+            for (auto& gene : genome._genes) {
+                for (auto& node : gene._nodes) {
+                    resetCellType(node._cellType);
+                }
+            }
+        };
+        reset(expected);
+        reset(actual);
+        return expected == actual;
+    }
+};
 
 TEST_F(CellTypeMutationTests, cellTypeMutation_changesCellTypeToDefaults)
 {
@@ -25,17 +46,16 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_changesCellTypeToDefaults)
     auto actualGenome = getMutatedGenome();
     auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
 
-    // The cell type must have changed away from the original Sensor type.
     EXPECT_FALSE(std::holds_alternative<SensorGenomeDesc>(cellType));
 
     // The new cell type must be initialized with default attribute values.
     std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
 }
 
-TEST_F(CellTypeMutationTests, cellTypeMutation_zeroProbabilityKeepsCellType)
+TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellType)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(DetonatorGenomeDesc().countdown(42))})});
-    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(0.0f);
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -45,26 +65,6 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_zeroProbabilityKeepsCellType)
     }
 
     auto actualGenome = getMutatedGenome();
-    auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
 
-    ASSERT_TRUE(std::holds_alternative<DetonatorGenomeDesc>(cellType));
-    EXPECT_EQ(std::get<DetonatorGenomeDesc>(cellType)._countdown, 42);
-}
-
-TEST_F(CellTypeMutationTests, cellTypeMutation_resultingCellTypesAlwaysHaveDefaults)
-{
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
-    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-
-    // After every mutation the freshly assigned cell type must carry default attribute values, regardless of which type was chosen.
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-        auto actualGenome = getMutatedGenome();
-        auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
-        std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
-    }
+    EXPECT_TRUE(compareAllExceptCellType(genome, actualGenome));
 }

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -1,0 +1,70 @@
+#include <type_traits>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class CellTypeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_changesCellTypeToDefaults)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(SensorGenomeDesc().autoTrigger(false).minRange(123).maxRange(200))})});
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
+
+    // The cell type must have changed away from the original Sensor type.
+    EXPECT_FALSE(std::holds_alternative<SensorGenomeDesc>(cellType));
+
+    // The new cell type must be initialized with default attribute values.
+    std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
+}
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_zeroProbabilityKeepsCellType)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(DetonatorGenomeDesc().countdown(42))})});
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
+
+    ASSERT_TRUE(std::holds_alternative<DetonatorGenomeDesc>(cellType));
+    EXPECT_EQ(std::get<DetonatorGenomeDesc>(cellType)._countdown, 42);
+}
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_resultingCellTypesAlwaysHaveDefaults)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+
+    // After every mutation the freshly assigned cell type must carry default attribute values, regardless of which type was chosen.
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+        auto actualGenome = getMutatedGenome();
+        auto const& cellType = actualGenome._genes.at(0)._nodes.at(0)._cellType;
+        std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
+    }
+}

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -234,3 +234,43 @@ TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesZeroSigmaNoChange)
     auto actualGenome = getMutatedGenome();
     EXPECT_EQ(actualGenome._mutationRates._cellTypeModeMutation._eventProbability, 0.5f);
 }
+
+TEST_F(MetaMutationTests, metaMutation_cellTypeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationCellTypeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_NE(actualGenome._mutationRates._cellTypeMutation._eventProbability, 0.5f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypeMutation._eventProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._cellTypeMutation._eventProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_cellTypeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationCellTypeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._cellTypeMutation._eventProbability, 0.5f);
+}

--- a/source/Gui/MutationRateDialog.cpp
+++ b/source/Gui/MutationRateDialog.cpp
@@ -106,6 +106,23 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    void processCellTypeMutationRate(std::string const& name, std::string const& id, CellTypeMutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Event probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._eventProbability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     template <typename Func>
     void processConcreteMutationRates(Func&& processMutationRates)
     {
@@ -165,6 +182,8 @@ void MutationRateDialog::loadSettings(MutationRatesDesc& mutationRates, std::str
         settings.getValue(settingsPrefix + "cell type property mutation 2.value probability", mutationRates._cellTypePropertiesMutations[1]._probability);
     mutationRates._cellTypeModeMutation._eventProbability =
         settings.getValue(settingsPrefix + "cell type mode mutation.probability", mutationRates._cellTypeModeMutation._eventProbability);
+    mutationRates._cellTypeMutation._eventProbability =
+        settings.getValue(settingsPrefix + "cell type mutation.probability", mutationRates._cellTypeMutation._eventProbability);
 }
 
 void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, std::string const& settingsPrefix) const
@@ -192,6 +211,7 @@ void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, st
     settings.setValue(settingsPrefix + "cell type property mutation 2.sigma", mutationRates._cellTypePropertiesMutations[1]._sigma);
     settings.setValue(settingsPrefix + "cell type property mutation 2.value probability", mutationRates._cellTypePropertiesMutations[1]._probability);
     settings.setValue(settingsPrefix + "cell type mode mutation.probability", mutationRates._cellTypeModeMutation._eventProbability);
+    settings.setValue(settingsPrefix + "cell type mutation.probability", mutationRates._cellTypeMutation._eventProbability);
 }
 
 void MutationRateDialog::processIntern()
@@ -234,6 +254,14 @@ void MutationRateDialog::processIntern()
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mode mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
                 processCellTypeModeMutationRate("Mutation rate", "CTMM", _mutation._cellTypeModeMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processCellTypeMutationRate("Mutation rate", "CTM", _mutation._cellTypeMutation, rightColumnWidth);
                 table.next();
             });
         }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -302,6 +302,8 @@ namespace
 
     auto constexpr Id_CellTypeModeMutation_EventProbability = 0;
 
+    auto constexpr Id_CellTypeMutation_EventProbability = 0;
+
     auto constexpr Id_Gene_Name = 0;
     auto constexpr Id_Gene_Shape = 1;
     auto constexpr Id_Gene_Stiffness = 5;
@@ -425,6 +427,7 @@ namespace
     auto constexpr Id_MutationRates_CellTypePropertiesMutation1 = 5;
     auto constexpr Id_MutationRates_CellTypePropertiesMutation2 = 6;
     auto constexpr Id_MutationRates_CellTypeModeMutation = 7;
+    auto constexpr Id_MutationRates_CellTypeMutation = 8;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -908,6 +911,15 @@ namespace cereal
     SPLIT_SERIALIZATION(CellTypeModeMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, CellTypeMutationDesc& data)
+    {
+        CellTypeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_CellTypeMutation_EventProbability, data._eventProbability, defaultObject._eventProbability);
+    }
+    SPLIT_SERIALIZATION(CellTypeMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, MutationRatesDesc& data)
     {
         MutationRatesDesc defaultObject;
@@ -919,6 +931,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation1, data._cellTypePropertiesMutations[0]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation2, data._cellTypePropertiesMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
+        scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
     }
     SPLIT_SERIALIZATION(MutationRatesDesc)
 


### PR DESCRIPTION
## Summary
- Add a new mutation type `CellTypeMutation` (single instance, field `eventProbability`) alongside the existing NeuronMutation, ConnectionMutation, CellTypeProperties and CellTypeModeMutations.
- Extend `MutationRates`, `MutationRatesTO` and `MutationRatesDesc` and adapt the full data-transfer chain: `DescConverterService`, `SerializerService`, `EntityFactory`, `DataAccessKernels`, `GenomeDescHash` and `DescTestDataFactory`.
- Add a "Cell type mutations" section to `MutationRateDialog` (slider + settings load/save).
- Add the simulation parameter `metaMutationCellTypeSigma` (`SimulationParameters` + meta-mutation UI group).
- Implement the mutation logic in `MutationProcessor`:
  - `applyMutations_cellType`: with the given `eventProbability`, changes a node's cell type to a randomly chosen different type (e.g. Sensor to Detonator). The new type is initialized with default attribute values (matching the host-side `GenomeDesc` defaults / `*_Default` constants), so the genome stays valid and corrected by construction. `accumulatedMutations` is increased per changed node.
  - `applyMutations_meta`: evaluates `metaMutationCellTypeSigma` to meta-mutate `cellTypeMutation.eventProbability`.
- Clamp the new rate in `DescValidationService`.
- Tests: new `CellTypeMutationTests`, plus `metaMutationCellTypeSigma` cases in `MetaMutationTests` and a `CellType` case in `AccumulatedMutationTests`.

## Original task
Add a new mutation type `CellTypeMutation` containing the field `eventProbability` (single instance like CellTypeModeMutations). Extend MutationRates/TO/Desc, adapt data transfer (DescConverterService, SerializerService, EntityFactory, DataAccessKernels, DescTestDataFactory), MutationRateDialog, add simulation parameter `metaMutationCellTypeSigma`, and implement the main mutation logic in MutationProcessor: CellTypeMutation changes a node's cell type with the given eventProbability, new type gets default values for all attributes (like CellTypeModeMutations), the genome is validated/corrected after mutation, existing code is reused and accumulatedMutations is increased; for meta mutations extend applyMutations_meta with metaMutationCellTypeSigma.

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (3004 passed, 0 failed, 3 pre-existing skips unrelated to this change; the new CellTypeMutation / MetaMutation / AccumulatedMutation tests pass)
- `./cli --help`: passed

## Notes
- The cell-type change uses default values for every target type, which is what keeps the mutated genome valid (the "validate and correct" requirement); the Injector default `geneIndex` 0 is always valid and a mutated Memory node uses 0 signal entries (null buffer is guarded everywhere by `numSignalEntries > 0`).
- A clean-up rebuild of the EngineKernels objects was required after the `SimulationParameters` struct grew (constant-memory size), which is expected for this codebase.
- `external/vcpkg` was left untouched.