### PR TITLE
Use Ninja preset for Windows CI build

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -40,10 +40,12 @@ jobs:
         .\bootstrap-vcpkg.bat -disableMetrics
         Pop-Location
 
-    - name: Configure CMake
-      shell: pwsh
-      run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="external\vcpkg\scripts\buildsystems\vcpkg.cmake" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CUDA_COMPILER=nvcc
-
-    - name: Build
-      shell: pwsh
-      run: cmake --build build -j32
+    # Build with the "Ninja Multi-Config" preset instead of the default Visual
+    # Studio generator. Ninja compiles all CUDA translation units in parallel
+    # (file-level), which is considerably faster than MSVC building the CUDA
+    # libraries one project after another. The build-windows-ninja.bat script
+    # sets up the MSVC environment, puts Ninja/CMake on PATH and runs the
+    # ninja preset (see CMakePresets.json).
+    - name: Build (Ninja)
+      shell: cmd
+      run: build-windows-ninja.bat ${{ env.BUILD_TYPE }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -40,12 +40,6 @@ jobs:
         .\bootstrap-vcpkg.bat -disableMetrics
         Pop-Location
 
-    # Build with the "Ninja Multi-Config" preset instead of the default Visual
-    # Studio generator. Ninja compiles all CUDA translation units in parallel
-    # (file-level), which is considerably faster than MSVC building the CUDA
-    # libraries one project after another. The build-windows-ninja.bat script
-    # sets up the MSVC environment, puts Ninja/CMake on PATH and runs the
-    # ninja preset (see CMakePresets.json).
     - name: Build (Ninja)
       shell: cmd
       run: build-windows-ninja.bat ${{ env.BUILD_TYPE }}


### PR DESCRIPTION
## Summary

Switch the Windows CI build from the default Visual Studio generator to the **Ninja Multi-Config** preset to speed up compilation.

The Visual Studio generator builds the CUDA libraries one project after another, whereas Ninja compiles all CUDA translation units in parallel (file-level), which is considerably faster.

## Changes

- Replaced the separate *Configure CMake* and *Build* steps in `.github/workflows/windows-ci.yml` with a single step that runs the existing, tested `build-windows-ninja.bat`.
- The script encapsulates exactly the ninja-preset workflow: it sets up the MSVC environment via `vcvars64.bat` (required for Ninja), puts Ninja/CMake on `PATH`, and runs `cmake --preset ninja` + `cmake --build --preset ninja-release` (see `CMakePresets.json`).
- The vcpkg unshallow/bootstrap steps are unchanged; the vcpkg toolchain now comes from the preset instead of a manual `-DCMAKE_TOOLCHAIN_FILE`. `nvcc` is still auto-detected from `PATH`.

## Notes

- The build output directory changes from `build/` to `build-ninja/`. No later workflow steps depend on `build/`, so this is harmless.
- `BUILD_TYPE: Release` maps to the `ninja-release` build preset (`Debug` would map to `ninja-debug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)