### PR TITLE
Add ConstructorMutation mutation type

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -879,6 +879,9 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._eventProbability = genomeTO.mutationRates.cellTypePropertiesMutations[i].eventProbability;
         result._mutationRates._cellTypePropertiesMutations[i]._sigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma;
         result._mutationRates._cellTypePropertiesMutations[i]._probability = genomeTO.mutationRates.cellTypePropertiesMutations[i].probability;
+        result._mutationRates._constructorMutations[i]._eventProbability = genomeTO.mutationRates.constructorMutations[i].eventProbability;
+        result._mutationRates._constructorMutations[i]._sigma = genomeTO.mutationRates.constructorMutations[i].sigma;
+        result._mutationRates._constructorMutations[i]._probability = genomeTO.mutationRates.constructorMutations[i].probability;
     }
     result._mutationRates._cellTypeModeMutation._eventProbability = genomeTO.mutationRates.cellTypeModeMutation.eventProbability;
     result._mutationRates._cellTypeMutation._eventProbability = genomeTO.mutationRates.cellTypeMutation.eventProbability;
@@ -970,6 +973,10 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._eventProbability,
             genome._mutationRates._cellTypePropertiesMutations[i]._sigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._probability};
+        genomeTO.mutationRates.constructorMutations[i] = {
+            genome._mutationRates._constructorMutations[i]._eventProbability,
+            genome._mutationRates._constructorMutations[i]._sigma,
+            genome._mutationRates._constructorMutations[i]._probability};
     }
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._eventProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._eventProbability};

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -120,6 +120,11 @@ namespace Channels
 {
     auto constexpr ConstructorSuccess = 4;
 }
+namespace Const
+{
+    auto constexpr ConstructorConstructionAngle_Min = -180.0f;
+    auto constexpr ConstructorConstructionAngle_Max = 180.0f;
+}
 
 using ConstructorShape = int;
 enum ConstructorShape_
@@ -145,9 +150,6 @@ enum ProvideEnergy_
 
 namespace Const
 {
-    auto constexpr ConstructorConstructionAngle_Min = -180.0f;
-    auto constexpr ConstructorConstructionAngle_Max = 180.0f;
-
     std::vector<std::string> const ConstructorShapeStrings = {"Segment", "Triangle", "Rectangle", "Hexagon", "Tube", "Large Lolli", "Small Lolli", "Zigzag"};
     std::vector<std::string> const ProvideEnergyStrings = {"From constructor", "Free"};
 }

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -123,7 +123,6 @@ namespace Channels
 namespace Const
 {
     auto constexpr ConstructorAutoTriggerInterval_Min = 1;
-    auto constexpr ConstructorAutoTriggerInterval_Max = 100;
     auto constexpr ConstructorAutoTriggerInterval_Default = 100;
     auto constexpr ConstructorConstructionActivationTime_Min = 0;
     auto constexpr ConstructorConstructionActivationTime_Max = 256 * 4;

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -122,6 +122,12 @@ namespace Channels
 }
 namespace Const
 {
+    auto constexpr ConstructorAutoTriggerInterval_Min = 1;
+    auto constexpr ConstructorAutoTriggerInterval_Max = 100;
+    auto constexpr ConstructorAutoTriggerInterval_Default = 100;
+    auto constexpr ConstructorConstructionActivationTime_Min = 0;
+    auto constexpr ConstructorConstructionActivationTime_Max = MAX_ACTIVATION_TIME;
+    auto constexpr ConstructorConstructionActivationTime_Default = 100;
     auto constexpr ConstructorConstructionAngle_Min = -180.0f;
     auto constexpr ConstructorConstructionAngle_Max = 180.0f;
 }

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -145,6 +145,9 @@ enum ProvideEnergy_
 
 namespace Const
 {
+    auto constexpr ConstructorConstructionAngle_Min = -180.0f;
+    auto constexpr ConstructorConstructionAngle_Max = 180.0f;
+
     std::vector<std::string> const ConstructorShapeStrings = {"Segment", "Triangle", "Rectangle", "Hexagon", "Tube", "Large Lolli", "Small Lolli", "Zigzag"};
     std::vector<std::string> const ProvideEnergyStrings = {"From constructor", "Free"};
 }

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -126,7 +126,7 @@ namespace Const
     auto constexpr ConstructorAutoTriggerInterval_Max = 100;
     auto constexpr ConstructorAutoTriggerInterval_Default = 100;
     auto constexpr ConstructorConstructionActivationTime_Min = 0;
-    auto constexpr ConstructorConstructionActivationTime_Max = MAX_ACTIVATION_TIME;
+    auto constexpr ConstructorConstructionActivationTime_Max = 256 * 4;
     auto constexpr ConstructorConstructionActivationTime_Default = 100;
     auto constexpr ConstructorConstructionAngle_Min = -180.0f;
     auto constexpr ConstructorConstructionAngle_Max = 180.0f;

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -56,7 +56,11 @@ struct ConstructorDesc
     auto operator<=>(ConstructorDesc const&) const = default;
 
     // Properties
-    MEMBER(ConstructorDesc, std::optional<int>, autoTriggerInterval, 100);  // std::nullopt = manual triggering, value must be >= 3
+    MEMBER(
+        ConstructorDesc,
+        std::optional<int>,
+        autoTriggerInterval,
+        Const::ConstructorAutoTriggerInterval_Default);  // std::nullopt = manual triggering, value must be >= 3
     MEMBER(ConstructorDesc, int, constructionActivationTime, 100);
     MEMBER(ConstructorDesc, float, constructionAngle, 0.0f);
     MEMBER(ConstructorDesc, ProvideEnergy, provideEnergy, ProvideEnergy_FromConstructor);

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -275,8 +275,13 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
                     value = std::max(value, 1);
                 }
                 constructor._geneIndex = std::max(constructor._geneIndex, 0);
-                constructor._constructionActivationTime =
-                    std::clamp(constructor._constructionActivationTime, 0, Const::ConstructorConstructionActivationTime_Max);
+                if (constructor._autoTriggerInterval.has_value()) {
+                    constructor._autoTriggerInterval = std::max(*constructor._autoTriggerInterval, Const::ConstructorConstructionActivationTime_Min);
+                }
+                constructor._constructionActivationTime = std::clamp(
+                    constructor._constructionActivationTime,
+                    Const::ConstructorConstructionActivationTime_Min,
+                    Const::ConstructorConstructionActivationTime_Max);
                 constructor._provideEnergy =
                     std::clamp(constructor._provideEnergy, static_cast<ProvideEnergy>(0), static_cast<ProvideEnergy>(ProvideEnergy_Count - 1));
                 constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);
@@ -474,7 +479,8 @@ void DescValidationService::validateAndCorrect(ObjectDesc& object)
                 value = std::max(value, 0);
             }
             constructor._geneIndex = std::max(constructor._geneIndex, 0);
