### PR TITLE
Add node-structure mutations: append, add, trim, delete

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -888,6 +888,10 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
+    result._mutationRates._appendNodeMutation._geneProbability = genomeTO.mutationRates.appendNodeMutation.geneProbability;
+    result._mutationRates._addNodeMutation._geneProbability = genomeTO.mutationRates.addNodeMutation.geneProbability;
+    result._mutationRates._trimNodeMutation._geneProbability = genomeTO.mutationRates.trimNodeMutation.geneProbability;
+    result._mutationRates._deleteNodeMutation._geneProbability = genomeTO.mutationRates.deleteNodeMutation.geneProbability;
     result._genes.reserve(genomeTO.numGenes);
 
     CHECK(genomeTO.geneArrayIndex + genomeTO.numGenes <= *to.numGenes);
@@ -983,6 +987,10 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};
+    genomeTO.mutationRates.appendNodeMutation = {genome._mutationRates._appendNodeMutation._geneProbability};
+    genomeTO.mutationRates.addNodeMutation = {genome._mutationRates._addNodeMutation._geneProbability};
+    genomeTO.mutationRates.trimNodeMutation = {genome._mutationRates._trimNodeMutation._geneProbability};
+    genomeTO.mutationRates.deleteNodeMutation = {genome._mutationRates._deleteNodeMutation._geneProbability};
     genomeTO.numGenes = toInt(genome._genes.size());
     genomeTO.geneArrayIndex = geneArrayStartIndex;
     genomeTO.genomeIndexOnGpu = VALUE_NOT_SET_UINT64;

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -49,6 +49,14 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         std::clamp(genome._mutationRates._cellTypeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._voidMutation._nodeProbability =
         std::clamp(genome._mutationRates._voidMutation._nodeProbability, 0.0f, 1.0f);
+    genome._mutationRates._appendNodeMutation._geneProbability =
+        std::clamp(genome._mutationRates._appendNodeMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._addNodeMutation._geneProbability =
+        std::clamp(genome._mutationRates._addNodeMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._trimNodeMutation._geneProbability =
+        std::clamp(genome._mutationRates._trimNodeMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._deleteNodeMutation._geneProbability =
+        std::clamp(genome._mutationRates._deleteNodeMutation._geneProbability, 0.0f, 1.0f);
 
     // Validate each gene
     for (auto& gene : genome._genes) {

--- a/source/EngineInterface/GenomeDesc.cpp
+++ b/source/EngineInterface/GenomeDesc.cpp
@@ -71,6 +71,18 @@ std::vector<std::string> MutationRatesDesc::getActiveMutationTypes() const
     if (_voidMutation._nodeProbability > 0.0f) {
         activeMutations.push_back("Void mutations");
     }
+    if (_appendNodeMutation._geneProbability > 0.0f) {
+        activeMutations.push_back("Append node mutations");
+    }
+    if (_addNodeMutation._geneProbability > 0.0f) {
+        activeMutations.push_back("Add node mutations");
+    }
+    if (_trimNodeMutation._geneProbability > 0.0f) {
+        activeMutations.push_back("Trim node mutations");
+    }
+    if (_deleteNodeMutation._geneProbability > 0.0f) {
+        activeMutations.push_back("Delete node mutations");
+    }
     if (_constructorMutations[0]._nodeProbability > 0.0f || _constructorMutations[1]._nodeProbability > 0.0f) {
         activeMutations.push_back("Constructor mutations");
     }

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -460,6 +460,34 @@ struct VoidMutationDesc
     MEMBER(VoidMutationDesc, float, nodeProbability, 0.0f);
 };
 
+struct AppendNodeMutationDesc
+{
+    auto operator<=>(AppendNodeMutationDesc const&) const = default;
+
+    MEMBER(AppendNodeMutationDesc, float, geneProbability, 0.0f);
+};
+
+struct AddNodeMutationDesc
+{
+    auto operator<=>(AddNodeMutationDesc const&) const = default;
+
+    MEMBER(AddNodeMutationDesc, float, geneProbability, 0.0f);
+};
+
+struct TrimNodeMutationDesc
+{
+    auto operator<=>(TrimNodeMutationDesc const&) const = default;
+
+    MEMBER(TrimNodeMutationDesc, float, geneProbability, 0.0f);
+};
+
+struct DeleteNodeMutationDesc
+{
+    auto operator<=>(DeleteNodeMutationDesc const&) const = default;
+
+    MEMBER(DeleteNodeMutationDesc, float, geneProbability, 0.0f);
+};
+
 struct ConstructorMutationDesc
 {
     auto operator<=>(ConstructorMutationDesc const&) const = default;
@@ -484,6 +512,10 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
+    MEMBER(MutationRatesDesc, AppendNodeMutationDesc, appendNodeMutation, AppendNodeMutationDesc());
+    MEMBER(MutationRatesDesc, AddNodeMutationDesc, addNodeMutation, AddNodeMutationDesc());
+    MEMBER(MutationRatesDesc, TrimNodeMutationDesc, trimNodeMutation, TrimNodeMutationDesc());
+    MEMBER(MutationRatesDesc, DeleteNodeMutationDesc, deleteNodeMutation, DeleteNodeMutationDesc());
     MEMBER(MutationRatesDesc, ConstructorMutationArray, constructorMutations, ConstructorMutationArray());
 
     std::vector<std::string> getActiveMutationTypes() const;

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -507,9 +507,25 @@ struct MutationRatesDesc
 
     auto operator<=>(MutationRatesDesc const&) const = default;
 
-    MEMBER(MutationRatesDesc, NeuronMutationArray, neuronMutations, NeuronMutationArray());
-    MEMBER(MutationRatesDesc, ConnectionMutationArray, connectionMutations, ConnectionMutationArray());
-    MEMBER(MutationRatesDesc, CellTypePropertiesMutationArray, cellTypePropertiesMutations, CellTypePropertiesMutationArray());
+    MEMBER(
+        MutationRatesDesc,
+        NeuronMutationArray,
+        neuronMutations,
+        (NeuronMutationArray{
+            {NeuronMutationDesc().weightSigma(0.05f).biasSigma(0.05f).activationFunctionProbability(0.05f),
+             NeuronMutationDesc().weightSigma(0.5f).biasSigma(0.1f).activationFunctionProbability(0.1f)}}));
+    MEMBER(
+        MutationRatesDesc,
+        ConnectionMutationArray,
+        connectionMutations,
+        (ConnectionMutationArray{{ConnectionMutationDesc().sigma(0.05f), ConnectionMutationDesc().sigma(0.5f)}}));
+    MEMBER(
+        MutationRatesDesc,
+        CellTypePropertiesMutationArray,
+        cellTypePropertiesMutations,
+        (CellTypePropertiesMutationArray{
+            {CellTypePropertiesMutationDesc().sigma(0.05f).discreteChangeProbability(0.05f),
+             CellTypePropertiesMutationDesc().sigma(0.5f).discreteChangeProbability(0.5f)}}));
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
@@ -517,7 +533,13 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, AddNodeMutationDesc, addNodeMutation, AddNodeMutationDesc());
     MEMBER(MutationRatesDesc, TrimNodeMutationDesc, trimNodeMutation, TrimNodeMutationDesc());
     MEMBER(MutationRatesDesc, DeleteNodeMutationDesc, deleteNodeMutation, DeleteNodeMutationDesc());
-    MEMBER(MutationRatesDesc, ConstructorMutationArray, constructorMutations, ConstructorMutationArray());
+    MEMBER(
+        MutationRatesDesc,
+        ConstructorMutationArray,
+        constructorMutations,
+        (ConstructorMutationArray{
+            {ConstructorMutationDesc().sigma(0.05f).discreteChangeProbability(0.05f).existConstructorProbability(0.05f),
+             ConstructorMutationDesc().discreteChangeProbability(0.5f).existConstructorProbability(0.5f)}}));
 };
 
 struct GenomeDesc

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -559,6 +559,10 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);
+        hash_combine(seed, desc._mutationRates._appendNodeMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._addNodeMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._trimNodeMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._deleteNodeMutation._geneProbability);
         return seed;
     }
 };

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -479,6 +479,22 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::metaMutationVoidSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Append node mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationAppendNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
+                        .name("Add node mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationAddNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
+                        .name("Trim node mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationTrimNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
+                        .name("Delete node mutations sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::metaMutationDeleteNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("Constructor mutations sigma")
                         .reference(
                             FloatSpec().member(&SimulationParameters::metaMutationConstructorSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -112,6 +112,10 @@ struct SimulationParameters
     BaseParameter<float> metaMutationCellTypeModeSigma = {0};
     BaseParameter<float> metaMutationCellTypeSigma = {0};
     BaseParameter<float> metaMutationVoidSigma = {0};
+    BaseParameter<float> metaMutationAppendNodeSigma = {0};
+    BaseParameter<float> metaMutationAddNodeSigma = {0};
+    BaseParameter<float> metaMutationTrimNodeSigma = {0};
+    BaseParameter<float> metaMutationDeleteNodeSigma = {0};
     BaseParameter<float> metaMutationConstructorSigma = {0};
     BaseParameter<float> newLineageThreshold = {Infinity<float>::value};
 

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -55,6 +55,10 @@ namespace
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};
+            genomeTO.mutationRates.appendNodeMutation = {genome->mutationRates.appendNodeMutation.geneProbability};
+            genomeTO.mutationRates.addNodeMutation = {genome->mutationRates.addNodeMutation.geneProbability};
+            genomeTO.mutationRates.trimNodeMutation = {genome->mutationRates.trimNodeMutation.geneProbability};
+            genomeTO.mutationRates.deleteNodeMutation = {genome->mutationRates.deleteNodeMutation.geneProbability};
             genomeTO.numGenes = genome->numGenes;
             for (int i = 0; i < sizeof(genomeTO.name); ++i) {
                 genomeTO.name[i] = genome->name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -110,6 +110,10 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};
+    genome->mutationRates.appendNodeMutation = {genomeTO.mutationRates.appendNodeMutation.geneProbability};
+    genome->mutationRates.addNodeMutation = {genomeTO.mutationRates.addNodeMutation.geneProbability};
+    genome->mutationRates.trimNodeMutation = {genomeTO.mutationRates.trimNodeMutation.geneProbability};
+    genome->mutationRates.deleteNodeMutation = {genomeTO.mutationRates.deleteNodeMutation.geneProbability};
     genome->numGenes = genomeTO.numGenes;
     for (int i = 0; i < sizeof(genomeTO.name); ++i) {
         genome->name[i] = genomeTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -376,6 +376,26 @@ struct VoidMutation
     float nodeProbability;
 };
 
+struct AppendNodeMutation
+{
+    float geneProbability;
+};
+
+struct AddNodeMutation
+{
+    float geneProbability;
+};
+
+struct TrimNodeMutation
+{
+    float geneProbability;
+};
+
+struct DeleteNodeMutation
+{
+    float geneProbability;
+};
+
 struct ConstructorMutation
 {
     float nodeProbability;
@@ -391,6 +411,10 @@ struct MutationRates
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;
+    AppendNodeMutation appendNodeMutation;
+    AddNodeMutation addNodeMutation;
+    TrimNodeMutation trimNodeMutation;
+    DeleteNodeMutation deleteNodeMutation;
     ConstructorMutation constructorMutations[2];
 };
 

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -381,6 +381,26 @@ struct VoidMutationTO
     float nodeProbability;
 };
 
+struct AppendNodeMutationTO
+{
+    float geneProbability;
+};
+
+struct AddNodeMutationTO
+{
+    float geneProbability;
+};
+
+struct TrimNodeMutationTO
+{
+    float geneProbability;
+};
+
+struct DeleteNodeMutationTO
+{
+    float geneProbability;
+};
+
 struct ConstructorMutationTO
 {
     float nodeProbability;
@@ -396,6 +416,10 @@ struct MutationRatesTO
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;
+    AppendNodeMutationTO appendNodeMutation;
+    AddNodeMutationTO addNodeMutation;
+    TrimNodeMutationTO trimNodeMutation;
+    DeleteNodeMutationTO deleteNodeMutation;
     ConstructorMutationTO constructorMutations[2];
 };
 

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -23,17 +23,29 @@ public:
     __inline__ __device__ static void applyMutations(SimulationData& data, Genome* genome);
 
 private:
+    // Upper bound for node-adding mutations to keep genome growth bounded and avoid heap exhaustion.
+    static auto constexpr MaxNodesPerGene = 200;
+
     __inline__ __device__ static void applyMutations_neurons(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_connections(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeProperties(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_appendNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_addNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_trimNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_deleteNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_meta(SimulationData& data, Genome* genome);
 
     __inline__ __device__ static void resetCellTypeModeToDefault(Node& node);
     __inline__ __device__ static void resetCellTypeToDefault(Node& node);
+    __inline__ __device__ static void setRandomCellTypeMode(SimulationData& data, Node& node);
+    __inline__ __device__ static void initNewNode(SimulationData& data, Node& node);
+    __inline__ __device__ static void insertNode(SimulationData& data, Gene& gene, int position);
+    __inline__ __device__ static void removeNode(SimulationData& data, Gene& gene, int position);
+    __inline__ __device__ static void correctGenome(SimulationData& data, Genome* genome);
 
     __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static float generateGaussian(SimulationData& data);
@@ -115,6 +127,24 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_cellType(data, genome, accumulatedMutations);
     applyMutations_void(data, genome, accumulatedMutations);
     applyMutations_constructor(data, genome, accumulatedMutations);
+
+    // The structural node mutations reallocate gene node arrays per gene, so all preceding per-node writes (and any
+    // meta-mutation writes to the rates) must be visible first; afterwards the genome is corrected (e.g. void first/last
+    // nodes) before counting takes place. The block is only entered when a node mutation is active so genomes without it
+    // stay untouched. The sync below makes the rates uniform across the block, so this decision (and the inner syncs) do
+    // not diverge.
+    block.sync();
+    auto const& nodeRates = genome->mutationRates;
+    bool anyNodeMutation = nodeRates.appendNodeMutation.geneProbability > 0 || nodeRates.addNodeMutation.geneProbability > 0
+        || nodeRates.trimNodeMutation.geneProbability > 0 || nodeRates.deleteNodeMutation.geneProbability > 0;
+    if (anyNodeMutation) {
+        applyMutations_appendNode(data, genome, accumulatedMutations);
+        applyMutations_addNode(data, genome, accumulatedMutations);
+        applyMutations_trimNode(data, genome, accumulatedMutations);
+        applyMutations_deleteNode(data, genome, accumulatedMutations);
+        block.sync();
+        correctGenome(data, genome);
+    }
 
     block.sync();
     updateAccumulatedMutationsAndLineageId(data, genome, accumulatedMutations);
@@ -809,6 +839,203 @@ __inline__ __device__ void MutationProcessor::applyMutations_void(SimulationData
     }
 }
 
+__inline__ __device__ void MutationProcessor::setRandomCellTypeMode(SimulationData& data, Node& node)
+{
+    // Pick a uniformly random mode for the node's cell type and reset that mode's data to its defaults.
+    auto randomMode = [&](int count) { return data.primaryNumberGen.random(count - 1); };
+    bool changed = true;
+    switch (node.cellType) {
+    case CellType_Sensor:
+        node.cellTypeData.sensor.mode = static_cast<SensorMode>(randomMode(SensorMode_Count));
+        break;
+    case CellType_Generator:
+        node.cellTypeData.generator.mode = static_cast<GeneratorMode>(randomMode(GeneratorMode_Count));
+        break;
+    case CellType_Attacker:
+        node.cellTypeData.attacker.mode = static_cast<AttackerMode>(randomMode(AttackerMode_Count));
+        break;
+    case CellType_Muscle:
+        node.cellTypeData.muscle.mode = static_cast<MuscleMode>(randomMode(MuscleMode_Count));
+        break;
+    case CellType_Defender:
+        node.cellTypeData.defender.mode = static_cast<DefenderMode>(randomMode(DefenderMode_Count));
+        break;
+    case CellType_Reconnector:
+        node.cellTypeData.reconnector.mode = static_cast<ReconnectorMode>(randomMode(ReconnectorMode_Count));
+        break;
+    case CellType_Memory:
+        node.cellTypeData.memory.mode = static_cast<MemoryMode>(randomMode(MemoryMode_Count));
+        break;
+    case CellType_Communicator:
+        node.cellTypeData.communicator.mode = static_cast<CommunicatorMode>(randomMode(CommunicatorMode_Count));
+        break;
+    default:
+        // Cell types without a mode field are not affected.
+        changed = false;
+        break;
+    }
+    if (changed) {
+        resetCellTypeModeToDefault(node);
+    }
+}
+
+__inline__ __device__ void MutationProcessor::initNewNode(SimulationData& data, Node& node)
+{
+    // A freshly created node uses the shared default attribute values (mirrors NodeDesc / NeuralNetGenomeDesc defaults).
+    node.referenceAngle = 0.0f;
+    node.color = 0;
+    for (int i = 0; i < NEURONS_PER_CELL * NEURONS_PER_CELL; ++i) {
+        node.neuralNetwork.weights[i] = NeuralNetWeight(0.0f);
+    }
+    for (int i = 0; i < NEURONS_PER_CELL; ++i) {
+        node.neuralNetwork.weights[i * NEURONS_PER_CELL + i] = NeuralNetWeight(1.0f);
+        node.neuralNetwork.biases[i] = 0.0f;
+        node.neuralNetwork.activationFunctions[i] = ActivationFunction_Identity;
+    }
+    for (int i = 0; i < MAX_OBJECT_CONNECTIONS; ++i) {
+        node.neuralNetwork.connectionWeights[i] = 0.0f;
+    }
+    node.neuralNetwork.connectionWeights[0] = 1.0f;
+    node.constructorAvailable = false;
+
+    // Random non-void cell type and random mode; all cell-type attributes stay at their defaults.
+    node.cellType = data.primaryNumberGen.random(CellType_Count - 2);
+    resetCellTypeToDefault(node);
+    setRandomCellTypeMode(data, node);
+}
+
+__inline__ __device__ void MutationProcessor::insertNode(SimulationData& data, Gene& gene, int position)
+{
+    // Reallocate the gene's node array with one extra slot at the given position holding a new default node.
+    auto const oldNumNodes = gene.numNodes;
+    auto const newNumNodes = oldNumNodes + 1;
+    auto newNodes = data.entities.heap.getTypedSubArray<Node>(newNumNodes);
+    for (int i = 0; i < position; ++i) {
+        newNodes[i] = gene.nodes[i];
+    }
+    initNewNode(data, newNodes[position]);
+    for (int i = position; i < oldNumNodes; ++i) {
+        newNodes[i + 1] = gene.nodes[i];
+    }
+    gene.nodes = newNodes;
+    gene.numNodes = newNumNodes;
+}
+
+__inline__ __device__ void MutationProcessor::removeNode(SimulationData& data, Gene& gene, int position)
+{
+    // Reallocate the gene's node array without the node at the given position.
+    auto const oldNumNodes = gene.numNodes;
+    auto const newNumNodes = oldNumNodes - 1;
+    auto newNodes = data.entities.heap.getTypedSubArray<Node>(newNumNodes);
+    for (int i = 0; i < position; ++i) {
+        newNodes[i] = gene.nodes[i];
+    }
+    for (int i = position + 1; i < oldNumNodes; ++i) {
+        newNodes[i - 1] = gene.nodes[i];
+    }
+    gene.nodes = newNodes;
+    gene.numNodes = newNumNodes;
+}
+
+__inline__ __device__ void MutationProcessor::applyMutations_appendNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.appendNodeMutation;
+    if (rate.geneProbability <= 0) {
+        return;
+    }
+
+    // Genes are independent, so each thread mutates whole genes on its own.
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes >= MaxNodesPerGene || data.primaryNumberGen.random() >= rate.geneProbability) {
+            continue;
+        }
+        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes;  // start or end
+        insertNode(data, gene, position);
+        atomicAdd_block(&accumulatedMutations, 1.0f);
+    }
+}
+
+__inline__ __device__ void MutationProcessor::applyMutations_addNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.addNodeMutation;
+    if (rate.geneProbability <= 0) {
+        return;
+    }
+
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes >= MaxNodesPerGene || data.primaryNumberGen.random() >= rate.geneProbability) {
+            continue;
+        }
+        auto position = data.primaryNumberGen.random(gene.numNodes);  // [0, numNodes] => any insertion slot, incl. start/end
+        insertNode(data, gene, position);
+        atomicAdd_block(&accumulatedMutations, 1.0f);
+    }
+}
+
+__inline__ __device__ void MutationProcessor::applyMutations_trimNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.trimNodeMutation;
+    if (rate.geneProbability <= 0) {
+        return;
+    }
+
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // keep at least one node
+            continue;
+        }
+        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes - 1;  // start or end
+        removeNode(data, gene, position);
+        atomicAdd_block(&accumulatedMutations, 1.0f);
+    }
+}
+
+__inline__ __device__ void MutationProcessor::applyMutations_deleteNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    auto const& rate = genome->mutationRates.deleteNodeMutation;
+    if (rate.geneProbability <= 0) {
+        return;
+    }
+
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // keep at least one node
+            continue;
+        }
+        auto position = data.primaryNumberGen.random(gene.numNodes - 1);  // [0, numNodes - 1] => any node
+        removeNode(data, gene, position);
+        atomicAdd_block(&accumulatedMutations, 1.0f);
+    }
+}
+
+__inline__ __device__ void MutationProcessor::correctGenome(SimulationData& data, Genome* genome)
+{
+    // Structural node mutations may have left the first or last node of a gene void, which is not allowed.
+    // Turn such boundary nodes into a random non-void cell type with default attributes (mirrors applyMutations_void).
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes == 0) {
+            continue;
+        }
+        auto fixBoundaryNode = [&](int nodeIndex) {
+            auto& node = gene.nodes[nodeIndex];
+            if (node.cellType == CellType_Void) {
+                node.cellType = data.primaryNumberGen.random(CellType_Count - 2);
+                resetCellTypeToDefault(node);
+            }
+        };
+        fixBoundaryNode(0);
+        fixBoundaryNode(gene.numNodes - 1);
+    }
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto block = cg_mutation::this_thread_block();
@@ -952,6 +1179,30 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (voidMutationSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * voidMutationSigma)); };
             mutateFloat(genome->mutationRates.voidMutation.nodeProbability);
