### PR TITLE
Count only directly selected creatures in selection window

### DIFF
--- a/source/EngineKernels/EditKernels.cu
+++ b/source/EngineKernels/EditKernels.cu
@@ -529,7 +529,7 @@ __global__ void cudaGetSelectionShallowData_step2(SimulationData data, int refOb
         auto const& object = data.entities.objects.at(index);
         if (0 != object->selected) {
             result.collectObject(object, refPos, data.objectMap);
-            if (object->type == ObjectType_Cell) {
+            if (object->selected == 1 && object->type == ObjectType_Cell) {
                 if (alienAtomicExch64(&object->typeData.cell.creature->creatureIndex, static_cast<uint64_t>(1)) == static_cast<uint64_t>(0)) {
                     result.collectCreature();
                 }

--- a/source/EngineTests/EditTests.cpp
+++ b/source/EngineTests/EditTests.cpp
@@ -150,6 +150,31 @@ TEST_F(EditTests, getSelectionShallowData_selectMultipleCreatures)
     EXPECT_EQ(0, selectionData.numEnergyParticles);
 }
 
+TEST_F(EditTests, getSelectionShallowData_onlyDirectlySelectedCreatures)
+{
+    auto data = Desc()
+                    .addCreature({
+                        ObjectDesc().id(1).pos({50, 50}),
+                        ObjectDesc().id(2).pos({51, 50}),
+                    })
+                    .addCreature({
+                        ObjectDesc().id(3).pos({52, 50}),
+                        ObjectDesc().id(4).pos({53, 50}),
+                    });
+    data.addConnection(1, 2);
+    data.addConnection(3, 4);
+    data.addConnection(2, 3);
+    _simulationFacade->setSimulationData(data);
+
+    _simulationFacade->setSelection({49, 49}, {51.5f, 51});
+    auto selectionData = _simulationFacade->getSelectionShallowData();
+
+    EXPECT_EQ(2, selectionData.numObjects);
+    EXPECT_EQ(1, selectionData.numCreatures);
+    EXPECT_EQ(4, selectionData.numClusterCells);
+    EXPECT_EQ(0, selectionData.numEnergyParticles);
+}
+
 TEST_F(EditTests, injectGenomeToSelectedCreatures_noSelection)
 {
     auto data = Desc().addCreature({ObjectDesc().id(1).pos({50, 50})}, CreatureDesc(), GenomeDesc());


### PR DESCRIPTION
## Summary
The SelectionWindow "Creatures" count previously included every creature reachable through the physical cluster (cells with `selected == 2`, pulled in by the selection rollout). For a cluster spanning multiple creatures, this over-counted.

Now creatures are counted only for directly selected cells (`selected == 1`), making the "Creatures" value consistent with the "Cells" count. "Connected cells" still reports the full cluster.

## Change
`cudaGetSelectionShallowData_step2` in `EditKernels.cu`: guard creature counting with `object->selected == 1`.

## Tests
- New `EditTests.getSelectionShallowData_onlyDirectlySelectedCreatures`: cluster of two creatures, only one directly selected → `numCreatures == 1`, `numClusterCells == 4`.
- Full `EditTests` suite: 11/11 pass. Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)