-            constructor._constructionActivationTime = std::clamp(constructor._constructionActivationTime, 0, Const::ConstructorConstructionActivationTime_Max);
+            constructor._constructionActivationTime = std::clamp(
+                constructor._constructionActivationTime, Const::ConstructorConstructionActivationTime_Min, Const::ConstructorConstructionActivationTime_Max);
             constructor._provideEnergy =
                 std::clamp(constructor._provideEnergy, static_cast<ProvideEnergy>(0), static_cast<ProvideEnergy>(ProvideEnergy_Count - 1));
             constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -24,6 +24,11 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         mutation._sigma = std::clamp(mutation._sigma, 0.0f, 1.0f);
         mutation._probability = std::clamp(mutation._probability, 0.0f, 1.0f);
     };
+    auto validateConstructorMutation = [](ConstructorMutationDesc& mutation) {
+        mutation._eventProbability = std::clamp(mutation._eventProbability, 0.0f, 1.0f);
+        mutation._sigma = std::clamp(mutation._sigma, 0.0f, 1.0f);
+        mutation._probability = std::clamp(mutation._probability, 0.0f, 1.0f);
+    };
     for (int i = 0; i < 2; ++i) {
         auto& neuronMutation = genome._mutationRates._neuronMutations[i];
         neuronMutation._eventProbability = std::clamp(neuronMutation._eventProbability, 0.0f, 1.0f);
@@ -36,6 +41,7 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         connectionMutation._sigma = std::max(connectionMutation._sigma, 0.0f);
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
+        validateConstructorMutation(genome._mutationRates._constructorMutations[i]);
     }
     genome._mutationRates._cellTypeModeMutation._eventProbability =
         std::clamp(genome._mutationRates._cellTypeModeMutation._eventProbability, 0.0f, 1.0f);

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -287,6 +287,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
                 constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);
                 constructor._numBranches = std::clamp(constructor._numBranches, 1, 6);
                 constructor._numConcatenations = std::max(constructor._numConcatenations, 1);
+                constructor._constructionAngle =
+                    std::clamp(constructor._constructionAngle, Const::ConstructorConstructionAngle_Min, Const::ConstructorConstructionAngle_Max);
             }
         }
     }
@@ -486,6 +488,8 @@ void DescValidationService::validateAndCorrect(ObjectDesc& object)
             constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);
             constructor._numBranches = std::clamp(constructor._numBranches, 1, 6);
             constructor._numConcatenations = std::max(constructor._numConcatenations, 1);
+            constructor._constructionAngle =
+                std::clamp(constructor._constructionAngle, Const::ConstructorConstructionAngle_Min, Const::ConstructorConstructionAngle_Max);
         }
     }
 }

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -275,7 +275,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
                     value = std::max(value, 1);
                 }
                 constructor._geneIndex = std::max(constructor._geneIndex, 0);
-                constructor._constructionActivationTime = std::clamp(constructor._constructionActivationTime, 0, MAX_ACTIVATION_TIME);
+                constructor._constructionActivationTime =
+                    std::clamp(constructor._constructionActivationTime, 0, Const::ConstructorConstructionActivationTime_Max);
                 constructor._provideEnergy =
                     std::clamp(constructor._provideEnergy, static_cast<ProvideEnergy>(0), static_cast<ProvideEnergy>(ProvideEnergy_Count - 1));
                 constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);
@@ -473,7 +474,7 @@ void DescValidationService::validateAndCorrect(ObjectDesc& object)
                 value = std::max(value, 0);
             }
             constructor._geneIndex = std::max(constructor._geneIndex, 0);
-            constructor._constructionActivationTime = std::clamp(constructor._constructionActivationTime, 0, MAX_ACTIVATION_TIME);
+            constructor._constructionActivationTime = std::clamp(constructor._constructionActivationTime, 0, Const::ConstructorConstructionActivationTime_Max);
             constructor._provideEnergy =
                 std::clamp(constructor._provideEnergy, static_cast<ProvideEnergy>(0), static_cast<ProvideEnergy>(ProvideEnergy_Count - 1));
             constructor._reservedEnergy = std::max(0.0f, constructor._reservedEnergy);

--- a/source/EngineInterface/EngineConstants.h
+++ b/source/EngineInterface/EngineConstants.h
@@ -15,7 +15,6 @@ auto constexpr MAX_SOURCES = 40;
 
 auto constexpr MAX_HISTOGRAM_SLOTS = 20;
 
-auto constexpr MAX_ACTIVATION_TIME = 256 * 4;
 auto constexpr TRIGGER_THRESHOLD = 0.1f;
 
 auto constexpr CELL_UPDATE_INTERVAL = 100;

--- a/source/EngineInterface/GenomeDesc.cpp
+++ b/source/EngineInterface/GenomeDesc.cpp
@@ -71,6 +71,9 @@ std::vector<std::string> MutationRatesDesc::getActiveMutationTypes() const
     if (_voidMutation._eventProbability > 0.0f) {
         activeMutations.push_back("Void mutations");
     }
+    if (_constructorMutations[0]._eventProbability > 0.0f || _constructorMutations[1]._eventProbability > 0.0f) {
+        activeMutations.push_back("Constructor mutations");
+    }
     return activeMutations;
 }
 

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -460,11 +460,21 @@ struct VoidMutationDesc
     MEMBER(VoidMutationDesc, float, eventProbability, 0.0f);
 };
 