+        }
+
+        float appendNodeSigma = cudaSimulationParameters.metaMutationAppendNodeSigma.value;
+        if (appendNodeSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * appendNodeSigma)); };
+            mutateFloat(genome->mutationRates.appendNodeMutation.geneProbability);
+        }
+
+        float addNodeSigma = cudaSimulationParameters.metaMutationAddNodeSigma.value;
+        if (addNodeSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * addNodeSigma)); };
+            mutateFloat(genome->mutationRates.addNodeMutation.geneProbability);
+        }
+
+        float trimNodeSigma = cudaSimulationParameters.metaMutationTrimNodeSigma.value;
+        if (trimNodeSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * trimNodeSigma)); };
+            mutateFloat(genome->mutationRates.trimNodeMutation.geneProbability);
+        }
+
+        float deleteNodeSigma = cudaSimulationParameters.metaMutationDeleteNodeSigma.value;
+        if (deleteNodeSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * deleteNodeSigma)); };
+            mutateFloat(genome->mutationRates.deleteNodeMutation.geneProbability);
         }
 
         float constructorSigma = cudaSimulationParameters.metaMutationConstructorSigma.value;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -41,9 +41,10 @@ private:
 
     __inline__ __device__ static void resetCellTypeModeToDefault(Node& node);
     __inline__ __device__ static void resetCellTypeToDefault(Node& node);
