### PR TITLE
Shorten MuscleTests sampling further by reducing deviation amplitudes

### DIFF
--- a/source/EngineTests/MuscleTests.cpp
+++ b/source/EngineTests/MuscleTests.cpp
@@ -139,7 +139,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(MuscleTests_AutoBending, muscleWithTwoConnections)
 {
-    auto constexpr MaxAngleDeviation = 15.0f;
+    auto constexpr MaxAngleDeviation = 5.0f;
     auto constexpr AnglePrecision = NEAR_ZERO;
 
     auto [side, channel0, channel1] = GetParam();
@@ -174,7 +174,7 @@ TEST_P(MuscleTests_AutoBending, muscleWithTwoConnections)
 
     auto minAngle = 180.0f;
     auto maxAngle = 180.0f;
-    for (int i = 0; i < 220; ++i) {
+    for (int i = 0; i < 90; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -225,7 +225,7 @@ TEST_P(MuscleTests_AutoBending, muscleWithTwoConnections)
 
 TEST_P(MuscleTests_AutoBending, muscleWithOneConnection)
 {
-    auto constexpr MaxAngleDeviation = 15.0f;
+    auto constexpr MaxAngleDeviation = 5.0f;
     auto constexpr AnglePrecision = NEAR_ZERO;
 
     auto [side, channel0, channel1] = GetParam();
@@ -260,7 +260,7 @@ TEST_P(MuscleTests_AutoBending, muscleWithOneConnection)
 
     auto minAngle = 90.0f;
     auto maxAngle = 90.0f;
-    for (int i = 0; i < 220; ++i) {
+    for (int i = 0; i < 90; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -670,7 +670,7 @@ INSTANTIATE_TEST_SUITE_P(MuscleTests_AutoCrawling, MuscleTests_AutoCrawling, ::t
 
 TEST_P(MuscleTests_AutoCrawling, muscleWithTwoConnections)
 {
-    auto constexpr MaxDistanceDeviation = 0.5f;
+    auto constexpr MaxDistanceDeviation = 0.2f;
 
     auto channel0 = GetParam();
 
@@ -698,7 +698,7 @@ TEST_P(MuscleTests_AutoCrawling, muscleWithTwoConnections)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 300; ++i) {
+    for (int i = 0; i < 80; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -743,7 +743,7 @@ TEST_P(MuscleTests_AutoCrawling, muscleWithTwoConnections)
 
 TEST_P(MuscleTests_AutoCrawling, muscleWithOneConnection)
 {
-    auto constexpr MaxDistanceDeviation = 0.5f;
+    auto constexpr MaxDistanceDeviation = 0.2f;
 
     auto channel0 = GetParam();
 
@@ -769,7 +769,7 @@ TEST_P(MuscleTests_AutoCrawling, muscleWithOneConnection)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 300; ++i) {
+    for (int i = 0; i < 80; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -817,7 +817,7 @@ INSTANTIATE_TEST_SUITE_P(MuscleTests_ManualCrawling, MuscleTests_ManualCrawling,
 
 TEST_P(MuscleTests_ManualCrawling, muscleWithTwoConnections)
 {
-    auto constexpr MaxDistanceDeviation = 0.5f;
+    auto constexpr MaxDistanceDeviation = 0.2f;
 
     auto channel0 = GetParam();
 
@@ -847,7 +847,7 @@ TEST_P(MuscleTests_ManualCrawling, muscleWithTwoConnections)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 300; ++i) {
+    for (int i = 0; i < 80; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();
@@ -877,7 +877,7 @@ TEST_P(MuscleTests_ManualCrawling, muscleWithTwoConnections)
 
 TEST_P(MuscleTests_ManualCrawling, muscleWithOneConnection)
 {
-    auto constexpr MaxDistanceDeviation = 0.5f;
+    auto constexpr MaxDistanceDeviation = 0.2f;
 
     auto channel0 = GetParam();
 
@@ -905,7 +905,7 @@ TEST_P(MuscleTests_ManualCrawling, muscleWithOneConnection)
 
     auto minDistance = 1.0f;
     auto maxDistance = 1.0f;
-    for (int i = 0; i < 300; ++i) {
+    for (int i = 0; i < 80; ++i) {
         _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
 
         auto actualData = _simulationFacade->getSimulationData();


### PR DESCRIPTION
## Summary
Follow-up to #718 (merged). The auto-bending / crawling muscles ramp their amplitude up to the configured deviation, and the time to reach that amplitude scales ~linearly with it. Reducing the tested deviation therefore lets the sampling loop be much shorter, at the same `NEAR_ZERO` precision.

Measured convergence (iteration at which the min/max envelope is first reached within `NEAR_ZERO`):
- AutoBending angle deviation `15° → 5°`: envelope reached at iter **63** (was 190) → loop `220 → 90`
- AutoCrawling/ManualCrawling distance deviation `0.5 → 0.2`: envelope reached at iter **50** → loop `300 → 80`
- ManualBending left unchanged: its `numNegativeAngleChanges > 10` assertion shrinks with a smaller deviation, so reducing it there is unsafe.
- AngleBending (120°) has no sampling loop and is untouched.

Loop counts keep a comfortable margin over the measured convergence (90 vs 63; 80 vs 50). The final min/max land exactly on the new envelope (±5° / ±0.2).

## Original task
Investigate whether reducing the max angle/distance deviation lets the MuscleTests sampling be shortened further.

## Measurement (local, idle GPU, full `*Muscle*`, 134 tests)
- Baseline before #718: **58.2 s**
- After #718 (tail trim): 47.4 s
- After this PR (smaller deviations + shorter loops): **34.9 s**, 134/134 passed
- → **1.67× vs. the pre-#718 baseline** (1.36× on top of #718).

## Build and tests
- `cmake --build build --config Release -j32`: passed
- `./EngineTests --gtest_filter=*Muscle*`: passed (134/134, 34.9 s)
- `./EngineTests` (full): not run (skipped on request) — change only touches `MuscleTests` constants/loop counts
- `./EngineInterfaceTests` / `./NetworkTests` / `./PersisterTests`: not run — unaffected

## Notes
- Trade-off: the muscle now bends to 5° (was 15°) and crawls ±0.2 (was ±0.5) — a smaller but still fully-precise operating point. The bending/crawling mechanism and the exact-envelope assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)