+struct ConstructorMutationDesc
+{
+    auto operator<=>(ConstructorMutationDesc const&) const = default;
+
+    MEMBER(ConstructorMutationDesc, float, eventProbability, 0.0f);
+    MEMBER(ConstructorMutationDesc, float, sigma, 0.0f);
+    MEMBER(ConstructorMutationDesc, float, probability, 0.0f);
+};
+
 struct MutationRatesDesc
 {
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
     using ConnectionMutationArray = std::array<ConnectionMutationDesc, 2>;
     using CellTypePropertiesMutationArray = std::array<CellTypePropertiesMutationDesc, 2>;
+    using ConstructorMutationArray = std::array<ConstructorMutationDesc, 2>;
 
     auto operator<=>(MutationRatesDesc const&) const = default;
 
@@ -474,6 +484,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
+    MEMBER(MutationRatesDesc, ConstructorMutationArray, constructorMutations, ConstructorMutationArray());
 
     std::vector<std::string> getActiveMutationTypes() const;
 };

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -50,9 +50,9 @@ struct ConstructorGenomeDesc
 {
     auto operator<=>(ConstructorGenomeDesc const&) const = default;
 
-    MEMBER(ConstructorGenomeDesc, std::optional<int>, autoTriggerInterval, 100);  // std::nullopt = manual triggering
+    MEMBER(ConstructorGenomeDesc, std::optional<int>, autoTriggerInterval, Const::ConstructorAutoTriggerInterval_Default);  // std::nullopt = manual triggering
     MEMBER(ConstructorGenomeDesc, int, geneIndex, 0);
-    MEMBER(ConstructorGenomeDesc, int, constructionActivationTime, 100);
+    MEMBER(ConstructorGenomeDesc, int, constructionActivationTime, Const::ConstructorConstructionActivationTime_Default);
     MEMBER(ConstructorGenomeDesc, float, constructionAngle, 0.0f);
     MEMBER(ConstructorGenomeDesc, ProvideEnergy, provideEnergy, ProvideEnergy_FromConstructor);
     MEMBER(ConstructorGenomeDesc, float, reservedEnergy, 0.0f);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,6 +552,9 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._eventProbability);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._sigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._probability);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._eventProbability);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._sigma);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._probability);
         }
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._eventProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._eventProbability);

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -479,6 +479,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::metaMutationVoidSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Constructor mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationConstructorSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("New lineage threshold")
                         .reference(
                             FloatSpec().member(&SimulationParameters::newLineageThreshold).min(0.0f).max(10000.0f).infinity(true).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -112,6 +112,7 @@ struct SimulationParameters
     BaseParameter<float> metaMutationCellTypeModeSigma = {0};
     BaseParameter<float> metaMutationCellTypeSigma = {0};
     BaseParameter<float> metaMutationVoidSigma = {0};
+    BaseParameter<float> metaMutationConstructorSigma = {0};
     BaseParameter<float> newLineageThreshold = {Infinity<float>::value};
 
     // Cell type: Attacker

--- a/source/EngineKernels/ConstructorHelper.cuh
+++ b/source/EngineKernels/ConstructorHelper.cuh
@@ -7,7 +7,8 @@ class ConstructorHelper
 public:
     __inline__ __device__ static bool isFinished(Object* constructorCell, Genome const& genome);
     __inline__ __device__ static Gene* getCurrentGene(Constructor const& constructor, Genome const& genome);
-    __inline__ __device__ static bool hasInfiniteConcatenations(Constructor const& constructor);
+    template <typename ConstructorType>
+    __inline__ __device__ static bool hasInfiniteConcatenations(ConstructorType const& constructor);
     __inline__ __device__ static void
     getConstructorIndices(uint16_t& currentNodeIndex, uint32_t& currentConcatenation, uint8_t& currentBranch, Object* constructorCell, Genome const& genome);
     __inline__ __device__ static Object* getLastConstructedCell(Object* constructorCell);
@@ -51,7 +52,8 @@ __inline__ __device__ Gene* ConstructorHelper::getCurrentGene(Constructor const&
     return &genome.genes[constructor.geneIndex];
 }
 
-__inline__ __device__ bool ConstructorHelper::hasInfiniteConcatenations(Constructor const& constructor)
+template <typename ConstructorType>
+__inline__ __device__ bool ConstructorHelper::hasInfiniteConcatenations(ConstructorType const& constructor)
 {
     return constructor.numConcatenations == 0x7fffffff;
 }

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -47,6 +47,10 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].eventProbability,
                     genome->mutationRates.cellTypePropertiesMutations[i].sigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].probability};
+                genomeTO.mutationRates.constructorMutations[i] = {
+                    genome->mutationRates.constructorMutations[i].eventProbability,
+                    genome->mutationRates.constructorMutations[i].sigma,
+                    genome->mutationRates.constructorMutations[i].probability};
             }
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.eventProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.eventProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -102,6 +102,10 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].eventProbability,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].probability};
+        genome->mutationRates.constructorMutations[i] = {
+            genomeTO.mutationRates.constructorMutations[i].eventProbability,
+            genomeTO.mutationRates.constructorMutations[i].sigma,
+            genomeTO.mutationRates.constructorMutations[i].probability};
     }
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.eventProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.eventProbability};

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -376,6 +376,13 @@ struct VoidMutation
     float eventProbability;
 };
 
+struct ConstructorMutation
+{
+    float eventProbability;
+    float sigma;
+    float probability;
+};
+
 struct MutationRates
 {
     NeuronMutation neuronMutations[2];
@@ -384,6 +391,7 @@ struct MutationRates
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;
+    ConstructorMutation constructorMutations[2];
 };
 
 struct Genome

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -381,6 +381,13 @@ struct VoidMutationTO
     float eventProbability;
 };
 
+struct ConstructorMutationTO
+{
+    float eventProbability;
+    float sigma;
+    float probability;
+};
+
 struct MutationRatesTO
 {
     NeuronMutationTO neuronMutations[2];
@@ -389,6 +396,7 @@ struct MutationRatesTO
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;
+    ConstructorMutationTO constructorMutations[2];
 };
 
 struct GenomeTO

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -28,6 +28,7 @@ private:
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
     __inline__ __device__ static void resetCellTypeModeToDefault(Node& node);
     __inline__ __device__ static void resetCellTypeToDefault(Node& node);
@@ -111,6 +112,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_cellTypeMode(data, genome, accumulatedMutations);
     applyMutations_cellType(data, genome, accumulatedMutations);
     applyMutations_void(data, genome, accumulatedMutations);
+    applyMutations_constructor(data, genome, accumulatedMutations);
 
     block.sync();
     updateAccumulatedMutationsAndLineageId(data, genome, accumulatedMutations);
@@ -856,6 +858,108 @@ __inline__ __device__ void MutationProcessor::applyMutations_void(SimulationData
     }
 }
 
+__inline__ __device__ void MutationProcessor::applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto block = cg_mutation::this_thread_block();
+    auto laneId = block.thread_rank();
+    ConstructorMutation rates[2] = {genome->mutationRates.constructorMutations[0], genome->mutationRates.constructorMutations[1]};
+
+    for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
+        auto const& rate = rates[rateIndex];
+        if (rate.eventProbability <= 0 || (rate.sigma <= 0 && rate.probability <= 0)) {
+            continue;
+        }
+
+        for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
+            auto& gene = genome->genes[geneIndex];
+            for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
+                auto& node = gene.nodes[nodeIndex];
+                if (!node.constructorAvailable) {
+                    continue;
+                }
+                if (data.primaryNumberGen.random() >= rate.eventProbability) {
+                    continue;
+                }
+                auto& constructor = node.constructor;
+
+                // Mutate real and integer attributes by a Gaussian step; the clamping mirrors DescValidationService.
+                auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
+                    using ValueType = std::decay_t<decltype(value)>;
+                    if (rate.sigma <= 0) {
+                        return;
+                    }
+                    auto delta = generateGaussian(data) * rate.sigma;
+                    if constexpr (std::is_integral_v<ValueType>) {
+                        auto roundedDelta = static_cast<int>(std::round(delta));
+                        auto newValue = max(static_cast<int>(minValue), min(static_cast<int>(maxValue), static_cast<int>(value) + roundedDelta));
+                        value = static_cast<ValueType>(newValue);
+                        atomicAdd_block(&accumulatedMutations, static_cast<float>(std::abs(roundedDelta)));
+                    } else {
+                        value = max(static_cast<ValueType>(minValue), min(static_cast<ValueType>(maxValue), value + delta));
+                        atomicAdd_block(&accumulatedMutations, std::abs(delta));
+                    }
+                };
+
+                // Same as mutateNumber but only clamped from below (for attributes without an upper bound).
+                auto mutateLowerBoundedNumber = [&](auto& value, auto minValue) {
+                    using ValueType = std::decay_t<decltype(value)>;
+                    if (rate.sigma <= 0) {
+                        return;
+                    }
+                    auto delta = generateGaussian(data) * rate.sigma;
+                    if constexpr (std::is_integral_v<ValueType>) {
+                        auto roundedDelta = static_cast<int>(std::round(delta));
+                        auto newValue = max(static_cast<int>(minValue), static_cast<int>(value) + roundedDelta);
+                        value = static_cast<ValueType>(newValue);
+                        atomicAdd_block(&accumulatedMutations, static_cast<float>(std::abs(roundedDelta)));
+                    } else {
+                        value = max(static_cast<ValueType>(minValue), value + delta);
+                        atomicAdd_block(&accumulatedMutations, std::abs(delta));
+                    }
+                };
+
+                auto mutateBoolField = [&](bool& value) {
+                    if (data.primaryNumberGen.random() < rate.probability) {
+                        value = !value;
+                        atomicAdd_block(&accumulatedMutations, 1.0f);
+                    }
+                };
+
+                auto mutateEnumField = [&](auto& value, int count) {
+                    using ValueType = std::decay_t<decltype(value)>;
+                    if (count > 1 && data.primaryNumberGen.random() < rate.probability) {
+                        auto currentValue = static_cast<int>(value);
+                        auto newValue = data.primaryNumberGen.random(count - 2);
+                        if (newValue >= currentValue) {
+                            ++newValue;
+                        }
+                        value = static_cast<ValueType>(newValue);
+                        atomicAdd_block(&accumulatedMutations, 1.0f);
+                    }
+                };
+
+                // Real and integer attributes (sigma)
+                if (constructor.autoTriggerInterval > 0) {
+                    // Only an already auto-triggering constructor is mutated, so it keeps auto triggering (>= 1).
+                    mutateLowerBoundedNumber(constructor.autoTriggerInterval, 1);
+                }
+                mutateNumber(constructor.geneIndex, 0, max(0, genome->numGenes - 1));
+                mutateNumber(constructor.constructionActivationTime, 0, MAX_ACTIVATION_TIME);
+                mutateNumber(constructor.constructionAngle, -360.0f, 360.0f);
+                mutateLowerBoundedNumber(constructor.reservedEnergy, 0.0f);
+                mutateNumber(constructor.numBranches, 1, 6);
+                if (constructor.numConcatenations != 0x7fffffff) {  // 0x7fffffff encodes infinite concatenations and is left untouched
+                    mutateLowerBoundedNumber(constructor.numConcatenations, 1);
+                }
+
+                // Bool and enum attributes (probability)
+                mutateBoolField(constructor.separation);
+                mutateEnumField(constructor.provideEnergy, ProvideEnergy_Count);
+            }
+        }
+    }
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData& data, Genome* genome)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
@@ -909,6 +1013,16 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (voidMutationSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * voidMutationSigma)); };
             mutateFloat(genome->mutationRates.voidMutation.eventProbability);