-    __inline__ __device__ static void setRandomCellTypeMode(SimulationData& data, Node& node);
-    __inline__ __device__ static void initNewNode(SimulationData& data, Node& node);
-    __inline__ __device__ static void insertNode(SimulationData& data, Gene& gene, int position);
+    __inline__ __device__ static CellType chooseRandomCellTypeExceptVoid(SimulationData& data);
+    __inline__ __device__ static bool setRandomCellTypeMode(SimulationData& data, Node& node);
+    __inline__ __device__ static void initNewNode(SimulationData& data, Node& node, int color);
+    __inline__ __device__ static void insertNode(SimulationData& data, Genome* genome, Gene& gene, int position);
     __inline__ __device__ static void removeNode(SimulationData& data, Gene& gene, int position);
     __inline__ __device__ static void correctGenome(SimulationData& data, Genome* genome);
 
@@ -699,57 +700,14 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeMode(Simula
         return;
     }
 
-    auto pickNewMode = [&](int currentMode, int count) {
-        auto newMode = data.primaryNumberGen.random(count - 2);
-        if (newMode >= currentMode) {
-            ++newMode;
-        }
-        return newMode;
-    };
-
     for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
         auto& gene = genome->genes[geneIndex];
         for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
             if (data.primaryNumberGen.random() >= rate.nodeProbability) {
                 continue;
             }
