### PR TITLE
Add resistanceToInjection genome field

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -870,6 +870,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._prevLineageId = genomeTO.prevLineageId != 0 ? std::make_optional(genomeTO.prevLineageId) : std::nullopt;
     result._frontAngle = genomeTO.frontAngle;
     result._accumulatedMutations = genomeTO.accumulatedMutations;
+    result._resistanceToInjection = genomeTO.resistanceToInjection;
     for (int i = 0; i < 2; ++i) {
         result._mutationRates._neuronMutations[i]._nodeProbability = genomeTO.mutationRates.neuronMutations[i].nodeProbability;
         result._mutationRates._neuronMutations[i]._weightSigma = genomeTO.mutationRates.neuronMutations[i].weightSigma;
@@ -963,6 +964,7 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.prevLineageId = genome._prevLineageId.value_or(0);
     genomeTO.frontAngle = genome._frontAngle;
     genomeTO.accumulatedMutations = genome._accumulatedMutations;
+    genomeTO.resistanceToInjection = genome._resistanceToInjection;
     for (int i = 0; i < 2; ++i) {
         genomeTO.mutationRates.neuronMutations[i] = {
             genome._mutationRates._neuronMutations[i]._nodeProbability,

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -503,6 +503,7 @@ struct GenomeDesc
     MEMBER(GenomeDesc, std::optional<int>, prevLineageId, std::nullopt);
     MEMBER(GenomeDesc, float, frontAngle, 0.0f);
     MEMBER(GenomeDesc, float, accumulatedMutations, 0.0f);
+    MEMBER(GenomeDesc, bool, resistanceToInjection, false);
 
     MEMBER(GenomeDesc, MutationRatesDesc, mutationRates, MutationRatesDesc());
 };

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -541,6 +541,7 @@ struct std::hash<GenomeDesc>
         }
         hash_combine(seed, desc._frontAngle);
         hash_combine(seed, desc._accumulatedMutations);
+        hash_combine(seed, desc._resistanceToInjection);
         hash_combine(seed, desc._prevLineageId);
         for (int i = 0; i < 2; ++i) {
             hash_combine(seed, desc._mutationRates._neuronMutations[i]._nodeProbability);

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -35,6 +35,7 @@ namespace
             genomeTO.prevLineageId = genome->prevLineageId;
             genomeTO.frontAngle = genome->frontAngle;
             genomeTO.accumulatedMutations = genome->accumulatedMutations;
+            genomeTO.resistanceToInjection = genome->resistanceToInjection;
             for (int i = 0; i < 2; ++i) {
                 genomeTO.mutationRates.neuronMutations[i] = {
                     genome->mutationRates.neuronMutations[i].nodeProbability,

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -90,6 +90,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->prevLineageId = genomeTO.prevLineageId;
     genome->frontAngle = genomeTO.frontAngle;
     genome->accumulatedMutations = genomeTO.accumulatedMutations;
+    genome->resistanceToInjection = genomeTO.resistanceToInjection;
     for (int i = 0; i < 2; ++i) {
         genome->mutationRates.neuronMutations[i] = {
             genomeTO.mutationRates.neuronMutations[i].nodeProbability,

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -405,6 +405,7 @@ struct Genome
     uint32_t prevLineageId;
     float frontAngle;
     float accumulatedMutations;
+    bool resistanceToInjection;
     MutationRates mutationRates;
 
     // Temporary data

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -410,6 +410,7 @@ struct GenomeTO
     uint32_t prevLineageId;
     float frontAngle;
     float accumulatedMutations;
+    bool resistanceToInjection;
     MutationRatesTO mutationRates;
 
     // Temporary data

--- a/source/EngineKernels/InjectorProcessor.cuh
+++ b/source/EngineKernels/InjectorProcessor.cuh
@@ -50,6 +50,9 @@ __inline__ __device__ void InjectorProcessor::processCell(SimulationData& data, 
                 if (!otherObject->typeData.cell.constructorAvailable) {
                     return;
                 }
+                if (otherObject->typeData.cell.creature->genome->resistanceToInjection) {
+                    return;
+                }
                 // Only inject to other cells which are in a visible cone with respect to the injector cell
                 if (ObjectConnectionProcessor::existsOwnIntersectingObjectInBetween(data, object, otherObject)) {
                     return;

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -195,6 +195,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                       .prevLineageId(501)
                       .frontAngle(270.0f)
                       .accumulatedMutations(0.05f)
+                      .resistanceToInjection(true)
                       .mutationRates(mutation)
                       .genes({
                           GeneDesc()

--- a/source/EngineTests/InjectorTests.cpp
+++ b/source/EngineTests/InjectorTests.cpp
@@ -232,3 +232,38 @@ TEST_F(InjectorTests, injectionResetsConstructionProgress)
     // Construction progress should be reset
     EXPECT_FALSE(actualConstructor._lastConstructedCellId.has_value());
 }
+
+/**
+ * Test: No injection on creatures resistant to injection
+ * Cells of a creature whose genome has resistanceToInjection enabled should not be injected
+ */
+TEST_F(InjectorTests, noInjectionOnResistantCreature)
+{
+    // Create injector with geneIndex=2
+    auto data = createInjectorWithGenerator({100.0f, 100.0f}, 2);
+
+    // Add target creature within injection radius whose genome resists injection
+    data.addCreature(
+        {
+            ObjectDesc().id(100).pos({100.0f, 103.0f}).type(CellDesc().constructor(ConstructorDesc().geneIndex(0))),
+            ObjectDesc().id(101).pos({101.0f, 103.0f}),
+        },
+        CreatureDesc().id(2),
+        GenomeDesc().id(2).resistanceToInjection(true));
+    data.addConnection(100, 101);
+
+    auto origConstructor = data.getObjectRef(100).getCellRef()._constructor.value();
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->calcTimesteps(4 * TIMESTEPS_PER_CELL_FUNCTION);
+
+    auto actualData = _simulationFacade->getSimulationData();
+    auto actualInjector = actualData.getObjectRef(1);
+    auto actualConstructor = actualData.getObjectRef(100).getCellRef()._constructor.value();
+
+    // Constructor's geneIndex should remain unchanged because the creature resists injection
+    EXPECT_EQ(origConstructor._geneIndex, actualConstructor._geneIndex);
+
+    // Injector should report failure
+    EXPECT_TRUE(approxCompare(0.0f, actualInjector.getCellRef()._signal._channels[Channels::InjectorSuccess]));
+}

--- a/source/Gui/GenomeEditorWidget.cpp
+++ b/source/Gui/GenomeEditorWidget.cpp
@@ -90,6 +90,13 @@ void _GenomeEditorWidget::processHeaderData()
                 AlienGui::SliderFloatParameters().name("Front angle").format("%.1f").min(-180.0f).max(180.0f).textWidth(rightColumnWidth),
                 &_editData->genome._frontAngle);
 
+            AlienGui::Checkbox(
+                AlienGui::CheckboxParameters()
+                    .name("Resistance to injection")
+                    .textWidth(rightColumnWidth)
+                    .tooltip("If enabled, no cell of a creature with this genome can be injected by a hostile injector."),
+                _editData->genome._resistanceToInjection);
+
             table.next();
 
             AlienGui::Group(AlienGui::GroupParameters().text("Mutation rates"));

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -553,6 +553,7 @@ void _InspectionWindow::processCreatureNode(ExtendedObjectDesc& extendedObject)
             inspectorText("Front angle", frontAngle.str());
             inspectorText("Genome name", genome._name);
             inspectorText("Lineage id", std::to_string(genome._lineageId));
+            inspectorText("Resistance to injection", genome._resistanceToInjection ? "Yes" : "No");
             if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Edit genome").textWidth(TextWidth))) {
                 GenomeEditorWindow::get().openTab(genome, false);
             }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -287,6 +287,7 @@ namespace
     auto constexpr Id_Genome_LineageId = 3;
     auto constexpr Id_Genome_AccumulatedMutations = 4;
     auto constexpr Id_Genome_PrevLineageId = 5;
+    auto constexpr Id_Genome_ResistanceToInjection = 6;
 
     auto constexpr Id_NeuronMutation_NodeProbability = 0;
     auto constexpr Id_NeuronMutation_WeightSigma = 1;
@@ -978,6 +979,7 @@ namespace cereal
         scope.addMember(Id_Genome_AccumulatedMutations, data._accumulatedMutations, defaultObject._accumulatedMutations);
         scope.addMember(Id_Genome_PrevLineageId, data._prevLineageId, defaultObject._prevLineageId);
         scope.addMember(Id_Genome_FrontAngle, data._frontAngle, defaultObject._frontAngle);
+        scope.addMember(Id_Genome_ResistanceToInjection, data._resistanceToInjection, defaultObject._resistanceToInjection);
         scope.addDesc(Id_Genome_Genes, data._genes);
         scope.addDesc(Id_Genome_MutationRates, data._mutationRates);
     }


### PR DESCRIPTION
## Summary
Adds a new top-level genome field `resistanceToInjection`. When enabled, no cell of a creature carrying that genome can be taken over by a hostile injector. The field is intentionally **not** mutated.

## Changes
- **Engine**: new field in `GenomeDesc`, `GenomeTO` and the GPU `Genome`, plumbed through all conversions (`DescConverterService`, `DataAccessKernels`, `EntityFactory`), the genome hash and the serializer (`Id_Genome_ResistanceToInjection = 6`).
- **Behavior**: `InjectorProcessor` now skips target cells whose creature genome has `resistanceToInjection` set.
- **Not mutated**: `MutationProcessor` is untouched; `cloneGenome` copies the field via struct copy, so it survives mutation/injection but is never altered.
- **GUI**: checkbox in the genome editor and a read-only entry in the creature inspection window.
- **Tests**: `DescTestDataFactory` sets the field (covers serializer and data-transfer round-trips) and a new `InjectorTests.noInjectionOnResistantCreature`.

## Testing
- `build-windows-ninja.bat` → success
- `PersisterTests` 64/64, `EngineInterfaceTests` 155/155
- `EngineTests` (Injector + DataTransfer) 145/145, including the new resistance test

🤖 Generated with [Claude Code](https://claude.com/claude-code)