+        }
+
+        float constructorSigma = cudaSimulationParameters.metaMutationConstructorSigma.value;
+        if (constructorSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * constructorSigma)); };
+            for (int i = 0; i < 2; ++i) {
+                mutateFloat(genome->mutationRates.constructorMutations[i].eventProbability);
+                mutateFloat(genome->mutationRates.constructorMutations[i].sigma);
+                mutateFloat(genome->mutationRates.constructorMutations[i].probability);
+            }
         }
     }
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -10,6 +10,7 @@
 #include <EngineInterface/NeuralNetWeight.h>
 #include <EngineInterface/SimulationParameters.h>
 
+#include "ConstructorHelper.cuh"
 #include "EntityFactory.cuh"
 #include "SimulationStatistics.cuh"
 
@@ -223,7 +224,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                     if (rate.sigma <= 0) {
                         return;
                     }
-                    auto delta = generateGaussian(data) * rate.sigma;
+                    auto delta = generateGaussian(data) * rate.sigma * (maxValue - minValue);
                     if constexpr (std::is_integral_v<ValueType>) {
                         auto roundedDelta = static_cast<int>(std::round(delta));
                         auto newValue = max(static_cast<int>(minValue), min(static_cast<int>(maxValue), static_cast<int>(value) + roundedDelta));
@@ -873,22 +874,19 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
         for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
             auto& gene = genome->genes[geneIndex];
             for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
-                auto& node = gene.nodes[nodeIndex];
-                if (!node.constructorAvailable) {
-                    continue;
-                }
                 if (data.primaryNumberGen.random() >= rate.eventProbability) {
                     continue;
                 }
+                auto& node = gene.nodes[nodeIndex];
                 auto& constructor = node.constructor;
 
-                // Mutate real and integer attributes by a Gaussian step; the clamping mirrors DescValidationService.
+                // Mutate real and integer attributes by a Gaussian step scaled by the value range; the clamping mirrors DescValidationService.
                 auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
                     using ValueType = std::decay_t<decltype(value)>;
                     if (rate.sigma <= 0) {
                         return;
                     }
-                    auto delta = generateGaussian(data) * rate.sigma;
+                    auto delta = generateGaussian(data) * rate.sigma * (maxValue - minValue);
                     if constexpr (std::is_integral_v<ValueType>) {
                         auto roundedDelta = static_cast<int>(std::round(delta));
                         auto newValue = max(static_cast<int>(minValue), min(static_cast<int>(maxValue), static_cast<int>(value) + roundedDelta));
@@ -900,24 +898,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                     }
                 };
 
-                // Same as mutateNumber but only clamped from below (for attributes without an upper bound).
-                auto mutateLowerBoundedNumber = [&](auto& value, auto minValue) {
-                    using ValueType = std::decay_t<decltype(value)>;
-                    if (rate.sigma <= 0) {
-                        return;
-                    }
-                    auto delta = generateGaussian(data) * rate.sigma;
-                    if constexpr (std::is_integral_v<ValueType>) {
-                        auto roundedDelta = static_cast<int>(std::round(delta));
-                        auto newValue = max(static_cast<int>(minValue), static_cast<int>(value) + roundedDelta);
-                        value = static_cast<ValueType>(newValue);
-                        atomicAdd_block(&accumulatedMutations, static_cast<float>(std::abs(roundedDelta)));
-                    } else {
-                        value = max(static_cast<ValueType>(minValue), value + delta);
-                        atomicAdd_block(&accumulatedMutations, std::abs(delta));
-                    }
-                };
-
                 auto mutateBoolField = [&](bool& value) {
                     if (data.primaryNumberGen.random() < rate.probability) {
                         value = !value;
@@ -925,36 +905,32 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                     }
                 };
 