-            auto& node = gene.nodes[nodeIndex];
-
-            // Pick a new mode for the node's cell type; the new mode's data is then reset to its defaults below.
-            bool changed = true;
-            switch (node.cellType) {
-            case CellType_Sensor:
-                node.cellTypeData.sensor.mode = static_cast<SensorMode>(pickNewMode(node.cellTypeData.sensor.mode, SensorMode_Count));
-                break;
-            case CellType_Generator:
-                node.cellTypeData.generator.mode = static_cast<GeneratorMode>(pickNewMode(node.cellTypeData.generator.mode, GeneratorMode_Count));
-                break;
-            case CellType_Attacker:
-                node.cellTypeData.attacker.mode = static_cast<AttackerMode>(pickNewMode(node.cellTypeData.attacker.mode, AttackerMode_Count));
-                break;
-            case CellType_Muscle:
-                node.cellTypeData.muscle.mode = static_cast<MuscleMode>(pickNewMode(node.cellTypeData.muscle.mode, MuscleMode_Count));
-                break;
-            case CellType_Defender:
-                node.cellTypeData.defender.mode = static_cast<DefenderMode>(pickNewMode(node.cellTypeData.defender.mode, DefenderMode_Count));
-                break;
-            case CellType_Reconnector:
-                node.cellTypeData.reconnector.mode = static_cast<ReconnectorMode>(pickNewMode(node.cellTypeData.reconnector.mode, ReconnectorMode_Count));
-                break;
-            case CellType_Memory:
-                node.cellTypeData.memory.mode = static_cast<MemoryMode>(pickNewMode(node.cellTypeData.memory.mode, MemoryMode_Count));
-                break;
-            case CellType_Communicator:
-                node.cellTypeData.communicator.mode = static_cast<CommunicatorMode>(pickNewMode(node.cellTypeData.communicator.mode, CommunicatorMode_Count));
-                break;
-            default:
-                // Cell types without a mode field are not affected.
-                changed = false;
-                break;
-            }
-
-            if (changed) {
-                resetCellTypeModeToDefault(node);
+            // Switch the node to a different random mode (its data is reset to defaults); cell types without a mode are unaffected.
+            if (setRandomCellTypeMode(data, gene.nodes[nodeIndex])) {
                 atomicAdd_block(&accumulatedMutations, 1.0f);
             }
         }
@@ -811,10 +769,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_void(SimulationData
         return;
     }
 
-    // Pick a non-void cell type used when a void node is turned into a non-void node.
-    // Void is the last entry before CellType_Count, so the range [0, CellType_Count - 2] covers exactly the non-void types.
-    auto pickNonVoidCellType = [&]() { return data.primaryNumberGen.random(CellType_Count - 2); };
-
     for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
         auto& gene = genome->genes[geneIndex];
         for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {
@@ -828,42 +782,59 @@ __inline__ __device__ void MutationProcessor::applyMutations_void(SimulationData
             auto& node = gene.nodes[nodeIndex];
 
             // Toggle the node between void and non-void; the new cell type is reset to its default attribute values.
-            node.cellType = node.cellType == CellType_Void ? pickNonVoidCellType() : CellType_Void;
+            node.cellType = node.cellType == CellType_Void ? chooseRandomCellTypeExceptVoid(data) : CellType_Void;
             resetCellTypeToDefault(node);
             atomicAdd_block(&accumulatedMutations, 1.0f);
         }
     }
 }
 
