### PR TITLE
Preserve void invariant and mutate homogeneCellType in cell type mutation

### DIFF
--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -716,7 +716,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         return;
     }
 
-    // Pick a new non-void cell type that differs from the current one; void nodes keep their type (see below).
+    // Pick a new non-void cell type that differs from the current one; void nodes keep their type
     auto pickNewCellType = [&](int currentCellType) {
         auto newCellType = data.primaryNumberGen.random(CellType_Count - 3);
         if (newCellType >= currentCellType) {
@@ -728,7 +728,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
     for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
         auto& gene = genome->genes[geneIndex];
 
-        // The homogeneous cell type flag is a per-gene property, so let a single thread mutate it.
         if (laneId == 0 && data.primaryNumberGen.random() < rate.eventProbability) {
             gene.homogeneCellType = !gene.homogeneCellType;
             atomicAdd_block(&accumulatedMutations, 1.0f);
@@ -737,7 +736,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
             auto& node = gene.nodes[nodeIndex];
 
-            // Void nodes must stay void and non-void nodes must stay non-void.
             if (node.cellType == CellType_Void) {
                 continue;
             }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -716,10 +716,14 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         return;
     }
 
-    // Pick a new non-void cell type that differs from the current one; void nodes keep their type (see below).
+    // Pick a cell type and shift it past the current type and the void type, so that neither can be selected.
+    // The explicit void shift keeps this correct even if further cell types are added next to the void type.
     auto pickNewCellType = [&](int currentCellType) {
         auto newCellType = data.primaryNumberGen.random(CellType_Count - 3);
         if (newCellType >= currentCellType) {
+            ++newCellType;
+        }
+        if (newCellType >= CellType_Void) {
             ++newCellType;
         }
         return newCellType;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -716,8 +716,9 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         return;
     }
 
+    // Pick a new non-void cell type that differs from the current one; void nodes keep their type (see below).
     auto pickNewCellType = [&](int currentCellType) {
-        auto newCellType = data.primaryNumberGen.random(CellType_Count - 2);
+        auto newCellType = data.primaryNumberGen.random(CellType_Count - 3);
         if (newCellType >= currentCellType) {
             ++newCellType;
         }
@@ -726,11 +727,23 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
 
     for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
         auto& gene = genome->genes[geneIndex];
+
+        // The homogeneous cell type flag is a per-gene property, so let a single thread mutate it.
+        if (laneId == 0 && data.primaryNumberGen.random() < rate.eventProbability) {
+            gene.homogeneCellType = !gene.homogeneCellType;
+            atomicAdd_block(&accumulatedMutations, 1.0f);
+        }
+
         for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
+            auto& node = gene.nodes[nodeIndex];
+
+            // Void nodes must stay void and non-void nodes must stay non-void.
+            if (node.cellType == CellType_Void) {
+                continue;
+            }
             if (data.primaryNumberGen.random() >= rate.eventProbability) {
                 continue;
             }
-            auto& node = gene.nodes[nodeIndex];
 
             node.cellType = pickNewCellType(node.cellType);
 
@@ -788,9 +801,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
             } break;
             case CellType_Communicator:
                 cellTypeData.communicator.mode = CommunicatorMode_Sender;
-                break;
-            case CellType_Void:
-                cellTypeData.voidCell = {};
                 break;
             }
 

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -69,7 +69,12 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellTypeAndHom
 
 TEST_F(CellTypeMutationTests, cellTypeMutation_keepsVoidNodesVoid)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(VoidGenomeDesc())})});