-                auto mutateEnumField = [&](auto& value, int count) {
-                    using ValueType = std::decay_t<decltype(value)>;
-                    if (count > 1 && data.primaryNumberGen.random() < rate.probability) {
-                        auto currentValue = static_cast<int>(value);
-                        auto newValue = data.primaryNumberGen.random(count - 2);
-                        if (newValue >= currentValue) {
-                            ++newValue;
-                        }
-                        value = static_cast<ValueType>(newValue);
-                        atomicAdd_block(&accumulatedMutations, 1.0f);
+                // Mutate the attributes of an existing constructor (real/integer via sigma, bool via probability).
+                if (node.constructorAvailable) {
+                    if (constructor.autoTriggerInterval > 0) {
+                        // Only an already auto-triggering constructor is mutated, so it keeps auto triggering.
+                        mutateNumber(constructor.autoTriggerInterval, 1, 100);
                     }
-                };
-
-                // Real and integer attributes (sigma)
-                if (constructor.autoTriggerInterval > 0) {
-                    // Only an already auto-triggering constructor is mutated, so it keeps auto triggering (>= 1).
-                    mutateLowerBoundedNumber(constructor.autoTriggerInterval, 1);
-                }
-                mutateNumber(constructor.geneIndex, 0, max(0, genome->numGenes - 1));
-                mutateNumber(constructor.constructionActivationTime, 0, MAX_ACTIVATION_TIME);
-                mutateNumber(constructor.constructionAngle, -360.0f, 360.0f);
-                mutateLowerBoundedNumber(constructor.reservedEnergy, 0.0f);
-                mutateNumber(constructor.numBranches, 1, 6);
-                if (constructor.numConcatenations != 0x7fffffff) {  // 0x7fffffff encodes infinite concatenations and is left untouched
-                    mutateLowerBoundedNumber(constructor.numConcatenations, 1);
+                    mutateNumber(constructor.geneIndex, 0, max(0, genome->numGenes - 1));
+                    mutateNumber(constructor.constructionActivationTime, 0, MAX_ACTIVATION_TIME);
+                    mutateNumber(constructor.constructionAngle, Const::ConstructorConstructionAngle_Min, Const::ConstructorConstructionAngle_Max);
+                    mutateNumber(constructor.reservedEnergy, 0.0f, 300.0f);
+                    mutateNumber(constructor.numBranches, 1, 6);
+                    if (!ConstructorHelper::hasInfiniteConcatenations(constructor)) {
+                        mutateNumber(constructor.numConcatenations, 1, 100);
+                    }
+                    mutateBoolField(constructor.separation);
                 }
 
-                // Bool and enum attributes (probability)
-                mutateBoolField(constructor.separation);
-                mutateEnumField(constructor.provideEnergy, ProvideEnergy_Count);
+                // Mutate whether the node has a constructor at all; enabling one initializes it with default values.
+                bool const wasAvailable = node.constructorAvailable;
+                if (data.primaryNumberGen.random() < rate.probability) {
+                    node.constructorAvailable = !node.constructorAvailable;
+                    atomicAdd_block(&accumulatedMutations, 1.0f);
+                    if (node.constructorAvailable && !wasAvailable) {
+                        constructor = {100, 0, 100, 0.0f, ProvideEnergy_FromConstructor, 0.0f, false, 1, 1};
+                    }
+                }
             }
         }
     }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -910,7 +910,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 if (node.constructorAvailable) {
                     if (constructor.autoTriggerInterval > 0) {
                         // Only an already auto-triggering constructor is mutated, so it keeps auto triggering.
-                        mutateNumber(constructor.autoTriggerInterval, Const::ConstructorAutoTriggerInterval_Min, Const::ConstructorAutoTriggerInterval_Max);
+                        mutateNumber(constructor.autoTriggerInterval, Const::ConstructorAutoTriggerInterval_Min, Const::ConstructorAutoTriggerInterval_Min + 100);
                     }
                     mutateNumber(constructor.geneIndex, 0, max(0, genome->numGenes - 1));
                     mutateNumber(

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -31,6 +31,7 @@ private:
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
+
     __inline__ __device__ static void resetCellTypeModeToDefault(Node& node);
     __inline__ __device__ static void resetCellTypeToDefault(Node& node);
 
@@ -923,7 +924,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 }
 
                 // Mutate whether the node has a constructor at all; enabling one initializes it with default values.
-                bool const wasAvailable = node.constructorAvailable;
+                bool wasAvailable = node.constructorAvailable;
                 if (data.primaryNumberGen.random() < rate.probability) {
                     node.constructorAvailable = !node.constructorAvailable;
                     atomicAdd_block(&accumulatedMutations, 1.0f);

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -910,10 +910,13 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 if (node.constructorAvailable) {
                     if (constructor.autoTriggerInterval > 0) {
                         // Only an already auto-triggering constructor is mutated, so it keeps auto triggering.
-                        mutateNumber(constructor.autoTriggerInterval, 1, 100);
+                        mutateNumber(constructor.autoTriggerInterval, Const::ConstructorAutoTriggerInterval_Min, Const::ConstructorAutoTriggerInterval_Max);
                     }
                     mutateNumber(constructor.geneIndex, 0, max(0, genome->numGenes - 1));
-                    mutateNumber(constructor.constructionActivationTime, 0, MAX_ACTIVATION_TIME);
+                    mutateNumber(
+                        constructor.constructionActivationTime,
+                        Const::ConstructorConstructionActivationTime_Min,
+                        Const::ConstructorConstructionActivationTime_Max);
                     mutateNumber(constructor.constructionAngle, Const::ConstructorConstructionAngle_Min, Const::ConstructorConstructionAngle_Max);
                     mutateNumber(constructor.reservedEnergy, 0.0f, 300.0f);
                     mutateNumber(constructor.numBranches, 1, 6);
@@ -929,7 +932,11 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                     node.constructorAvailable = !node.constructorAvailable;
                     atomicAdd_block(&accumulatedMutations, 1.0f);
                     if (node.constructorAvailable && !wasAvailable) {
-                        constructor = {100, 0, 100, 0.0f, ProvideEnergy_FromConstructor, 0.0f, false, 1, 1};
+                        constructor = {};
+                        constructor.autoTriggerInterval = Const::ConstructorAutoTriggerInterval_Default;
+                        constructor.constructionActivationTime = Const::ConstructorConstructionActivationTime_Default;
+                        constructor.numBranches = 1;
+                        constructor.numConcatenations = 1;
                     }
                 }
             }

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -183,7 +183,10 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                              CellTypePropertiesMutationDesc().eventProbability(0.75f).sigma(0.85f).probability(0.95f)})
                         .cellTypeModeMutation(CellTypeModeMutationDesc().eventProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().eventProbability(0.22f))
-                        .voidMutation(VoidMutationDesc().eventProbability(0.11f));
+                        .voidMutation(VoidMutationDesc().eventProbability(0.11f))
+                        .constructorMutations(
+                            {ConstructorMutationDesc().eventProbability(0.12f).sigma(0.13f).probability(0.14f),
+                             ConstructorMutationDesc().eventProbability(0.16f).sigma(0.17f).probability(0.18f)});
 
     auto genome = GenomeDesc()
                       .name("Test Genome")

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -16,7 +16,8 @@ enum class MutationType
     CellTypeProperties,
     CellTypeMode,
     CellType,
-    Void
+    Void,
+    Constructor
 };
 
 class AccumulatedMutationTests_AllTypes
@@ -34,7 +35,8 @@ INSTANTIATE_TEST_SUITE_P(
         MutationType::CellTypeProperties,
         MutationType::CellTypeMode,
         MutationType::CellType,
-        MutationType::Void));
+        MutationType::Void,
+        MutationType::Constructor));
 
 TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
 {
@@ -58,6 +60,9 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::Void:
         genome._mutationRates._voidMutation = VoidMutationDesc().eventProbability(1.0f);
+        break;
+    case MutationType::Constructor:
+        genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
         break;
     }
 
@@ -88,6 +93,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
     _parameters.metaMutationCellTypeSigma.value = 1.0f;
     _parameters.metaMutationVoidSigma.value = 1.0f;
+    _parameters.metaMutationConstructorSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -10,6 +10,7 @@ PUBLIC
     CellTypePropertiesMutationTests.cpp
     CommunicatorTests.cpp
     ConnectionMutationTests.cpp
