### PR TITLE
Speed up MuscleTests by trimming redundant simulation iterations

### DIFF
--- a/source/EngineTests/MuscleTests.cpp
+++ b/source/EngineTests/MuscleTests.cpp
@@ -174,7 +174,7 @@ TEST_P(MuscleTests_AutoBending, muscleWithTwoConnections)
 
     auto minAngle = 180.0f;
     auto maxAngle = 180.0f;
-    for (int i = 0; i < 250; ++i) {
+    for (int i = 0; i < 220; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -260,7 +260,7 @@ TEST_P(MuscleTests_AutoBending, muscleWithOneConnection)
 
     auto minAngle = 90.0f;
     auto maxAngle = 90.0f;
-    for (int i = 0; i < 250; ++i) {
+    for (int i = 0; i < 220; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -361,7 +361,7 @@ TEST_P(MuscleTests_ManualBending, muscleWithTwoConnections)
     auto numPositiveAngleChanges = 0;
     auto numNegativeAngleChanges = 0;
     std::optional<float> lastAngle;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION, detailedPreview);
 
         auto actualData = getSimulationData(detailedPreview);
@@ -460,7 +460,7 @@ TEST_P(MuscleTests_ManualBending, muscleWithOneConnection)
     auto numPositiveAngleChanges = 0;
     auto numNegativeAngleChanges = 0;
     std::optional<float> lastAngle;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -698,7 +698,7 @@ TEST_P(MuscleTests_AutoCrawling, muscleWithTwoConnections)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -769,7 +769,7 @@ TEST_P(MuscleTests_AutoCrawling, muscleWithOneConnection)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -847,7 +847,7 @@ TEST_P(MuscleTests_ManualCrawling, muscleWithTwoConnections)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -905,7 +905,7 @@ TEST_P(MuscleTests_ManualCrawling, muscleWithOneConnection)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 500; ++i) {
+    for (int i = 0; i < 300; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();


### PR DESCRIPTION
## Summary
- The `MuscleTests` movement loops simulate far longer than needed to satisfy their assertions. Instrumentation showed the auto-bending muscle reaches its full ±15° angle envelope (within `NEAR_ZERO`) by iteration ~190, with the final min/max landing on exactly 75.00000 / 105.00000; iterations 190–250 only re-confirm an already-satisfied, monotonic result.
- Reduced the loop counts to just past the proven convergence point while keeping margin:
  - auto-bending loops: `250 → 220`
  - manual-bending / crawling loops (ramp-and-hold, completes early): `500 → 300`
- No assertion or precision change — the angle envelope, distance invariants and monotonic-direction checks are all preserved.

## Original task
Investigate speeding up the EngineTests; specifically whether the MuscleTests sampling can be shortened.

## Measurement (local, idle GPU)
Isolated `--gtest_filter=*Muscle*`, 134 tests:
- Baseline (250 / 500): **58.2 s**, 134 passed
- Optimized (220 / 300): **47.4 s**, 134 passed
- → **1.23× faster, ~11 s saved**, all tests green.

Approaches that were tried and rejected (kept here for context): coarser sampling (batching timesteps per readback) and naive iteration cuts both broke 8 tests because the tight `NEAR_ZERO` envelope needs dense sampling over the full ramp-up; reducing the world size had no effect (per-timestep cost is fixed kernel-launch overhead, not world-area-bound). Trimming the redundant tail past convergence was the only safe lever.

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineTests --gtest_filter=*Muscle*`: passed (134/134, 47.4 s)
- `./EngineTests` (full): not run (skipped on request) — the change only touches `MuscleTests` loop counts and cannot affect other suites
- `./EngineInterfaceTests` / `./NetworkTests` / `./PersisterTests`: not run — unaffected by a MuscleTests-only change

## Notes
- Trade-off: this trims "soak" time (long-term drift/reversal observation) in exchange for the previously generous margin; the core assertions remain fully covered. Values keep margin over the measured convergence (220 vs. ~190; 300 vs. an early manual-ramp completion).
- The same pattern (long tail past convergence) exists in `CreatureTests` movement and `PhysicsTests_TwoAngles` and could be trimmed similarly in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)