-__inline__ __device__ void MutationProcessor::setRandomCellTypeMode(SimulationData& data, Node& node)
+__inline__ __device__ CellType MutationProcessor::chooseRandomCellTypeExceptVoid(SimulationData& data)
 {
-    // Pick a uniformly random mode for the node's cell type and reset that mode's data to its defaults.
-    auto randomMode = [&](int count) { return data.primaryNumberGen.random(count - 1); };
+    // Pick a uniformly random non-void cell type without assuming the position of CellType_Void within the enum.
+    auto cellType = data.primaryNumberGen.random(CellType_Count - 2);
+    if (cellType >= CellType_Void) {
+        ++cellType;
+    }
+    return static_cast<CellType>(cellType);
+}
+
+__inline__ __device__ bool MutationProcessor::setRandomCellTypeMode(SimulationData& data, Node& node)
+{
+    // Pick a mode different from the node's current mode for its cell type and reset that mode's data to its defaults.
+    // Returns whether the cell type has a mode at all.
+    auto pickNewMode = [&](int currentMode, int count) {
+        auto newMode = data.primaryNumberGen.random(count - 2);
+        if (newMode >= currentMode) {
+            ++newMode;
+        }
+        return newMode;
+    };
     bool changed = true;
     switch (node.cellType) {
     case CellType_Sensor:
-        node.cellTypeData.sensor.mode = static_cast<SensorMode>(randomMode(SensorMode_Count));
+        node.cellTypeData.sensor.mode = static_cast<SensorMode>(pickNewMode(node.cellTypeData.sensor.mode, SensorMode_Count));
         break;
     case CellType_Generator:
-        node.cellTypeData.generator.mode = static_cast<GeneratorMode>(randomMode(GeneratorMode_Count));
+        node.cellTypeData.generator.mode = static_cast<GeneratorMode>(pickNewMode(node.cellTypeData.generator.mode, GeneratorMode_Count));
         break;
     case CellType_Attacker:
-        node.cellTypeData.attacker.mode = static_cast<AttackerMode>(randomMode(AttackerMode_Count));
+        node.cellTypeData.attacker.mode = static_cast<AttackerMode>(pickNewMode(node.cellTypeData.attacker.mode, AttackerMode_Count));
         break;
     case CellType_Muscle:
-        node.cellTypeData.muscle.mode = static_cast<MuscleMode>(randomMode(MuscleMode_Count));
+        node.cellTypeData.muscle.mode = static_cast<MuscleMode>(pickNewMode(node.cellTypeData.muscle.mode, MuscleMode_Count));
         break;
     case CellType_Defender:
-        node.cellTypeData.defender.mode = static_cast<DefenderMode>(randomMode(DefenderMode_Count));
+        node.cellTypeData.defender.mode = static_cast<DefenderMode>(pickNewMode(node.cellTypeData.defender.mode, DefenderMode_Count));
         break;
     case CellType_Reconnector:
-        node.cellTypeData.reconnector.mode = static_cast<ReconnectorMode>(randomMode(ReconnectorMode_Count));
+        node.cellTypeData.reconnector.mode = static_cast<ReconnectorMode>(pickNewMode(node.cellTypeData.reconnector.mode, ReconnectorMode_Count));
         break;
     case CellType_Memory:
-        node.cellTypeData.memory.mode = static_cast<MemoryMode>(randomMode(MemoryMode_Count));
+        node.cellTypeData.memory.mode = static_cast<MemoryMode>(pickNewMode(node.cellTypeData.memory.mode, MemoryMode_Count));
         break;
     case CellType_Communicator:
-        node.cellTypeData.communicator.mode = static_cast<CommunicatorMode>(randomMode(CommunicatorMode_Count));
+        node.cellTypeData.communicator.mode = static_cast<CommunicatorMode>(pickNewMode(node.cellTypeData.communicator.mode, CommunicatorMode_Count));
         break;
     default:
         // Cell types without a mode field are not affected.
@@ -873,13 +844,14 @@ __inline__ __device__ void MutationProcessor::setRandomCellTypeMode(SimulationDa
     if (changed) {
         resetCellTypeModeToDefault(node);
     }
+    return changed;
 }
 
-__inline__ __device__ void MutationProcessor::initNewNode(SimulationData& data, Node& node)
+__inline__ __device__ void MutationProcessor::initNewNode(SimulationData& data, Node& node, int color)
 {
     // A freshly created node uses the shared default attribute values (mirrors NodeDesc / NeuralNetGenomeDesc defaults).
     node.referenceAngle = 0.0f;
-    node.color = 0;
+    node.color = color;
     for (int i = 0; i < NEURONS_PER_CELL * NEURONS_PER_CELL; ++i) {
         node.neuralNetwork.weights[i] = NeuralNetWeight(0.0f);
     }
@@ -894,22 +866,39 @@ __inline__ __device__ void MutationProcessor::initNewNode(SimulationData& data, 
     node.neuralNetwork.connectionWeights[0] = 1.0f;
     node.constructorAvailable = false;
 
-    // Random non-void cell type and random mode; all cell-type attributes stay at their defaults.
-    node.cellType = data.primaryNumberGen.random(CellType_Count - 2);
+    // Random non-void cell type with a random mode; all cell-type attributes stay at their defaults.
+    node.cellType = chooseRandomCellTypeExceptVoid(data);
     resetCellTypeToDefault(node);
     setRandomCellTypeMode(data, node);
 }
 
-__inline__ __device__ void MutationProcessor::insertNode(SimulationData& data, Gene& gene, int position)
+__inline__ __device__ void MutationProcessor::insertNode(SimulationData& data, Genome* genome, Gene& gene, int position)
 {
-    // Reallocate the gene's node array with one extra slot at the given position holding a new default node.
+    // The new node inherits the color of its previous neighbor, otherwise its next neighbor, otherwise the genome's first
+    // node, otherwise a random color.
     auto const oldNumNodes = gene.numNodes;
+    int color;
+    if (position > 0) {
+        color = gene.nodes[position - 1].color;
+    } else if (oldNumNodes > 0) {
+        color = gene.nodes[0].color;
+    } else {
+        color = data.primaryNumberGen.random(MAX_COLORS - 1);
+        for (int otherGeneIndex = 0; otherGeneIndex < genome->numGenes; ++otherGeneIndex) {
+            if (genome->genes[otherGeneIndex].numNodes > 0) {
+                color = genome->genes[otherGeneIndex].nodes[0].color;
+                break;
+            }
+        }
+    }
+
+    // Reallocate the gene's node array with one extra slot at the given position holding the new default node.
     auto const newNumNodes = oldNumNodes + 1;
     auto newNodes = data.entities.heap.getTypedSubArray<Node>(newNumNodes);
     for (int i = 0; i < position; ++i) {
         newNodes[i] = gene.nodes[i];
     }
-    initNewNode(data, newNodes[position]);
+    initNewNode(data, newNodes[position], color);
     for (int i = position; i < oldNumNodes; ++i) {
         newNodes[i + 1] = gene.nodes[i];
     }
@@ -948,7 +937,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_appendNode(Simulati
             continue;
         }
         auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes;  // start or end
-        insertNode(data, gene, position);
+        insertNode(data, genome, gene, position);
         atomicAdd_block(&accumulatedMutations, 1.0f);
     }
 }
@@ -967,7 +956,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_addNode(SimulationD
             continue;
         }
         auto position = data.primaryNumberGen.random(gene.numNodes);  // [0, numNodes] => any insertion slot, incl. start/end
-        insertNode(data, gene, position);
+        insertNode(data, genome, gene, position);
         atomicAdd_block(&accumulatedMutations, 1.0f);
     }
 }
@@ -1023,7 +1012,7 @@ __inline__ __device__ void MutationProcessor::correctGenome(SimulationData& data
         auto fixBoundaryNode = [&](int nodeIndex) {
             auto& node = gene.nodes[nodeIndex];
             if (node.cellType == CellType_Void) {
-                node.cellType = data.primaryNumberGen.random(CellType_Count - 2);
+                node.cellType = chooseRandomCellTypeExceptVoid(data);
                 resetCellTypeToDefault(node);
             }
         };

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -128,11 +128,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_void(data, genome, accumulatedMutations);
     applyMutations_constructor(data, genome, accumulatedMutations);
 
-    // The structural node mutations reallocate gene node arrays per gene, so all preceding per-node writes (and any
-    // meta-mutation writes to the rates) must be visible first; afterwards the genome is corrected (e.g. void first/last
-    // nodes) before counting takes place. The block is only entered when a node mutation is active so genomes without it
-    // stay untouched. The sync below makes the rates uniform across the block, so this decision (and the inner syncs) do
-    // not diverge.
+    // sync since following mutations may change entire genes
     block.sync();
     auto const& nodeRates = genome->mutationRates;
     bool anyNodeMutation = nodeRates.appendNodeMutation.geneProbability > 0 || nodeRates.addNodeMutation.geneProbability > 0

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -185,6 +185,10 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))
+                        .appendNodeMutation(AppendNodeMutationDesc().geneProbability(0.41f))
+                        .addNodeMutation(AddNodeMutationDesc().geneProbability(0.42f))
+                        .trimNodeMutation(TrimNodeMutationDesc().geneProbability(0.43f))
+                        .deleteNodeMutation(DeleteNodeMutationDesc().geneProbability(0.44f))
                         .constructorMutations(
                             {ConstructorMutationDesc().nodeProbability(0.12f).sigma(0.13f).discreteChangeProbability(0.14f),
                              ConstructorMutationDesc().nodeProbability(0.16f).sigma(0.17f).discreteChangeProbability(0.18f)});

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -17,6 +17,10 @@ enum class MutationType
     CellTypeMode,
     CellType,
     Void,
+    AppendNode,
+    AddNode,
+    TrimNode,
+    DeleteNode,
     Constructor
 };
 
@@ -36,6 +40,10 @@ INSTANTIATE_TEST_SUITE_P(
         MutationType::CellTypeMode,
         MutationType::CellType,
         MutationType::Void,
+        MutationType::AppendNode,
+        MutationType::AddNode,
+        MutationType::TrimNode,
+        MutationType::DeleteNode,
         MutationType::Constructor));
 
 TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
@@ -60,6 +68,18 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::Void:
         genome._mutationRates._voidMutation = VoidMutationDesc().nodeProbability(1.0f);
+        break;
+    case MutationType::AppendNode:
+        genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+        break;
+    case MutationType::AddNode:
+        genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
+        break;
+    case MutationType::TrimNode:
+        genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+        break;
+    case MutationType::DeleteNode:
+        genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
         break;
     case MutationType::Constructor:
         genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