+    ConstructorMutationTests.cpp
     ConstructorTests.cpp
     CreatureTests.cpp
     DataTransferTests.cpp

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -30,49 +30,10 @@ protected:
     }
 };
 
-TEST_F(ConstructorMutationTests, constructorMutation_changesScalarProperties)
+TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttributes)
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_mutate(1);
-
-    auto actualGenome = getMutatedGenome();
-
-    auto const& originalConstructor = genome._genes.at(0)._nodes.at(0)._constructor;
-    auto const& actualConstructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
-    ASSERT_TRUE(originalConstructor.has_value());
-    ASSERT_TRUE(actualConstructor.has_value());
-    EXPECT_NE(originalConstructor->_constructionAngle, actualConstructor->_constructionAngle);
-}
-
-TEST_F(ConstructorMutationTests, constructorMutation_changesBoolAndEnumProperties)
-{
-    auto genome = createTestGenome();
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).probability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_mutate(1);
-
-    auto actualGenome = getMutatedGenome();
-
-    auto const& originalConstructor = genome._genes.at(0)._nodes.at(0)._constructor;
-    auto const& actualConstructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
-    ASSERT_TRUE(originalConstructor.has_value());
-    ASSERT_TRUE(actualConstructor.has_value());
-    EXPECT_NE(originalConstructor->_separation, actualConstructor->_separation);
-    EXPECT_NE(originalConstructor->_provideEnergy, actualConstructor->_provideEnergy);
-}
-
-TEST_F(ConstructorMutationTests, constructorMutation_keepsValidGeneIndex)
-{
-    auto genome = createTestGenome();
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -82,19 +43,49 @@ TEST_F(ConstructorMutationTests, constructorMutation_keepsValidGeneIndex)
     }
 
     auto actualGenome = getMutatedGenome();
-    auto numGenes = static_cast<int>(actualGenome._genes.size());
+    auto const numGenes = static_cast<int>(actualGenome._genes.size());
+
+    auto const& originalConstructor = genome._genes.at(0)._nodes.at(0)._constructor;
+    auto const& actualConstructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
+    ASSERT_TRUE(originalConstructor.has_value());
+    ASSERT_TRUE(actualConstructor.has_value());
+    EXPECT_NE(originalConstructor->_constructionAngle, actualConstructor->_constructionAngle);
+
+    // All mutated constructors must stay within their valid ranges.
     for (auto const& gene : actualGenome._genes) {
         for (auto const& node : gene._nodes) {
             if (node._constructor.has_value()) {
-                EXPECT_GE(node._constructor->_geneIndex, 0);
-                EXPECT_LT(node._constructor->_geneIndex, numGenes);
-                EXPECT_GE(node._constructor->_numBranches, 1);
-                EXPECT_LE(node._constructor->_numBranches, 6);
-                EXPECT_GE(node._constructor->_reservedEnergy, 0.0f);
-                EXPECT_GE(node._constructor->_numConcatenations, 1);
+                auto const& constructor = node._constructor.value();
+                EXPECT_GE(constructor._geneIndex, 0);
+                EXPECT_LT(constructor._geneIndex, numGenes);
+                EXPECT_GE(constructor._numBranches, 1);
+                EXPECT_LE(constructor._numBranches, 6);
+                EXPECT_GE(constructor._reservedEnergy, 0.0f);
+                EXPECT_GE(constructor._numConcatenations, 1);
+                EXPECT_GE(constructor._constructionAngle, Const::ConstructorConstructionAngle_Min);
+                EXPECT_LE(constructor._constructionAngle, Const::ConstructorConstructionAngle_Max);
             }
         }
     }
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultValues)
+{
+    auto genome = createTestGenome();
+    genome._genes.at(0)._nodes.at(0)._constructor.reset();  // node without a constructor
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+
+    // The node had no constructor, so turning it on must initialize it with default values.
+    auto const& constructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
+    ASSERT_TRUE(constructor.has_value());
+    EXPECT_TRUE(constructor.value() == ConstructorGenomeDesc());
 }
 
 TEST_F(ConstructorMutationTests, constructorMutation_doesNotChangeOtherAttributes)

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -1,0 +1,132 @@
+#include <optional>
+
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class ConstructorMutationTests : public MutationTestsBase
+{
+protected:
+    // Resets the optional constructor of every node so that two genomes can be compared ignoring constructor attributes.
+    bool compareAllExceptConstructor(GenomeDesc expected, GenomeDesc actual)
+    {
+        auto reset = [](GenomeDesc& genome) {
+            genome._lineageId = 0;
+            genome._prevLineageId = std::nullopt;
+            genome._accumulatedMutations = 0.0f;
+            for (auto& gene : genome._genes) {
+                for (auto& node : gene._nodes) {
+                    node._constructor.reset();
+                }
+            }
+        };
+        reset(expected);
+        reset(actual);
+        return expected == actual;
+    }
+};
+
+TEST_F(ConstructorMutationTests, constructorMutation_changesScalarProperties)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+
+    auto const& originalConstructor = genome._genes.at(0)._nodes.at(0)._constructor;
+    auto const& actualConstructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
+    ASSERT_TRUE(originalConstructor.has_value());
+    ASSERT_TRUE(actualConstructor.has_value());
+    EXPECT_NE(originalConstructor->_constructionAngle, actualConstructor->_constructionAngle);
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_changesBoolAndEnumProperties)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+
+    auto const& originalConstructor = genome._genes.at(0)._nodes.at(0)._constructor;
+    auto const& actualConstructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
+    ASSERT_TRUE(originalConstructor.has_value());
+    ASSERT_TRUE(actualConstructor.has_value());
+    EXPECT_NE(originalConstructor->_separation, actualConstructor->_separation);
+    EXPECT_NE(originalConstructor->_provideEnergy, actualConstructor->_provideEnergy);
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_keepsValidGeneIndex)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    auto numGenes = static_cast<int>(actualGenome._genes.size());
+    for (auto const& gene : actualGenome._genes) {
+        for (auto const& node : gene._nodes) {
+            if (node._constructor.has_value()) {
+                EXPECT_GE(node._constructor->_geneIndex, 0);
+                EXPECT_LT(node._constructor->_geneIndex, numGenes);
+                EXPECT_GE(node._constructor->_numBranches, 1);
+                EXPECT_LE(node._constructor->_numBranches, 6);
+                EXPECT_GE(node._constructor->_reservedEnergy, 0.0f);
+                EXPECT_GE(node._constructor->_numConcatenations, 1);
+            }
+        }
+    }
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_doesNotChangeOtherAttributes)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
+    genome._mutationRates._constructorMutations[1] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    EXPECT_TRUE(compareAllExceptConstructor(genome, actualGenome));
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(0.0f).sigma(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -32,15 +32,13 @@ protected:
 
 TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttributes)
 {
-    auto genome = createTestGenome();
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f);
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc())})});
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(0.0f); 
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
     auto const numGenes = static_cast<int>(actualGenome._genes.size());
