### PR TITLE
Limit CI build threads to half of available cores

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -64,7 +64,7 @@ jobs:
         -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
 
     - name: Build
-      run: cmake --build build -j32
+      run: cmake --build build -j$(( $(nproc) / 2 ))
       
     - name: Run Tests
       run: |


### PR DESCRIPTION
## Summary
- The Ubuntu CI build step used a hardcoded `-j32`, fully saturating the self-hosted runner and leaving no headroom for other work on the machine.
- Replaced it with `-j$(( $(nproc) / 2 ))` so the build uses only half of the runner's available threads (16 of 32 on the current host).

## Notes
- `$(nproc)` adapts automatically if the runner hardware changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)