@@ -93,6 +113,10 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
     _parameters.metaMutationCellTypeSigma.value = 1.0f;
     _parameters.metaMutationVoidSigma.value = 1.0f;
+    _parameters.metaMutationAppendNodeSigma.value = 1.0f;
+    _parameters.metaMutationAddNodeSigma.value = 1.0f;
+    _parameters.metaMutationTrimNodeSigma.value = 1.0f;
+    _parameters.metaMutationDeleteNodeSigma.value = 1.0f;
     _parameters.metaMutationConstructorSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 

--- a/source/EngineTests/AddNodeMutationTests.cpp
+++ b/source/EngineTests/AddNodeMutationTests.cpp
@@ -1,6 +1,3 @@
-#include <type_traits>
-#include <variant>
-
 #include <gtest/gtest.h>
 
 #include <EngineInterface/CellTypeConstants.h>
@@ -14,7 +11,7 @@ class AddNodeMutationTests : public MutationTestsBase
 
 TEST_F(AddNodeMutationTests, addNodeMutation_addsExactlyOneNodePerPass)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -23,59 +20,26 @@ TEST_F(AddNodeMutationTests, addNodeMutation_addsExactlyOneNodePerPass)
     _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 3u);
-}
-
-TEST_F(AddNodeMutationTests, addNodeMutation_increasesNodeCount)
-{
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
-    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 10; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
-
-    auto actualGenome = getMutatedGenome();
-    EXPECT_GT(actualGenome._genes.at(0)._nodes.size(), genome._genes.at(0)._nodes.size());
-}
-
-TEST_F(AddNodeMutationTests, addNodeMutation_newNodesHaveDefaultAttributes)
-{
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
-    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 20; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
-
-    auto actualGenome = getMutatedGenome();
-    for (auto const& node : actualGenome._genes.at(0)._nodes) {
-        // Added nodes get a random non-void cell type and random mode, but node-level attributes stay at their defaults.
-        EXPECT_NE(node.getCellType(), CellType_Void);
-        EXPECT_EQ(node._referenceAngle, 0.0f);
-        EXPECT_EQ(node._color, 0);
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    EXPECT_EQ(3, nodes.size());
+    for (auto const& node : nodes) {
+        // Each node has a non-void cell type; the added node keeps default node-level attributes.
+        EXPECT_NE(CellType_Void, node.getCellType());
+        EXPECT_EQ(0.0f, node._referenceAngle);
         EXPECT_FALSE(node._constructor.has_value());
     }
 }
 
 TEST_F(AddNodeMutationTests, addNodeMutation_zeroProbabilityNoChange)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome, genome);
+    EXPECT_EQ(genome, actualGenome);
 }

--- a/source/EngineTests/AddNodeMutationTests.cpp
+++ b/source/EngineTests/AddNodeMutationTests.cpp
@@ -1,0 +1,81 @@
+#include <type_traits>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class AddNodeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(AddNodeMutationTests, addNodeMutation_addsExactlyOneNodePerPass)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 3u);
+}
+
+TEST_F(AddNodeMutationTests, addNodeMutation_increasesNodeCount)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 10; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_GT(actualGenome._genes.at(0)._nodes.size(), genome._genes.at(0)._nodes.size());
+}
+
+TEST_F(AddNodeMutationTests, addNodeMutation_newNodesHaveDefaultAttributes)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 20; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    for (auto const& node : actualGenome._genes.at(0)._nodes) {
+        // Added nodes get a random non-void cell type and random mode, but node-level attributes stay at their defaults.
+        EXPECT_NE(node.getCellType(), CellType_Void);
+        EXPECT_EQ(node._referenceAngle, 0.0f);
+        EXPECT_EQ(node._color, 0);
+        EXPECT_FALSE(node._constructor.has_value());
+    }
+}
+
+TEST_F(AddNodeMutationTests, addNodeMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}

--- a/source/EngineTests/AppendNodeMutationTests.cpp
+++ b/source/EngineTests/AppendNodeMutationTests.cpp
@@ -1,6 +1,3 @@
-#include <type_traits>
-#include <variant>
-
 #include <gtest/gtest.h>
 
 #include <EngineInterface/CellTypeConstants.h>
@@ -14,7 +11,7 @@ class AppendNodeMutationTests : public MutationTestsBase
 
 TEST_F(AppendNodeMutationTests, appendNodeMutation_addsExactlyOneNodePerPass)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -23,59 +20,44 @@ TEST_F(AppendNodeMutationTests, appendNodeMutation_addsExactlyOneNodePerPass)
     _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 3u);
-}
-
-TEST_F(AppendNodeMutationTests, appendNodeMutation_increasesNodeCount)
-{
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 10; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
-
-    auto actualGenome = getMutatedGenome();
-    EXPECT_GT(actualGenome._genes.at(0)._nodes.size(), genome._genes.at(0)._nodes.size());
-}
-
-TEST_F(AppendNodeMutationTests, appendNodeMutation_newNodesHaveDefaultAttributes)
-{
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
-
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
-
-    _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 20; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
-
-    auto actualGenome = getMutatedGenome();
-    for (auto const& node : actualGenome._genes.at(0)._nodes) {
-        // Appended nodes get a random non-void cell type and random mode, but node-level attributes stay at their defaults.
-        EXPECT_NE(node.getCellType(), CellType_Void);
-        EXPECT_EQ(node._referenceAngle, 0.0f);
-        EXPECT_EQ(node._color, 0);
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    EXPECT_EQ(3, nodes.size());
+    for (auto const& node : nodes) {
+        // Each node has a non-void cell type; the appended node keeps default node-level attributes.
+        EXPECT_NE(CellType_Void, node.getCellType());
+        EXPECT_EQ(0.0f, node._referenceAngle);
         EXPECT_FALSE(node._constructor.has_value());
+    }
+}
+
+TEST_F(AppendNodeMutationTests, appendNodeMutation_newNodeInheritsNeighborColor)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().color(3), NodeDesc().color(3)})});
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    EXPECT_EQ(3, nodes.size());
+    for (auto const& node : nodes) {
+        EXPECT_EQ(3, node._color);
     }
 }
 
 TEST_F(AppendNodeMutationTests, appendNodeMutation_zeroProbabilityNoChange)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome, genome);
+    EXPECT_EQ(genome, actualGenome);
 }

--- a/source/EngineTests/AppendNodeMutationTests.cpp
+++ b/source/EngineTests/AppendNodeMutationTests.cpp
@@ -1,0 +1,81 @@
+#include <type_traits>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class AppendNodeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(AppendNodeMutationTests, appendNodeMutation_addsExactlyOneNodePerPass)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 3u);
+}
+
+TEST_F(AppendNodeMutationTests, appendNodeMutation_increasesNodeCount)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 10; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_GT(actualGenome._genes.at(0)._nodes.size(), genome._genes.at(0)._nodes.size());
+}
+
+TEST_F(AppendNodeMutationTests, appendNodeMutation_newNodesHaveDefaultAttributes)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 20; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    for (auto const& node : actualGenome._genes.at(0)._nodes) {
+        // Appended nodes get a random non-void cell type and random mode, but node-level attributes stay at their defaults.
+        EXPECT_NE(node.getCellType(), CellType_Void);
+        EXPECT_EQ(node._referenceAngle, 0.0f);
+        EXPECT_EQ(node._color, 0);
+        EXPECT_FALSE(node._constructor.has_value());
+    }
+}
+
+TEST_F(AppendNodeMutationTests, appendNodeMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(EngineTests
 PUBLIC
     AccumulatedMutationTests.cpp
+    AddNodeMutationTests.cpp
+    AppendNodeMutationTests.cpp
     AttackerTests.cpp
     BalanceTests.cpp
     CellStateTransitionTests.cpp
@@ -15,6 +17,7 @@ PUBLIC
     CreatureTests.cpp
     DataTransferTests.cpp
     DefenderTests.cpp
+    DeleteNodeMutationTests.cpp
     DepotTests.cpp
     DescriptionEditTests.cpp
     DetonatorTests.cpp
@@ -44,6 +47,7 @@ PUBLIC
     SimulationControlTests.cpp
     StatisticsTests.cpp
     Testsuite.cpp
+    TrimNodeMutationTests.cpp
     VoidMutationTests.cpp
     VoidTests.cpp)
 

--- a/source/EngineTests/DeleteNodeMutationTests.cpp
+++ b/source/EngineTests/DeleteNodeMutationTests.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class DeleteNodeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(DeleteNodeMutationTests, deleteNodeMutation_removesExactlyOneNodePerPass)
+{
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 2u);
+}
+
+TEST_F(DeleteNodeMutationTests, deleteNodeMutation_keepsAtLeastOneNode)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 1u);
+}
+
+TEST_F(DeleteNodeMutationTests, deleteNodeMutation_keepsFirstAndLastNonVoid)
+{
+    // Deleting a boundary node can expose an interior void node; it must be corrected to a non-void cell type.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({
+        NodeDesc().cellType(BaseGenomeDesc()),
+        NodeDesc().cellType(VoidGenomeDesc()),
+        NodeDesc().cellType(BaseGenomeDesc()),
+    })});
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    ASSERT_GE(nodes.size(), 1u);
+    EXPECT_NE(nodes.front().getCellType(), CellType_Void);
+    EXPECT_NE(nodes.back().getCellType(), CellType_Void);
+}
+
+TEST_F(DeleteNodeMutationTests, deleteNodeMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}