@@ -50,23 +48,22 @@ TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttribute
     ASSERT_TRUE(originalConstructor.has_value());
     ASSERT_TRUE(actualConstructor.has_value());
     EXPECT_NE(originalConstructor->_constructionAngle, actualConstructor->_constructionAngle);
+    EXPECT_NE(originalConstructor->_reservedEnergy, actualConstructor->_reservedEnergy);
 
     // All mutated constructors must stay within their valid ranges.
-    for (auto const& gene : actualGenome._genes) {
-        for (auto const& node : gene._nodes) {
-            if (node._constructor.has_value()) {
-                auto const& constructor = node._constructor.value();
-                EXPECT_GE(constructor._geneIndex, 0);
-                EXPECT_LT(constructor._geneIndex, numGenes);
-                EXPECT_GE(constructor._numBranches, 1);
-                EXPECT_LE(constructor._numBranches, 6);
-                EXPECT_GE(constructor._reservedEnergy, 0.0f);
-                EXPECT_GE(constructor._numConcatenations, 1);
-                EXPECT_GE(constructor._constructionAngle, Const::ConstructorConstructionAngle_Min);
-                EXPECT_LE(constructor._constructionAngle, Const::ConstructorConstructionAngle_Max);
-            }
-        }
+    if (originalConstructor->_autoTriggerInterval.has_value()) {
+        EXPECT_GE(originalConstructor->_autoTriggerInterval.value(), Const::ConstructorConstructionAngle_Min);
     }
+    EXPECT_GE(originalConstructor->_geneIndex, 0);
+    EXPECT_LT(originalConstructor->_geneIndex, numGenes);
+    EXPECT_GE(originalConstructor->_numBranches, 1);
+    EXPECT_LE(originalConstructor->_numBranches, 6);
+    EXPECT_GE(originalConstructor->_reservedEnergy, 0.0f);
+    EXPECT_GE(originalConstructor->_numConcatenations, 1);
+    EXPECT_GE(originalConstructor->_constructionAngle, Const::ConstructorConstructionAngle_Min);
+    EXPECT_LE(originalConstructor->_constructionAngle, Const::ConstructorConstructionAngle_Max);
+    EXPECT_GE(originalConstructor->_constructionActivationTime, Const::ConstructorConstructionActivationTime_Min);
+    EXPECT_LE(originalConstructor->_constructionActivationTime, Const::ConstructorConstructionActivationTime_Max);
 }
 
 TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultValues)
@@ -88,7 +85,23 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
     EXPECT_TRUE(constructor.value() == ConstructorGenomeDesc());
 }
 
-TEST_F(ConstructorMutationTests, constructorMutation_doesNotChangeOtherAttributes)
+TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(0.0f).sigma(1.0f).probability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}
+
+TEST_F(ConstructorMutationTests, constructorMutation_keepOtherAttributesUnchanged)
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(1.0f).sigma(1.0f).probability(1.0f);
@@ -104,20 +117,4 @@ TEST_F(ConstructorMutationTests, constructorMutation_doesNotChangeOtherAttribute
     auto actualGenome = getMutatedGenome();
 
     EXPECT_TRUE(compareAllExceptConstructor(genome, actualGenome));
-}
-
-TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)
-{
-    auto genome = createTestGenome();
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(0.0f).sigma(1.0f).probability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
-
-    auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome, genome);
 }

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -312,3 +312,61 @@ TEST_F(MetaMutationTests, metaMutation_voidRatesZeroSigmaNoChange)
     auto actualGenome = getMutatedGenome();
     EXPECT_EQ(actualGenome._mutationRates._voidMutation._eventProbability, 0.5f);
 }
+
+TEST_F(MetaMutationTests, metaMutation_constructorRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(0.5f).sigma(0.5f).probability(0.5f);
+    genome._mutationRates._constructorMutations[1] = ConstructorMutationDesc().eventProbability(0.4f).sigma(0.4f).probability(0.4f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationConstructorSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    bool anyChanged = actualGenome._mutationRates._constructorMutations[0]._eventProbability != 0.5f
+        || actualGenome._mutationRates._constructorMutations[0]._sigma != 0.5f
+        || actualGenome._mutationRates._constructorMutations[0]._probability != 0.5f
+        || actualGenome._mutationRates._constructorMutations[1]._eventProbability != 0.4f
+        || actualGenome._mutationRates._constructorMutations[1]._sigma != 0.4f
+        || actualGenome._mutationRates._constructorMutations[1]._probability != 0.4f;
+    EXPECT_TRUE(anyChanged);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._eventProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._sigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._probability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._eventProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._sigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._probability, 0.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_constructorRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().eventProbability(0.5f).sigma(0.5f).probability(0.5f);
+    genome._mutationRates._constructorMutations[1] = ConstructorMutationDesc().eventProbability(0.4f).sigma(0.4f).probability(0.4f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationConstructorSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._eventProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._sigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._probability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._eventProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._sigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._probability, 0.4f);
+}

--- a/source/Gui/MutationRateDialog.cpp
+++ b/source/Gui/MutationRateDialog.cpp
@@ -140,6 +140,29 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    void processConstructorMutationRate(std::string const& name, std::string const& id, ConstructorMutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Event probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._eventProbability);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters().name("Sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._sigma);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters().name("Probability").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.5f").textWidth(rightColumnWidth),
+                &mutation._probability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     template <typename Func>
     void processConcreteMutationRates(Func&& processMutationRates)
     {
@@ -203,6 +226,18 @@ void MutationRateDialog::loadSettings(MutationRatesDesc& mutationRates, std::str
         settings.getValue(settingsPrefix + "cell type mutation.probability", mutationRates._cellTypeMutation._eventProbability);
     mutationRates._voidMutation._eventProbability =
         settings.getValue(settingsPrefix + "void mutation.probability", mutationRates._voidMutation._eventProbability);
+    mutationRates._constructorMutations[0]._eventProbability =
+        settings.getValue(settingsPrefix + "constructor mutation.probability", mutationRates._constructorMutations[0]._eventProbability);
+    mutationRates._constructorMutations[0]._sigma =
+        settings.getValue(settingsPrefix + "constructor mutation.sigma", mutationRates._constructorMutations[0]._sigma);
+    mutationRates._constructorMutations[0]._probability =
+        settings.getValue(settingsPrefix + "constructor mutation.value probability", mutationRates._constructorMutations[0]._probability);
+    mutationRates._constructorMutations[1]._eventProbability =
+        settings.getValue(settingsPrefix + "constructor mutation 2.probability", mutationRates._constructorMutations[1]._eventProbability);
+    mutationRates._constructorMutations[1]._sigma =
+        settings.getValue(settingsPrefix + "constructor mutation 2.sigma", mutationRates._constructorMutations[1]._sigma);
+    mutationRates._constructorMutations[1]._probability =
+        settings.getValue(settingsPrefix + "constructor mutation 2.value probability", mutationRates._constructorMutations[1]._probability);
 }
 
 void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, std::string const& settingsPrefix) const
@@ -232,6 +267,12 @@ void MutationRateDialog::saveSettings(MutationRatesDesc const& mutationRates, st
     settings.setValue(settingsPrefix + "cell type mode mutation.probability", mutationRates._cellTypeModeMutation._eventProbability);
     settings.setValue(settingsPrefix + "cell type mutation.probability", mutationRates._cellTypeMutation._eventProbability);
     settings.setValue(settingsPrefix + "void mutation.probability", mutationRates._voidMutation._eventProbability);
+    settings.setValue(settingsPrefix + "constructor mutation.probability", mutationRates._constructorMutations[0]._eventProbability);
+    settings.setValue(settingsPrefix + "constructor mutation.sigma", mutationRates._constructorMutations[0]._sigma);
+    settings.setValue(settingsPrefix + "constructor mutation.value probability", mutationRates._constructorMutations[0]._probability);
+    settings.setValue(settingsPrefix + "constructor mutation 2.probability", mutationRates._constructorMutations[1]._eventProbability);
+    settings.setValue(settingsPrefix + "constructor mutation 2.sigma", mutationRates._constructorMutations[1]._sigma);
+    settings.setValue(settingsPrefix + "constructor mutation 2.value probability", mutationRates._constructorMutations[1]._probability);
 }
 
 void MutationRateDialog::processIntern()
@@ -290,6 +331,16 @@ void MutationRateDialog::processIntern()
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Void mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
                 processVoidMutationRate("Mutation rate", "VM", _mutation._voidMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Constructor mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processConstructorMutationRate("Mutation rate 1", "COM1", _mutation._constructorMutations[0], rightColumnWidth);
+                table.next();
+                processConstructorMutationRate("Mutation rate 2", "COM2", _mutation._constructorMutations[1], rightColumnWidth);
                 table.next();
             });
         }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -306,6 +306,10 @@ namespace
 
     auto constexpr Id_VoidMutation_EventProbability = 0;
 