+    // The first and last node of a gene cannot be void, so put the void node in the middle.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({
+        NodeDesc().cellType(BaseGenomeDesc()),
+        NodeDesc().cellType(VoidGenomeDesc()),
+        NodeDesc().cellType(BaseGenomeDesc()),
+    })});
     genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -81,7 +86,10 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_keepsVoidNodesVoid)
 
     auto actualGenome = getMutatedGenome();
 
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.at(0).getCellType(), CellType_Void);
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    EXPECT_NE(nodes.at(0).getCellType(), CellType_Void);
+    EXPECT_EQ(nodes.at(1).getCellType(), CellType_Void);
+    EXPECT_NE(nodes.at(2).getCellType(), CellType_Void);
 }
 
 TEST_F(CellTypeMutationTests, cellTypeMutation_keepsNonVoidNodesNonVoid)

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -12,13 +12,14 @@
 class CellTypeMutationTests : public MutationTestsBase
 {
 protected:
-    bool compareAllExceptCellType(GenomeDesc expected, GenomeDesc actual)
+    bool compareAllExceptCellTypeAndHomogeneFlag(GenomeDesc expected, GenomeDesc actual)
     {
         auto reset = [](GenomeDesc& genome) {
             genome._lineageId = 0;
             genome._prevLineageId = std::nullopt;
             genome._accumulatedMutations = 0.0f;
             for (auto& gene : genome._genes) {
+                gene._homogeneCellType = false;  // canonicalize: the cell type mutation may also flip this flag
                 for (auto& node : gene._nodes) {
                     node._cellType = BaseGenomeDesc{};  // canonicalize so everything except the cell type is compared
                 }
@@ -49,7 +50,7 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_changesCellTypeToDefaults)
     std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
 }
 
-TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellType)
+TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellTypeAndHomogeneFlag)
 {
     auto genome = createTestGenome();
     genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
@@ -63,5 +64,65 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellType)
 
     auto actualGenome = getMutatedGenome();
 
-    EXPECT_TRUE(compareAllExceptCellType(genome, actualGenome));
+    EXPECT_TRUE(compareAllExceptCellTypeAndHomogeneFlag(genome, actualGenome));
+}
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_keepsVoidNodesVoid)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(VoidGenomeDesc())})});
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.at(0).getCellType(), CellType_Void);
+}
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_keepsNonVoidNodesNonVoid)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    // The cell type mutation must never turn a non-void node into a void node or vice versa.
+    ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
+    for (size_t geneIndex = 0; geneIndex < genome._genes.size(); ++geneIndex) {
+        auto const& expectedNodes = genome._genes.at(geneIndex)._nodes;
+        auto const& actualNodes = actualGenome._genes.at(geneIndex)._nodes;
+        ASSERT_EQ(expectedNodes.size(), actualNodes.size());
+        for (size_t nodeIndex = 0; nodeIndex < expectedNodes.size(); ++nodeIndex) {
+            auto expectedIsVoid = expectedNodes.at(nodeIndex).getCellType() == CellType_Void;
+            auto actualIsVoid = actualNodes.at(nodeIndex).getCellType() == CellType_Void;
+            EXPECT_EQ(expectedIsVoid, actualIsVoid);
+        }
+    }
+}
+
+TEST_F(CellTypeMutationTests, cellTypeMutation_changesHomogeneCellTypeFlag)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().homogeneCellType(false).nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().eventProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+
+    EXPECT_TRUE(actualGenome._genes.at(0)._homogeneCellType);
 }


### PR DESCRIPTION
## Summary
- `applyMutations_cellType` no longer changes void nodes into non-void nodes or vice versa: void nodes are skipped, and `pickNewCellType` now draws only from the non-void cell types (`random(CellType_Count - 3)`), so the void/non-void property of every node is preserved.
- The cell type mutation may now flip the per-gene `homogeneCellType` flag. A single thread (lane 0) toggles it per gene with the mutation event probability and counts it as an accumulated mutation.
- Removed the now-unreachable `CellType_Void` case from the cell type reset switch.

## Original task
Ensure that the cell type mutations (see `applyMutations_cellType`) does not change void nodes to non-void nodes and vice versa. Furthermore, the cell type mutations is allowed to change the `homogeneCellType` flag. Adapt tests.

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineInterfaceTests`: passed (153 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (3006 passed, 3 pre-existing skips, 0 failures)
- `./cli --help`: passed

## Notes
- Adapted `CellTypeMutationTests`: renamed the "does not change except cell type" test/helper to also canonicalize the `homogeneCellType` flag, and added tests `keepsVoidNodesVoid`, `keepsNonVoidNodesNonVoid`, and `changesHomogeneCellTypeFlag`.
- The `.cuh` change required touching `SimulationKernels.cu`/`TestKernels.cu` to force CUDA recompilation (header dependency tracking does not detect `.cuh` edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)