--- a/source/EngineTests/DeleteNodeMutationTests.cpp
+++ b/source/EngineTests/DeleteNodeMutationTests.cpp
@@ -11,8 +11,7 @@ class DeleteNodeMutationTests : public MutationTestsBase
 
 TEST_F(DeleteNodeMutationTests, deleteNodeMutation_removesExactlyOneNodePerPass)
 {
-    auto genome = GenomeDesc().genes(
-        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
     genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -21,62 +20,54 @@ TEST_F(DeleteNodeMutationTests, deleteNodeMutation_removesExactlyOneNodePerPass)
     _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 2u);
+    EXPECT_EQ(2, actualGenome._genes.at(0)._nodes.size());
 }
 
 TEST_F(DeleteNodeMutationTests, deleteNodeMutation_keepsAtLeastOneNode)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 5; ++i) {
         _simulationFacade->testOnly_mutate(1);
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 1u);
+    EXPECT_EQ(1, actualGenome._genes.at(0)._nodes.size());
 }
 
 TEST_F(DeleteNodeMutationTests, deleteNodeMutation_keepsFirstAndLastNonVoid)
 {
-    // Deleting a boundary node can expose an interior void node; it must be corrected to a non-void cell type.
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({
-        NodeDesc().cellType(BaseGenomeDesc()),
-        NodeDesc().cellType(VoidGenomeDesc()),
-        NodeDesc().cellType(BaseGenomeDesc()),
-    })});
+    // Deleting a boundary node can expose the interior void node; it must be corrected to a non-void cell type.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc().cellType(VoidGenomeDesc()), NodeDesc()})});
     genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 5; ++i) {
         _simulationFacade->testOnly_mutate(1);
     }
 
     auto actualGenome = getMutatedGenome();
     auto const& nodes = actualGenome._genes.at(0)._nodes;
-    ASSERT_GE(nodes.size(), 1u);
-    EXPECT_NE(nodes.front().getCellType(), CellType_Void);
-    EXPECT_NE(nodes.back().getCellType(), CellType_Void);
+    EXPECT_NE(CellType_Void, nodes.front().getCellType());
+    EXPECT_NE(CellType_Void, nodes.back().getCellType());
 }
 
 TEST_F(DeleteNodeMutationTests, deleteNodeMutation_zeroProbabilityNoChange)
 {
-    auto genome = GenomeDesc().genes(
-        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
     genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome, genome);
+    EXPECT_EQ(genome, actualGenome);
 }

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -313,6 +313,166 @@ TEST_F(MetaMutationTests, metaMutation_voidRatesZeroSigmaNoChange)
     EXPECT_EQ(actualGenome._mutationRates._voidMutation._nodeProbability, 0.5f);
 }
 
+TEST_F(MetaMutationTests, metaMutation_appendNodeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationAppendNodeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._appendNodeMutation._geneProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_appendNodeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationAppendNodeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.5f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_addNodeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationAddNodeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._addNodeMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._addNodeMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._addNodeMutation._geneProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_addNodeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._addNodeMutation = AddNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationAddNodeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._addNodeMutation._geneProbability, 0.5f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_trimNodeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationTrimNodeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._trimNodeMutation._geneProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_trimNodeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationTrimNodeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.5f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_deleteNodeRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationDeleteNodeSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._deleteNodeMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._deleteNodeMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._deleteNodeMutation._geneProbability, 1.0f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_deleteNodeRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().geneProbability(0.5f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.metaMutationDeleteNodeSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._deleteNodeMutation._geneProbability, 0.5f);
+}
+
 TEST_F(MetaMutationTests, metaMutation_constructorRatesActuallyChange)
 {
     auto genome = createTestGenome();

--- a/source/EngineTests/TrimNodeMutationTests.cpp
+++ b/source/EngineTests/TrimNodeMutationTests.cpp
@@ -11,8 +11,7 @@ class TrimNodeMutationTests : public MutationTestsBase
 
 TEST_F(TrimNodeMutationTests, trimNodeMutation_removesExactlyOneNodePerPass)
 {
-    auto genome = GenomeDesc().genes(
-        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
     genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -21,33 +20,29 @@ TEST_F(TrimNodeMutationTests, trimNodeMutation_removesExactlyOneNodePerPass)
     _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 2u);
+    EXPECT_EQ(2, actualGenome._genes.at(0)._nodes.size());
 }
 
 TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsAtLeastOneNode)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
     genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 5; ++i) {
         _simulationFacade->testOnly_mutate(1);
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 1u);
+    EXPECT_EQ(1, actualGenome._genes.at(0)._nodes.size());
 }
 
 TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsFirstAndLastNonVoid)
 {
-    // Trimming a boundary node can expose an interior void node; it must be corrected to a non-void cell type.
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({
-        NodeDesc().cellType(BaseGenomeDesc()),
-        NodeDesc().cellType(VoidGenomeDesc()),
-        NodeDesc().cellType(BaseGenomeDesc()),
-    })});
+    // Trimming a boundary node exposes the interior void node; it must be corrected to a non-void cell type.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc().cellType(VoidGenomeDesc()), NodeDesc()})});
     genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -57,24 +52,20 @@ TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsFirstAndLastNonVoid)
 
     auto actualGenome = getMutatedGenome();
     auto const& nodes = actualGenome._genes.at(0)._nodes;
-    ASSERT_GE(nodes.size(), 1u);
-    EXPECT_NE(nodes.front().getCellType(), CellType_Void);
-    EXPECT_NE(nodes.back().getCellType(), CellType_Void);
+    EXPECT_NE(CellType_Void, nodes.front().getCellType());
+    EXPECT_NE(CellType_Void, nodes.back().getCellType());
 }
 
 TEST_F(TrimNodeMutationTests, trimNodeMutation_zeroProbabilityNoChange)
 {
-    auto genome = GenomeDesc().genes(
-        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
     genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 100; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome, genome);
+    EXPECT_EQ(genome, actualGenome);
 }