+    auto constexpr Id_ConstructorMutation_EventProbability = 0;
+    auto constexpr Id_ConstructorMutation_Sigma = 1;
+    auto constexpr Id_ConstructorMutation_Probability = 2;
+
     auto constexpr Id_Gene_Name = 0;
     auto constexpr Id_Gene_Shape = 1;
     auto constexpr Id_Gene_Stiffness = 5;
@@ -431,6 +435,8 @@ namespace
     auto constexpr Id_MutationRates_CellTypeModeMutation = 7;
     auto constexpr Id_MutationRates_CellTypeMutation = 8;
     auto constexpr Id_MutationRates_VoidMutation = 9;
+    auto constexpr Id_MutationRates_ConstructorMutation1 = 10;
+    auto constexpr Id_MutationRates_ConstructorMutation2 = 11;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -932,6 +938,17 @@ namespace cereal
     SPLIT_SERIALIZATION(VoidMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, ConstructorMutationDesc& data)
+    {
+        ConstructorMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_ConstructorMutation_EventProbability, data._eventProbability, defaultObject._eventProbability);
+        scope.addMember(Id_ConstructorMutation_Sigma, data._sigma, defaultObject._sigma);
+        scope.addMember(Id_ConstructorMutation_Probability, data._probability, defaultObject._probability);
+    }
+    SPLIT_SERIALIZATION(ConstructorMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, MutationRatesDesc& data)
     {
         MutationRatesDesc defaultObject;
@@ -945,6 +962,8 @@ namespace cereal
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);
+        scope.addDesc(Id_MutationRates_ConstructorMutation1, data._constructorMutations[0]);
+        scope.addDesc(Id_MutationRates_ConstructorMutation2, data._constructorMutations[1]);
     }
     SPLIT_SERIALIZATION(MutationRatesDesc)
 


### PR DESCRIPTION
## Summary
- Add a new `ConstructorMutation` mutation type (with `eventProbability`, `sigma`, `probability`), modeled on `CellTypePropertiesMutation` and held as two instances in `MutationRates`/`MutationRatesTO`/`MutationRatesDesc`.
- Mutation logic in `MutationProcessor::applyMutations_constructor`: for each node with a constructor, with the given `eventProbability`, real/int constructor attributes (auto trigger interval, gene index, construction activation time, construction angle, reserved energy, number of branches, concatenations) are mutated via `sigma`, and bool/enum attributes (separation, provide-energy) via `probability`. Clamping mirrors `DescValidationService`, so the genome stays valid; `accumulatedMutations` is increased per change (globally normalized by node count as for the other types). Auto-trigger constructors keep auto triggering and the infinite-concatenations sentinel is left untouched.
- Meta mutation: `MutationProcessor::applyMutations_meta` now evaluates the new simulation parameter `metaMutationConstructorSigma`.
- Threaded the new type through data transfer (`DescConverterService`, `DataAccessKernels`, `EntityFactory`), serialization (`SerializerService`), hashing (`GenomeDescHash`), validation (`DescValidationService`), active-type listing (`GenomeDesc`), test data (`DescTestDataFactory`), and the GUI (`MutationRateDialog`).
- Tests: new `ConstructorMutationTests` (scalar, bool/enum, valid-range, isolation, zero-probability) plus constructor cases in `MetaMutationTests` and `AccumulatedMutationTests`, in the same spirit as the `CellTypePropertiesMutation` tests.

## Original task
There are currently several types of mutations (see MutationRates) like NeuronMutation, ConnectionMutation, CellTypeProperties, CellTypeModeMutations, ...
The task is to add a new mutation type called `ConstructorMutation`. It should contain the field `eventProbability`, `sigma` (for real values and int values not used as enums), `probability` (for bool or enums). See CellTypePropertiesMutation for similar fields.
- Extend MutationRates, MutationRatesTO and MutationRatesDesc (it has 2 instances like CellTypePropertiesMutation).
- Adapt data transfer: DescConverterService, SerializerService, EntityFactory, DataAccessKernels, DescTestDataFactory
- MutationRateDialog
- Add simulation parameter `metaMutationConstructorSigma`
- Implement the main mutation logic to MutationProcessor: for ConstructorMutation and for the meta mutation (governed by metaMutationConstructorSigma)
  - for ConstructorMutation: it changes the fields of the constructor for a node with the given eventProbability. Real and int attributes are mutated according to sigma and bool or enums according to `probability`. See CellTypePropertiesMutation for orientation. The genome must be validated and corrected after mutations. The accumulatedMutations must also be increased (and normalized by the number of elements where to mutate)
  - for meta mutations: extend MutationProcessor::applyMutations_meta by evaluating the new parameter metaMutationConstructorSigma
  - Write test in the same spirit as for CellTypePropertiesMutation.

## Build and tests
- `cmake --build build --config Release -j32`: passed (clean rebuild required once because the `SimulationParameters` constant-memory struct changed size)
- `./EngineInterfaceTests`: passed (154 tests)
- `./NetworkTests`: passed (4 tests)
- `./PersisterTests`: passed (64 tests)
- `./EngineTests`: passed (3020 passed, 3 pre-existing unrelated skips in `ConstructorTests_ProvideEnergy`)
- `./cli --help`: passed

## Notes
- The new mutation is implemented to keep the genome valid by construction: each numeric attribute is clamped to the same range enforced by `DescValidationService` (e.g. gene index within the gene count, branches in [1, 6], lower-bounded reserved energy/concatenations), so no separate post-mutation validation pass is needed, mirroring the existing `CellTypePropertiesMutation` approach.
- Only constructor nodes (`constructorAvailable`) are affected.