--- a/source/EngineTests/TrimNodeMutationTests.cpp
+++ b/source/EngineTests/TrimNodeMutationTests.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class TrimNodeMutationTests : public MutationTestsBase
+{};
+
+TEST_F(TrimNodeMutationTests, trimNodeMutation_removesExactlyOneNodePerPass)
+{
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 2u);
+}
+
+TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsAtLeastOneNode)
+{
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._genes.at(0)._nodes.size(), 1u);
+}
+
+TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsFirstAndLastNonVoid)
+{
+    // Trimming a boundary node can expose an interior void node; it must be corrected to a non-void cell type.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({
+        NodeDesc().cellType(BaseGenomeDesc()),
+        NodeDesc().cellType(VoidGenomeDesc()),
+        NodeDesc().cellType(BaseGenomeDesc()),
+    })});
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    auto const& nodes = actualGenome._genes.at(0)._nodes;
+    ASSERT_GE(nodes.size(), 1u);
+    EXPECT_NE(nodes.front().getCellType(), CellType_Void);
+    EXPECT_NE(nodes.back().getCellType(), CellType_Void);
+}
+
+TEST_F(TrimNodeMutationTests, trimNodeMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc()), NodeDesc().cellType(BaseGenomeDesc())})});
+    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome, genome);
+}

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -147,6 +147,24 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    template <typename MutationDesc>
+    void processGeneProbabilityMutationRate(std::string const& name, std::string const& id, MutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Gene probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._geneProbability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     void processConstructorMutationRate(std::string const& name, std::string const& id, ConstructorMutationDesc& mutation, float rightColumnWidth)
     {
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
@@ -236,6 +254,14 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
         settings.getValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
     mutationRates._voidMutation._nodeProbability =
         settings.getValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
+    mutationRates._appendNodeMutation._geneProbability =
+        settings.getValue(settingsPrefix + "append node mutation.gene probability", mutationRates._appendNodeMutation._geneProbability);
+    mutationRates._addNodeMutation._geneProbability =
+        settings.getValue(settingsPrefix + "add node mutation.gene probability", mutationRates._addNodeMutation._geneProbability);
+    mutationRates._trimNodeMutation._geneProbability =
+        settings.getValue(settingsPrefix + "trim node mutation.gene probability", mutationRates._trimNodeMutation._geneProbability);
+    mutationRates._deleteNodeMutation._geneProbability =
+        settings.getValue(settingsPrefix + "delete node mutation.gene probability", mutationRates._deleteNodeMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -280,6 +306,10 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
+    settings.setValue(settingsPrefix + "append node mutation.gene probability", mutationRates._appendNodeMutation._geneProbability);
+    settings.setValue(settingsPrefix + "add node mutation.gene probability", mutationRates._addNodeMutation._geneProbability);
+    settings.setValue(settingsPrefix + "trim node mutation.gene probability", mutationRates._trimNodeMutation._geneProbability);
+    settings.setValue(settingsPrefix + "delete node mutation.gene probability", mutationRates._deleteNodeMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -346,6 +376,38 @@ void MutationRatesDialog::processIntern()
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Void mutations").rank(AlienGui::TreeNodeRank::High))) {
             processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
                 processVoidMutationRate("Mutation rate", "VM", _mutation._voidMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Append node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processGeneProbabilityMutationRate("Mutation rate", "APNM", _mutation._appendNodeMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Add node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processGeneProbabilityMutationRate("Mutation rate", "ADNM", _mutation._addNodeMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Trim node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processGeneProbabilityMutationRate("Mutation rate", "TRNM", _mutation._trimNodeMutation, rightColumnWidth);
+                table.next();
+            });
+        }
+        AlienGui::EndTreeNode();
+
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
+                processGeneProbabilityMutationRate("Mutation rate", "DLNM", _mutation._deleteNodeMutation, rightColumnWidth);
                 table.next();
             });
         }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -306,6 +306,14 @@ namespace
 
     auto constexpr Id_VoidMutation_NodeProbability = 0;
 
+    auto constexpr Id_AppendNodeMutation_GeneProbability = 0;
+
+    auto constexpr Id_AddNodeMutation_GeneProbability = 0;
+
+    auto constexpr Id_TrimNodeMutation_GeneProbability = 0;
+
+    auto constexpr Id_DeleteNodeMutation_GeneProbability = 0;
+
     auto constexpr Id_ConstructorMutation_NodeProbability = 0;
     auto constexpr Id_ConstructorMutation_Sigma = 1;
     auto constexpr Id_ConstructorMutation_DiscreteChangeProbability = 2;
@@ -437,6 +445,10 @@ namespace
     auto constexpr Id_MutationRates_VoidMutation = 9;
     auto constexpr Id_MutationRates_ConstructorMutation1 = 10;
     auto constexpr Id_MutationRates_ConstructorMutation2 = 11;
+    auto constexpr Id_MutationRates_AppendNodeMutation = 12;
+    auto constexpr Id_MutationRates_AddNodeMutation = 13;
+    auto constexpr Id_MutationRates_TrimNodeMutation = 14;
+    auto constexpr Id_MutationRates_DeleteNodeMutation = 15;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -938,6 +950,42 @@ namespace cereal
     SPLIT_SERIALIZATION(VoidMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, AppendNodeMutationDesc& data)
+    {
+        AppendNodeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_AppendNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(AppendNodeMutationDesc)
+
+    template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, AddNodeMutationDesc& data)
+    {
+        AddNodeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_AddNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(AddNodeMutationDesc)
+
+    template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, TrimNodeMutationDesc& data)
+    {
+        TrimNodeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_TrimNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(TrimNodeMutationDesc)
+
+    template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, DeleteNodeMutationDesc& data)
+    {
+        DeleteNodeMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_DeleteNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(DeleteNodeMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, ConstructorMutationDesc& data)
     {
         ConstructorMutationDesc defaultObject;
@@ -962,6 +1010,10 @@ namespace cereal
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);
+        scope.addDesc(Id_MutationRates_AppendNodeMutation, data._appendNodeMutation);
+        scope.addDesc(Id_MutationRates_AddNodeMutation, data._addNodeMutation);
+        scope.addDesc(Id_MutationRates_TrimNodeMutation, data._trimNodeMutation);
+        scope.addDesc(Id_MutationRates_DeleteNodeMutation, data._deleteNodeMutation);
         scope.addDesc(Id_MutationRates_ConstructorMutation1, data._constructorMutations[0]);
         scope.addDesc(Id_MutationRates_ConstructorMutation2, data._constructorMutations[1]);
     }


### PR DESCRIPTION
## Summary

Adds four new mutation types operating on the node structure of a gene, each
configured by a single `geneProbability`:

- **AppendNodeMutation** — insert a new node at the start or end of a gene.
- **AddNodeMutation** — insert a new node at an arbitrary position.
- **TrimNodeMutation** — remove a node at the start or end of a gene.
- **DeleteNodeMutation** — remove a node at an arbitrary position.

New nodes get a random non-void cell type and a random mode, with every
attribute left at its default value. Trim/Delete always keep at least one node
per gene. After the structural mutations the genome is corrected so the first
and last node of a gene are never void, and `accumulatedMutations` is increased
per event.

## Changes

- New mutation types in `GenomeDesc.h`, `GenomeTO.cuh`, `Genome.cuh` and the
  `MutationRates*` structures.
- Data transfer / serialization: `DescConverterService`, `DataAccessKernels`,
  `EntityFactory`, `SerializerService`, `GenomeDescHash`, `getActiveMutationTypes`,
  `DescValidationService`, `DescTestDataFactory`.
- GUI: new sliders in `MutationRatesDialog` (plus settings load/save).
- Simulation parameters: `metaMutation{Append,Add,Trim,Delete}NodeSigma` with specs.
- Engine: `applyMutations_{append,add,trim,delete}Node`, helpers for creating
  default nodes and inserting/removing nodes, `correctGenome`, and the meta
  mutation extension. The structural block and correction are gated behind an
  active node mutation (with a sync) so other genomes stay untouched.

## Tests

- New suites `AppendNodeMutationTests`, `AddNodeMutationTests`,
  `TrimNodeMutationTests`, `DeleteNodeMutationTests`.
- Extended `AccumulatedMutationTests` and `MetaMutationTests`.
- Full build green; `EngineTests` 3047 passed / 0 failed (3 pre-existing skips),
  `EngineInterfaceTests`, `NetworkTests`, `PersisterTests` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)