### PR TITLE
Rename mutation and meta-mutation rate parameters

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -873,20 +873,20 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._resistanceToInjection = genomeTO.resistanceToInjection;
     for (int i = 0; i < 2; ++i) {
         result._mutationRates._neuronMutations[i]._nodeProbability = genomeTO.mutationRates.neuronMutations[i].nodeProbability;
-        result._mutationRates._neuronMutations[i]._weightSigma = genomeTO.mutationRates.neuronMutations[i].weightSigma;
-        result._mutationRates._neuronMutations[i]._biasSigma = genomeTO.mutationRates.neuronMutations[i].biasSigma;
-        result._mutationRates._neuronMutations[i]._activationFunctionProbability = genomeTO.mutationRates.neuronMutations[i].activationFunctionProbability;
+        result._mutationRates._neuronMutations[i]._weightChangeSigma = genomeTO.mutationRates.neuronMutations[i].weightChangeSigma;
+        result._mutationRates._neuronMutations[i]._biasChangeSigma = genomeTO.mutationRates.neuronMutations[i].biasChangeSigma;
+        result._mutationRates._neuronMutations[i]._actfnChangeProbability = genomeTO.mutationRates.neuronMutations[i].actfnChangeProbability;
         result._mutationRates._connectionMutations[i]._nodeProbability = genomeTO.mutationRates.connectionMutations[i].nodeProbability;
-        result._mutationRates._connectionMutations[i]._sigma = genomeTO.mutationRates.connectionMutations[i].sigma;
+        result._mutationRates._connectionMutations[i]._valueChangeSigma = genomeTO.mutationRates.connectionMutations[i].valueChangeSigma;
         result._mutationRates._cellTypePropertiesMutations[i]._nodeProbability = genomeTO.mutationRates.cellTypePropertiesMutations[i].nodeProbability;
-        result._mutationRates._cellTypePropertiesMutations[i]._sigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma;
-        result._mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability =
-            genomeTO.mutationRates.cellTypePropertiesMutations[i].discreteChangeProbability;
+        result._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma;
+        result._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability =
+            genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._nodeProbability = genomeTO.mutationRates.constructorMutations[i].nodeProbability;
-        result._mutationRates._constructorMutations[i]._sigma = genomeTO.mutationRates.constructorMutations[i].sigma;
-        result._mutationRates._constructorMutations[i]._discreteChangeProbability = genomeTO.mutationRates.constructorMutations[i].discreteChangeProbability;
-        result._mutationRates._constructorMutations[i]._existConstructorProbability =
-            genomeTO.mutationRates.constructorMutations[i].existConstructorProbability;
+        result._mutationRates._constructorMutations[i]._valueChangeSigma = genomeTO.mutationRates.constructorMutations[i].valueChangeSigma;
+        result._mutationRates._constructorMutations[i]._enumChangeProbability = genomeTO.mutationRates.constructorMutations[i].enumChangeProbability;
+        result._mutationRates._constructorMutations[i]._constructorToggleProbability =
+            genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability;
     }
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
@@ -974,20 +974,20 @@ void DescConverterService::convertGenomeToTO(
     for (int i = 0; i < 2; ++i) {
         genomeTO.mutationRates.neuronMutations[i] = {
             genome._mutationRates._neuronMutations[i]._nodeProbability,
-            genome._mutationRates._neuronMutations[i]._weightSigma,
-            genome._mutationRates._neuronMutations[i]._biasSigma,
-            genome._mutationRates._neuronMutations[i]._activationFunctionProbability};
+            genome._mutationRates._neuronMutations[i]._weightChangeSigma,
+            genome._mutationRates._neuronMutations[i]._biasChangeSigma,
+            genome._mutationRates._neuronMutations[i]._actfnChangeProbability};
         genomeTO.mutationRates.connectionMutations[i] = {
-            genome._mutationRates._connectionMutations[i]._nodeProbability, genome._mutationRates._connectionMutations[i]._sigma};
+            genome._mutationRates._connectionMutations[i]._nodeProbability, genome._mutationRates._connectionMutations[i]._valueChangeSigma};
         genomeTO.mutationRates.cellTypePropertiesMutations[i] = {
             genome._mutationRates._cellTypePropertiesMutations[i]._nodeProbability,
-            genome._mutationRates._cellTypePropertiesMutations[i]._sigma,
-            genome._mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability};
+            genome._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma,
+            genome._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.constructorMutations[i] = {
             genome._mutationRates._constructorMutations[i]._nodeProbability,
-            genome._mutationRates._constructorMutations[i]._sigma,
-            genome._mutationRates._constructorMutations[i]._discreteChangeProbability,
-            genome._mutationRates._constructorMutations[i]._existConstructorProbability};
+            genome._mutationRates._constructorMutations[i]._valueChangeSigma,
+            genome._mutationRates._constructorMutations[i]._enumChangeProbability,
+            genome._mutationRates._constructorMutations[i]._constructorToggleProbability};
     }
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -21,25 +21,25 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
     genome._accumulatedMutations = std::max(genome._accumulatedMutations, 0.0f);
     auto validateCellTypePropertiesMutation = [](CellTypePropertiesMutationDesc& mutation) {
         mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
-        mutation._sigma = std::clamp(mutation._sigma, 0.0f, 1.0f);
-        mutation._discreteChangeProbability = std::clamp(mutation._discreteChangeProbability, 0.0f, 1.0f);
+        mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
+        mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };
     auto validateConstructorMutation = [](ConstructorMutationDesc& mutation) {
         mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
-        mutation._sigma = std::clamp(mutation._sigma, 0.0f, 1.0f);
-        mutation._discreteChangeProbability = std::clamp(mutation._discreteChangeProbability, 0.0f, 1.0f);
-        mutation._existConstructorProbability = std::clamp(mutation._existConstructorProbability, 0.0f, 1.0f);
+        mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
+        mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
+        mutation._constructorToggleProbability = std::clamp(mutation._constructorToggleProbability, 0.0f, 1.0f);
     };
     for (int i = 0; i < 2; ++i) {
         auto& neuronMutation = genome._mutationRates._neuronMutations[i];
         neuronMutation._nodeProbability = std::clamp(neuronMutation._nodeProbability, 0.0f, 1.0f);
-        neuronMutation._weightSigma = std::max(neuronMutation._weightSigma, 0.0f);
-        neuronMutation._biasSigma = std::max(neuronMutation._biasSigma, 0.0f);
-        neuronMutation._activationFunctionProbability = std::clamp(neuronMutation._activationFunctionProbability, 0.0f, 1.0f);
+        neuronMutation._weightChangeSigma = std::max(neuronMutation._weightChangeSigma, 0.0f);
+        neuronMutation._biasChangeSigma = std::max(neuronMutation._biasChangeSigma, 0.0f);
+        neuronMutation._actfnChangeProbability = std::clamp(neuronMutation._actfnChangeProbability, 0.0f, 1.0f);
 
         auto& connectionMutation = genome._mutationRates._connectionMutations[i];
         connectionMutation._nodeProbability = std::clamp(connectionMutation._nodeProbability, 0.0f, 1.0f);
-        connectionMutation._sigma = std::max(connectionMutation._sigma, 0.0f);
+        connectionMutation._valueChangeSigma = std::max(connectionMutation._valueChangeSigma, 0.0f);
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
         validateConstructorMutation(genome._mutationRates._constructorMutations[i]);

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -417,9 +417,9 @@ struct NeuronMutationDesc
     auto operator<=>(NeuronMutationDesc const&) const = default;
 
     MEMBER(NeuronMutationDesc, float, nodeProbability, 0.0f);
-    MEMBER(NeuronMutationDesc, float, weightSigma, 0.0f);
-    MEMBER(NeuronMutationDesc, float, biasSigma, 0.0f);
-    MEMBER(NeuronMutationDesc, float, activationFunctionProbability, 0.0f);
+    MEMBER(NeuronMutationDesc, float, weightChangeSigma, 0.0f);
+    MEMBER(NeuronMutationDesc, float, biasChangeSigma, 0.0f);
+    MEMBER(NeuronMutationDesc, float, actfnChangeProbability, 0.0f);
 };
 
 struct ConnectionMutationDesc
@@ -427,7 +427,7 @@ struct ConnectionMutationDesc
     auto operator<=>(ConnectionMutationDesc const&) const = default;
 
     MEMBER(ConnectionMutationDesc, float, nodeProbability, 0.0f);
-    MEMBER(ConnectionMutationDesc, float, sigma, 0.0f);
+    MEMBER(ConnectionMutationDesc, float, valueChangeSigma, 0.0f);
 };
 
 struct CellTypePropertiesMutationDesc
@@ -435,8 +435,8 @@ struct CellTypePropertiesMutationDesc
     auto operator<=>(CellTypePropertiesMutationDesc const&) const = default;
 
     MEMBER(CellTypePropertiesMutationDesc, float, nodeProbability, 0.0f);
-    MEMBER(CellTypePropertiesMutationDesc, float, sigma, 0.0f);
-    MEMBER(CellTypePropertiesMutationDesc, float, discreteChangeProbability, 0.0f);
+    MEMBER(CellTypePropertiesMutationDesc, float, valueChangeSigma, 0.0f);
+    MEMBER(CellTypePropertiesMutationDesc, float, enumChangeProbability, 0.0f);
 };
 
 struct CellTypeModeMutationDesc
@@ -493,9 +493,9 @@ struct ConstructorMutationDesc
     auto operator<=>(ConstructorMutationDesc const&) const = default;
 
     MEMBER(ConstructorMutationDesc, float, nodeProbability, 0.0f);
-    MEMBER(ConstructorMutationDesc, float, sigma, 0.0f);
-    MEMBER(ConstructorMutationDesc, float, discreteChangeProbability, 0.0f);
-    MEMBER(ConstructorMutationDesc, float, existConstructorProbability, 0.0f);
+    MEMBER(ConstructorMutationDesc, float, valueChangeSigma, 0.0f);
+    MEMBER(ConstructorMutationDesc, float, enumChangeProbability, 0.0f);
+    MEMBER(ConstructorMutationDesc, float, constructorToggleProbability, 0.0f);
 };
 
 struct MutationRatesDesc
@@ -512,20 +512,20 @@ struct MutationRatesDesc
         NeuronMutationArray,
         neuronMutations,
         (NeuronMutationArray{
-            {NeuronMutationDesc().weightSigma(0.05f).biasSigma(0.05f).activationFunctionProbability(0.05f),
-             NeuronMutationDesc().weightSigma(0.5f).biasSigma(0.5f).activationFunctionProbability(0.5f)}}));
+            {NeuronMutationDesc().weightChangeSigma(0.05f).biasChangeSigma(0.05f).actfnChangeProbability(0.05f),
+             NeuronMutationDesc().weightChangeSigma(0.5f).biasChangeSigma(0.5f).actfnChangeProbability(0.5f)}}));
     MEMBER(
         MutationRatesDesc,
         ConnectionMutationArray,
         connectionMutations,
-        (ConnectionMutationArray{{ConnectionMutationDesc().sigma(0.05f), ConnectionMutationDesc().sigma(0.5f)}}));
+        (ConnectionMutationArray{{ConnectionMutationDesc().valueChangeSigma(0.05f), ConnectionMutationDesc().valueChangeSigma(0.5f)}}));
     MEMBER(
         MutationRatesDesc,
         CellTypePropertiesMutationArray,
         cellTypePropertiesMutations,
         (CellTypePropertiesMutationArray{
-            {CellTypePropertiesMutationDesc().sigma(0.05f).discreteChangeProbability(0.05f),
-             CellTypePropertiesMutationDesc().sigma(0.5f).discreteChangeProbability(0.5f)}}));
+            {CellTypePropertiesMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
+             CellTypePropertiesMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
@@ -538,8 +538,8 @@ struct MutationRatesDesc
         ConstructorMutationArray,
         constructorMutations,
         (ConstructorMutationArray{
-            {ConstructorMutationDesc().sigma(0.05f).discreteChangeProbability(0.05f).existConstructorProbability(0.05f),
-             ConstructorMutationDesc().discreteChangeProbability(0.5f).existConstructorProbability(0.5f)}}));
+            {ConstructorMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f).constructorToggleProbability(0.05f),
+             ConstructorMutationDesc().enumChangeProbability(0.5f).constructorToggleProbability(0.5f)}}));
 };
 
 struct GenomeDesc

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -545,18 +545,18 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._prevLineageId);
         for (int i = 0; i < 2; ++i) {
             hash_combine(seed, desc._mutationRates._neuronMutations[i]._nodeProbability);
-            hash_combine(seed, desc._mutationRates._neuronMutations[i]._weightSigma);
-            hash_combine(seed, desc._mutationRates._neuronMutations[i]._biasSigma);
-            hash_combine(seed, desc._mutationRates._neuronMutations[i]._activationFunctionProbability);
+            hash_combine(seed, desc._mutationRates._neuronMutations[i]._weightChangeSigma);
+            hash_combine(seed, desc._mutationRates._neuronMutations[i]._biasChangeSigma);
+            hash_combine(seed, desc._mutationRates._neuronMutations[i]._actfnChangeProbability);
             hash_combine(seed, desc._mutationRates._connectionMutations[i]._nodeProbability);
-            hash_combine(seed, desc._mutationRates._connectionMutations[i]._sigma);
+            hash_combine(seed, desc._mutationRates._connectionMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
-            hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._sigma);
-            hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability);
+            hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
+            hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._nodeProbability);
-            hash_combine(seed, desc._mutationRates._constructorMutations[i]._sigma);
-            hash_combine(seed, desc._mutationRates._constructorMutations[i]._discreteChangeProbability);
-            hash_combine(seed, desc._mutationRates._constructorMutations[i]._existConstructorProbability);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._valueChangeSigma);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._enumChangeProbability);
+            hash_combine(seed, desc._mutationRates._constructorMutations[i]._constructorToggleProbability);
         }
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -457,47 +457,47 @@ ParametersSpec const& SimulationParameters::getSpec()
                 .parameters({
                     ParameterSpec()
                         .name("Neuron mutations sigma")
-                        .reference(FloatSpec().member(&SimulationParameters::metaMutationNeuronsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                        .reference(FloatSpec().member(&SimulationParameters::neuronsMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Connection mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationConnectionsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::connectionsMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Cell type property mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationCellTypePropertiesSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::cellTypePropertiesMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Cell type mode mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationCellTypeModeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::cellTypeModeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Cell type mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationCellTypeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::cellTypeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Void mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationVoidSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::voidMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Append node mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationAppendNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::appendNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Add node mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationAddNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::addNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Trim node mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationTrimNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::trimNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Delete node mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationDeleteNodeSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::deleteNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Constructor mutations sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::metaMutationConstructorSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::constructorMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("New lineage threshold")
                         .reference(

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -106,17 +106,17 @@ struct SimulationParameters
     BaseParameter<ColorVector<float>> constructorConnectingCellDistance = {ColorVector<float>::uniform(3.5f)};
 
     // Meta mutations
-    BaseParameter<float> metaMutationNeuronsSigma = {0};
-    BaseParameter<float> metaMutationConnectionsSigma = {0};
-    BaseParameter<float> metaMutationCellTypePropertiesSigma = {0};
-    BaseParameter<float> metaMutationCellTypeModeSigma = {0};
-    BaseParameter<float> metaMutationCellTypeSigma = {0};
-    BaseParameter<float> metaMutationVoidSigma = {0};
-    BaseParameter<float> metaMutationAppendNodeSigma = {0};
-    BaseParameter<float> metaMutationAddNodeSigma = {0};
-    BaseParameter<float> metaMutationTrimNodeSigma = {0};
-    BaseParameter<float> metaMutationDeleteNodeSigma = {0};
-    BaseParameter<float> metaMutationConstructorSigma = {0};
+    BaseParameter<float> neuronsMetaMutationsSigma = {0};
+    BaseParameter<float> connectionsMetaMutationsSigma = {0};
+    BaseParameter<float> cellTypePropertiesMetaMutationsSigma = {0};
+    BaseParameter<float> cellTypeModeMetaMutationsSigma = {0};
+    BaseParameter<float> cellTypeMetaMutationsSigma = {0};
+    BaseParameter<float> voidMetaMutationsSigma = {0};
+    BaseParameter<float> appendNodeMetaMutationsSigma = {0};
+    BaseParameter<float> addNodeMetaMutationsSigma = {0};
+    BaseParameter<float> trimNodeMetaMutationsSigma = {0};
+    BaseParameter<float> deleteNodeMetaMutationsSigma = {0};
+    BaseParameter<float> constructorMetaMutationsSigma = {0};
     BaseParameter<float> newLineageThreshold = {Infinity<float>::value};
 
     // Cell type: Attacker

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -39,20 +39,20 @@ namespace
             for (int i = 0; i < 2; ++i) {
                 genomeTO.mutationRates.neuronMutations[i] = {
                     genome->mutationRates.neuronMutations[i].nodeProbability,
-                    genome->mutationRates.neuronMutations[i].weightSigma,
-                    genome->mutationRates.neuronMutations[i].biasSigma,
-                    genome->mutationRates.neuronMutations[i].activationFunctionProbability};
+                    genome->mutationRates.neuronMutations[i].weightChangeSigma,
+                    genome->mutationRates.neuronMutations[i].biasChangeSigma,
+                    genome->mutationRates.neuronMutations[i].actfnChangeProbability};
                 genomeTO.mutationRates.connectionMutations[i] = {
-                    genome->mutationRates.connectionMutations[i].nodeProbability, genome->mutationRates.connectionMutations[i].sigma};
+                    genome->mutationRates.connectionMutations[i].nodeProbability, genome->mutationRates.connectionMutations[i].valueChangeSigma};
                 genomeTO.mutationRates.cellTypePropertiesMutations[i] = {
                     genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability,
-                    genome->mutationRates.cellTypePropertiesMutations[i].sigma,
-                    genome->mutationRates.cellTypePropertiesMutations[i].discreteChangeProbability};
+                    genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
+                    genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.constructorMutations[i] = {
                     genome->mutationRates.constructorMutations[i].nodeProbability,
-                    genome->mutationRates.constructorMutations[i].sigma,
-                    genome->mutationRates.constructorMutations[i].discreteChangeProbability,
-                    genome->mutationRates.constructorMutations[i].existConstructorProbability};
+                    genome->mutationRates.constructorMutations[i].valueChangeSigma,
+                    genome->mutationRates.constructorMutations[i].enumChangeProbability,
+                    genome->mutationRates.constructorMutations[i].constructorToggleProbability};
             }
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -94,20 +94,20 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     for (int i = 0; i < 2; ++i) {
         genome->mutationRates.neuronMutations[i] = {
             genomeTO.mutationRates.neuronMutations[i].nodeProbability,
-            genomeTO.mutationRates.neuronMutations[i].weightSigma,
-            genomeTO.mutationRates.neuronMutations[i].biasSigma,
-            genomeTO.mutationRates.neuronMutations[i].activationFunctionProbability};
+            genomeTO.mutationRates.neuronMutations[i].weightChangeSigma,
+            genomeTO.mutationRates.neuronMutations[i].biasChangeSigma,
+            genomeTO.mutationRates.neuronMutations[i].actfnChangeProbability};
         genome->mutationRates.connectionMutations[i] = {
-            genomeTO.mutationRates.connectionMutations[i].nodeProbability, genomeTO.mutationRates.connectionMutations[i].sigma};
+            genomeTO.mutationRates.connectionMutations[i].nodeProbability, genomeTO.mutationRates.connectionMutations[i].valueChangeSigma};
         genome->mutationRates.cellTypePropertiesMutations[i] = {
             genomeTO.mutationRates.cellTypePropertiesMutations[i].nodeProbability,
-            genomeTO.mutationRates.cellTypePropertiesMutations[i].sigma,
-            genomeTO.mutationRates.cellTypePropertiesMutations[i].discreteChangeProbability};
+            genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
+            genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
         genome->mutationRates.constructorMutations[i] = {
             genomeTO.mutationRates.constructorMutations[i].nodeProbability,
-            genomeTO.mutationRates.constructorMutations[i].sigma,
-            genomeTO.mutationRates.constructorMutations[i].discreteChangeProbability,
-            genomeTO.mutationRates.constructorMutations[i].existConstructorProbability};
+            genomeTO.mutationRates.constructorMutations[i].valueChangeSigma,
+            genomeTO.mutationRates.constructorMutations[i].enumChangeProbability,
+            genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability};
     }
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -343,22 +343,22 @@ struct Gene
 struct NeuronMutation
 {
     float nodeProbability;
-    float weightSigma;
-    float biasSigma;
-    float activationFunctionProbability;
+    float weightChangeSigma;
+    float biasChangeSigma;
+    float actfnChangeProbability;
 };
 
 struct ConnectionMutation
 {
     float nodeProbability;
-    float sigma;
+    float valueChangeSigma;
 };
 
 struct CellTypePropertiesMutation
 {
     float nodeProbability;
-    float sigma;
-    float discreteChangeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
 };
 
 struct CellTypeModeMutation
@@ -399,9 +399,9 @@ struct DeleteNodeMutation
 struct ConstructorMutation
 {
     float nodeProbability;
-    float sigma;
-    float discreteChangeProbability;
-    float existConstructorProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
+    float constructorToggleProbability;
 };
 
 struct MutationRates

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -348,22 +348,22 @@ struct GeneTO
 struct NeuronMutationTO
 {
     float nodeProbability;
-    float weightSigma;
-    float biasSigma;
-    float activationFunctionProbability;
+    float weightChangeSigma;
+    float biasChangeSigma;
+    float actfnChangeProbability;
 };
 
 struct ConnectionMutationTO
 {
     float nodeProbability;
-    float sigma;
+    float valueChangeSigma;
 };
 
 struct CellTypePropertiesMutationTO
 {
     float nodeProbability;
-    float sigma;
-    float discreteChangeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
 };
 
 struct CellTypeModeMutationTO
@@ -404,9 +404,9 @@ struct DeleteNodeMutationTO
 struct ConstructorMutationTO
 {
     float nodeProbability;
-    float sigma;
-    float discreteChangeProbability;
-    float existConstructorProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
+    float constructorToggleProbability;
 };
 
 struct MutationRatesTO

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -155,7 +155,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_neurons(SimulationD
 
     for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
         auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || (rate.weightSigma <= 0 && rate.biasSigma <= 0 && rate.activationFunctionProbability <= 0)) {
+        if (rate.nodeProbability <= 0 || (rate.weightChangeSigma <= 0 && rate.biasChangeSigma <= 0 && rate.actfnChangeProbability <= 0)) {
             continue;
         }
         for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
@@ -165,11 +165,11 @@ __inline__ __device__ void MutationProcessor::applyMutations_neurons(SimulationD
                 if (laneId < NEURONS_PER_CELL) {
                     int neuronIndex = laneId;
                     if (data.primaryNumberGen.random() < rate.nodeProbability) {
-                        if (rate.weightSigma > 0) {
+                        if (rate.weightChangeSigma > 0) {
                             auto accumulatedWeightLocal = 0.0f;
                             for (int weightIndex = 0; weightIndex < NEURONS_PER_CELL; ++weightIndex) {
                                 auto& weight = node.neuralNetwork.weights[neuronIndex * NEURONS_PER_CELL + weightIndex];
-                                auto delta = generateGaussian(data) * rate.weightSigma;
+                                auto delta = generateGaussian(data) * rate.weightChangeSigma;
                                 float newValue = weight.getValue() + delta;
                                 newValue = max(-2.0f, min(2.0f, newValue));
                                 weight = NeuralNetWeight(newValue);
@@ -177,15 +177,15 @@ __inline__ __device__ void MutationProcessor::applyMutations_neurons(SimulationD
                             }
                             atomicAdd_block(&accumulatedMutations, accumulatedWeightLocal / (NEURONS_PER_CELL * NEURONS_PER_CELL));
                         }
-                        if (rate.biasSigma > 0) {
+                        if (rate.biasChangeSigma > 0) {
                             auto& bias = node.neuralNetwork.biases[neuronIndex];
-                            auto delta = generateGaussian(data) * rate.biasSigma;
+                            auto delta = generateGaussian(data) * rate.biasChangeSigma;
                             float newBias = bias + delta;
                             newBias = max(-2.0f, min(2.0f, newBias));
                             bias = newBias;
                             atomicAdd_block(&accumulatedMutations, abs(delta) / NEURONS_PER_CELL);
                         }
-                        if (rate.activationFunctionProbability > 0 && data.primaryNumberGen.random() < rate.activationFunctionProbability) {
+                        if (rate.actfnChangeProbability > 0 && data.primaryNumberGen.random() < rate.actfnChangeProbability) {
                             node.neuralNetwork.activationFunctions[neuronIndex] =
                                 static_cast<ActivationFunction>(data.primaryNumberGen.random(ActivationFunction_Count - 1));
                             atomicAdd_block(&accumulatedMutations, 1.0f / NEURONS_PER_CELL);
@@ -205,7 +205,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_connections(Simulat
 
     for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
         auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || rate.sigma <= 0) {
+        if (rate.nodeProbability <= 0 || rate.valueChangeSigma <= 0) {
             continue;
         }
         for (int geneIndex = 0; geneIndex < genome->numGenes; ++geneIndex) {
@@ -215,7 +215,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_connections(Simulat
                 if (laneId < MAX_OBJECT_CONNECTIONS) {
                     if (data.primaryNumberGen.random() < rate.nodeProbability) {
                         auto& weight = node.neuralNetwork.connectionWeights[laneId];
-                        auto delta = generateGaussian(data) * rate.sigma;
+                        auto delta = generateGaussian(data) * rate.valueChangeSigma;
                         float newValue = weight + delta;
                         newValue = max(-2.0f, min(2.0f, newValue));
                         weight = newValue;
@@ -235,7 +235,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 
     for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
         auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || (rate.sigma <= 0 && rate.discreteChangeProbability <= 0)) {
+        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
             continue;
         }
 
@@ -249,10 +249,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 
                 auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
                     using ValueType = std::decay_t<decltype(value)>;
-                    if (rate.sigma <= 0) {
+                    if (rate.valueChangeSigma <= 0) {
                         return;
                     }
-                    auto delta = generateGaussian(data) * rate.sigma * (maxValue - minValue);
+                    auto delta = generateGaussian(data) * rate.valueChangeSigma * (maxValue - minValue);
                     if constexpr (std::is_integral_v<ValueType>) {
                         auto roundedDelta = static_cast<int>(std::round(delta));
                         auto newValue = max(static_cast<int>(minValue), min(static_cast<int>(maxValue), static_cast<int>(value) + roundedDelta));
@@ -265,7 +265,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                 };
 
                 auto mutateBoolField = [&](bool& value) {
-                    if (data.primaryNumberGen.random() < rate.discreteChangeProbability) {
+                    if (data.primaryNumberGen.random() < rate.enumChangeProbability) {
                         value = !value;
                         atomicAdd_block(&accumulatedMutations, 1.0f);
                     }
@@ -278,7 +278,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                     auto const maskValue = static_cast<UnsignedType>(mask);
                     for (int bitIndex = 0; bitIndex < sizeof(UnsignedType) * 8; ++bitIndex) {
                         auto const bit = UnsignedType{1} << bitIndex;
-                        if ((maskValue & bit) != 0 && data.primaryNumberGen.random() < rate.discreteChangeProbability) {
+                        if ((maskValue & bit) != 0 && data.primaryNumberGen.random() < rate.enumChangeProbability) {
                             newValue ^= bit;
                         }
                     }
@@ -290,7 +290,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 
                 auto mutateEnumField = [&](auto& value, int count) {
                     using ValueType = std::decay_t<decltype(value)>;
-                    if (count > 1 && data.primaryNumberGen.random() < rate.discreteChangeProbability) {
+                    if (count > 1 && data.primaryNumberGen.random() < rate.enumChangeProbability) {
                         auto currentValue = static_cast<int>(value);
                         auto newValue = data.primaryNumberGen.random(count - 2);
                         if (newValue >= currentValue) {
@@ -429,10 +429,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                 case CellType_Memory: {
                     mutateBitset(node.cellTypeData.memory.channelBitMask, Const::MemoryChannelBitMask_Max);
 
-                    if (rate.sigma > 0) {
+                    if (rate.valueChangeSigma > 0) {
                         auto& memory = node.cellTypeData.memory;
                         auto oldNumSignalEntries = toInt(memory.numSignalEntries);
-                        auto roundedDelta = toInt(std::round(generateGaussian(data) * rate.sigma));
+                        auto roundedDelta = toInt(std::round(generateGaussian(data) * rate.valueChangeSigma));
                         auto newNumSignalEntries =
                             max(Const::MemoryNumSignalEntries_Min, min(Const::MemoryNumSignalEntries_Max, oldNumSignalEntries + roundedDelta));
                         if (newNumSignalEntries > oldNumSignalEntries) {
@@ -453,7 +453,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                             for (int entryIndex = 0; entryIndex < newNumSignalEntries; ++entryIndex) {
                                 auto& entry = memory.signalEntries[entryIndex];
                                 for (int channelIndex = 0; channelIndex < NEURONS_PER_CELL; ++channelIndex) {
-                                    auto delta = generateGaussian(data) * rate.sigma;
+                                    auto delta = generateGaussian(data) * rate.valueChangeSigma;
                                     auto newValue = max(-2.0f, min(2.0f, entry.channels[channelIndex] + delta));
                                     signalMutations += abs(newValue - entry.channels[channelIndex]);
                                     entry.channels[channelIndex] = newValue;
@@ -1029,7 +1029,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
 
     for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
         auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || (rate.sigma <= 0 && rate.discreteChangeProbability <= 0 && rate.existConstructorProbability <= 0)) {
+        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0 && rate.constructorToggleProbability <= 0)) {
             continue;
         }
 
@@ -1045,10 +1045,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 // Mutate real and integer attributes by a Gaussian step scaled by the value range; the clamping mirrors DescValidationService.
                 auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
                     using ValueType = std::decay_t<decltype(value)>;
-                    if (rate.sigma <= 0) {
+                    if (rate.valueChangeSigma <= 0) {
                         return;
                     }
-                    auto delta = generateGaussian(data) * rate.sigma * (maxValue - minValue);
+                    auto delta = generateGaussian(data) * rate.valueChangeSigma * (maxValue - minValue);
                     if constexpr (std::is_integral_v<ValueType>) {
                         auto roundedDelta = static_cast<int>(std::round(delta));
                         auto newValue = max(static_cast<int>(minValue), min(static_cast<int>(maxValue), static_cast<int>(value) + roundedDelta));
@@ -1061,16 +1061,16 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 };
 
                 auto mutateBoolField = [&](bool& value) {
-                    if (data.primaryNumberGen.random() < rate.discreteChangeProbability) {
+                    if (data.primaryNumberGen.random() < rate.enumChangeProbability) {
                         value = !value;
                         atomicAdd_block(&accumulatedMutations, 1.0f);
                     }
                 };
 
-                // Mutate the attributes of an existing constructor (real/integer via sigma, bool via discreteChangeProbability).
+                // Mutate the attributes of an existing constructor (real/integer via valueChangeSigma, bool via enumChangeProbability).
                 if (node.constructorAvailable) {
                     if (constructor.autoTriggerInterval == 0 || constructor.autoTriggerInterval == Const::ConstructorAutoTriggerInterval_Default) {
-                        if (data.primaryNumberGen.random() < rate.discreteChangeProbability) {
+                        if (data.primaryNumberGen.random() < rate.enumChangeProbability) {
                             constructor.autoTriggerInterval = constructor.autoTriggerInterval == 0 ? Const::ConstructorAutoTriggerInterval_Default : 0;
                             atomicAdd_block(&accumulatedMutations, 1.0f);
                         }
@@ -1095,7 +1095,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_constructor(Simulat
                 }
 
                 // Mutate whether the node has a constructor at all; enabling one initializes it with default values.
-                if (data.primaryNumberGen.random() < rate.existConstructorProbability) {
+                if (data.primaryNumberGen.random() < rate.constructorToggleProbability) {
                     node.constructorAvailable = !node.constructorAvailable;
                     if (node.constructorAvailable) {
                         constructor = {};
@@ -1117,87 +1117,87 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
 
     if (laneId == 0) {
         // Meta-mutate neuron mutation rates
-        float neuronSigma = cudaSimulationParameters.metaMutationNeuronsSigma.value;
+        float neuronSigma = cudaSimulationParameters.neuronsMetaMutationsSigma.value;
         if (neuronSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * neuronSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.neuronMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.neuronMutations[i].weightSigma);
-                mutateFloat(genome->mutationRates.neuronMutations[i].biasSigma);
-                mutateFloat(genome->mutationRates.neuronMutations[i].activationFunctionProbability);
+                mutateFloat(genome->mutationRates.neuronMutations[i].weightChangeSigma);
+                mutateFloat(genome->mutationRates.neuronMutations[i].biasChangeSigma);
+                mutateFloat(genome->mutationRates.neuronMutations[i].actfnChangeProbability);
             }
         }
 
         // Meta-mutate connection mutation rates
-        float connSigma = cudaSimulationParameters.metaMutationConnectionsSigma.value;
+        float connSigma = cudaSimulationParameters.connectionsMetaMutationsSigma.value;
         if (connSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * connSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.connectionMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.connectionMutations[i].sigma);
+                mutateFloat(genome->mutationRates.connectionMutations[i].valueChangeSigma);
             }
         }
 
-        float cellTypeSigma = cudaSimulationParameters.metaMutationCellTypePropertiesSigma.value;
+        float cellTypeSigma = cudaSimulationParameters.cellTypePropertiesMetaMutationsSigma.value;
         if (cellTypeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].sigma);
-                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].discreteChangeProbability);
+                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma);
+                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability);
             }
         }
 
-        float cellTypeModeSigma = cudaSimulationParameters.metaMutationCellTypeModeSigma.value;
+        float cellTypeModeSigma = cudaSimulationParameters.cellTypeModeMetaMutationsSigma.value;
         if (cellTypeModeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeModeSigma)); };
             mutateFloat(genome->mutationRates.cellTypeModeMutation.nodeProbability);
         }
 
-        float cellTypeMutationSigma = cudaSimulationParameters.metaMutationCellTypeSigma.value;
+        float cellTypeMutationSigma = cudaSimulationParameters.cellTypeMetaMutationsSigma.value;
         if (cellTypeMutationSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeMutationSigma)); };
             mutateFloat(genome->mutationRates.cellTypeMutation.nodeProbability);
         }
 
-        float voidMutationSigma = cudaSimulationParameters.metaMutationVoidSigma.value;
+        float voidMutationSigma = cudaSimulationParameters.voidMetaMutationsSigma.value;
         if (voidMutationSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * voidMutationSigma)); };
             mutateFloat(genome->mutationRates.voidMutation.nodeProbability);
         }
 
-        float appendNodeSigma = cudaSimulationParameters.metaMutationAppendNodeSigma.value;
+        float appendNodeSigma = cudaSimulationParameters.appendNodeMetaMutationsSigma.value;
         if (appendNodeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * appendNodeSigma)); };
             mutateFloat(genome->mutationRates.appendNodeMutation.geneProbability);
         }
 
-        float addNodeSigma = cudaSimulationParameters.metaMutationAddNodeSigma.value;
+        float addNodeSigma = cudaSimulationParameters.addNodeMetaMutationsSigma.value;
         if (addNodeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * addNodeSigma)); };
             mutateFloat(genome->mutationRates.addNodeMutation.geneProbability);
         }
 
-        float trimNodeSigma = cudaSimulationParameters.metaMutationTrimNodeSigma.value;
+        float trimNodeSigma = cudaSimulationParameters.trimNodeMetaMutationsSigma.value;
         if (trimNodeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * trimNodeSigma)); };
             mutateFloat(genome->mutationRates.trimNodeMutation.geneProbability);
         }
 
-        float deleteNodeSigma = cudaSimulationParameters.metaMutationDeleteNodeSigma.value;
+        float deleteNodeSigma = cudaSimulationParameters.deleteNodeMetaMutationsSigma.value;
         if (deleteNodeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * deleteNodeSigma)); };
             mutateFloat(genome->mutationRates.deleteNodeMutation.geneProbability);
         }
 
-        float constructorSigma = cudaSimulationParameters.metaMutationConstructorSigma.value;
+        float constructorSigma = cudaSimulationParameters.constructorMetaMutationsSigma.value;
         if (constructorSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * constructorSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.constructorMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.constructorMutations[i].sigma);
-                mutateFloat(genome->mutationRates.constructorMutations[i].discreteChangeProbability);
-                mutateFloat(genome->mutationRates.constructorMutations[i].existConstructorProbability);
+                mutateFloat(genome->mutationRates.constructorMutations[i].valueChangeSigma);
+                mutateFloat(genome->mutationRates.constructorMutations[i].enumChangeProbability);
+                mutateFloat(genome->mutationRates.constructorMutations[i].constructorToggleProbability);
             }
         }
     }

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -175,13 +175,13 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
 {
     auto mutation = MutationRatesDesc()
                         .neuronMutations(
-                            {NeuronMutationDesc().nodeProbability(0.1f).weightSigma(0.2f).biasSigma(0.15f).activationFunctionProbability(0.05f),
-                             NeuronMutationDesc().nodeProbability(0.3f).weightSigma(0.4f).biasSigma(0.35f).activationFunctionProbability(0.25f)})
+                            {NeuronMutationDesc().nodeProbability(0.1f).weightChangeSigma(0.2f).biasChangeSigma(0.15f).actfnChangeProbability(0.05f),
+                             NeuronMutationDesc().nodeProbability(0.3f).weightChangeSigma(0.4f).biasChangeSigma(0.35f).actfnChangeProbability(0.25f)})
                         .connectionMutations(
-                            {ConnectionMutationDesc().nodeProbability(0.6f).sigma(0.7f), ConnectionMutationDesc().nodeProbability(0.8f).sigma(0.9f)})
+                            {ConnectionMutationDesc().nodeProbability(0.6f).valueChangeSigma(0.7f), ConnectionMutationDesc().nodeProbability(0.8f).valueChangeSigma(0.9f)})
                         .cellTypePropertiesMutations(
-                            {CellTypePropertiesMutationDesc().nodeProbability(0.45f).sigma(0.55f).discreteChangeProbability(0.65f),
-                             CellTypePropertiesMutationDesc().nodeProbability(0.75f).sigma(0.85f).discreteChangeProbability(0.95f)})
+                            {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
+                             CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))
@@ -190,8 +190,8 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .trimNodeMutation(TrimNodeMutationDesc().geneProbability(0.43f))
                         .deleteNodeMutation(DeleteNodeMutationDesc().geneProbability(0.44f))
                         .constructorMutations(
-                            {ConstructorMutationDesc().nodeProbability(0.12f).sigma(0.13f).discreteChangeProbability(0.14f).existConstructorProbability(0.15f),
-                             ConstructorMutationDesc().nodeProbability(0.16f).sigma(0.17f).discreteChangeProbability(0.18f).existConstructorProbability(0.19f)});
+                            {ConstructorMutationDesc().nodeProbability(0.12f).valueChangeSigma(0.13f).enumChangeProbability(0.14f).constructorToggleProbability(0.15f),
+                             ConstructorMutationDesc().nodeProbability(0.16f).valueChangeSigma(0.17f).enumChangeProbability(0.18f).constructorToggleProbability(0.19f)});
 
     auto genome = GenomeDesc()
                       .name("Test Genome")

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -52,13 +52,13 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
     switch (GetParam()) {
     case MutationType::Neuron:
         genome._mutationRates._neuronMutations[0] =
-            NeuronMutationDesc().nodeProbability(1.0f).weightSigma(1.0f).biasSigma(1.0f).activationFunctionProbability(1.0f);
+            NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f).biasChangeSigma(1.0f).actfnChangeProbability(1.0f);
         break;
     case MutationType::Connection:
-        genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).sigma(1.0f);
+        genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f);
         break;
     case MutationType::CellTypeProperties:
-        genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
+        genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);
@@ -83,7 +83,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::Constructor:
         genome._mutationRates._constructorMutations[0] =
-            ConstructorMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f).existConstructorProbability(1.0f);
+            ConstructorMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f).constructorToggleProbability(1.0f);
         break;
     }
 
@@ -108,17 +108,17 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationNeuronsSigma.value = 1.0f;
-    _parameters.metaMutationConnectionsSigma.value = 1.0f;
-    _parameters.metaMutationCellTypePropertiesSigma.value = 1.0f;
-    _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
-    _parameters.metaMutationCellTypeSigma.value = 1.0f;
-    _parameters.metaMutationVoidSigma.value = 1.0f;
-    _parameters.metaMutationAppendNodeSigma.value = 1.0f;
-    _parameters.metaMutationAddNodeSigma.value = 1.0f;
-    _parameters.metaMutationTrimNodeSigma.value = 1.0f;
-    _parameters.metaMutationDeleteNodeSigma.value = 1.0f;
-    _parameters.metaMutationConstructorSigma.value = 1.0f;
+    _parameters.neuronsMetaMutationsSigma.value = 1.0f;
+    _parameters.connectionsMetaMutationsSigma.value = 1.0f;
+    _parameters.cellTypePropertiesMetaMutationsSigma.value = 1.0f;
+    _parameters.cellTypeModeMetaMutationsSigma.value = 1.0f;
+    _parameters.cellTypeMetaMutationsSigma.value = 1.0f;
+    _parameters.voidMetaMutationsSigma.value = 1.0f;
+    _parameters.appendNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.addNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.trimNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.deleteNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.constructorMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);

--- a/source/EngineTests/CellTypePropertiesMutationTests.cpp
+++ b/source/EngineTests/CellTypePropertiesMutationTests.cpp
@@ -75,7 +75,8 @@ protected:
 TEST_F(CellTypePropertiesMutationTests, cellTypePropertiesMutation_changesScalarBoolAndEnumProperties)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
+    genome._mutationRates._cellTypePropertiesMutations[0] =
+        CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -124,7 +125,7 @@ TEST_F(CellTypePropertiesMutationTests, cellTypePropertiesMutation_changesScalar
 TEST_F(CellTypePropertiesMutationTests, cellTypePropertiesMutation_changesBitsetPropertiesBitwise)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).discreteChangeProbability(1.0f);
+    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -173,8 +174,10 @@ TEST_F(CellTypePropertiesMutationTests, cellTypePropertiesMutation_changesBitset
 TEST_F(CellTypePropertiesMutationTests, cellTypePropertiesMutation_doesNotChangeOtherAttributes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
-    genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
+    genome._mutationRates._cellTypePropertiesMutations[0] =
+        CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._cellTypePropertiesMutations[1] =
+        CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/ConnectionMutationTests.cpp
+++ b/source/EngineTests/ConnectionMutationTests.cpp
@@ -32,8 +32,8 @@ protected:
 TEST_F(ConnectionMutationTests, connectionWeightMutation_weightsActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).sigma(1.0f);
-    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.0f).sigma(0.0f);
+    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f);
+    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.0f).valueChangeSigma(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -77,8 +77,8 @@ TEST_F(ConnectionMutationTests, connectionWeightMutation_weightsActuallyChange)
 TEST_F(ConnectionMutationTests, connectionWeightMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.0f).sigma(1.0f);
-    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.0f).sigma(1.0f);
+    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.0f).valueChangeSigma(1.0f);
+    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.0f).valueChangeSigma(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -105,8 +105,8 @@ TEST_F(ConnectionMutationTests, connectionWeightMutation_zeroProbabilityNoChange
 TEST_F(ConnectionMutationTests, connectionWeightMutation_keepOtherAttributesUnchanged)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).sigma(1.0f);
-    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(1.0f).sigma(1.0f);
+    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f);
+    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -33,7 +33,7 @@ protected:
 TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttributes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f);
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -45,7 +45,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttribute
     _simulationFacade->testOnly_mutate(1);
     auto const actualGenome = getMutatedGenome();
     auto const& constructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
-    ASSERT_TRUE(constructor.has_value());  // without existConstructorProbability the constructor must never be removed
+    ASSERT_TRUE(constructor.has_value());  // without constructorToggleProbability the constructor must never be removed
     auto const& mutated = constructor.value();
 
     EXPECT_TRUE(mutated._autoTriggerInterval != original._autoTriggerInterval);
@@ -62,7 +62,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
 {
     auto genome = createTestGenome();
     genome._genes.at(0)._nodes.at(0)._constructor.reset();  // node without a constructor
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).existConstructorProbability(1.0f);
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -81,7 +81,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] =
-        ConstructorMutationDesc().nodeProbability(0.0f).sigma(1.0f).discreteChangeProbability(1.0f).existConstructorProbability(1.0f);
+        ConstructorMutationDesc().nodeProbability(0.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -98,9 +98,9 @@ TEST_F(ConstructorMutationTests, constructorMutation_keepOtherAttributesUnchange
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] =
-        ConstructorMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f).existConstructorProbability(1.0f);
+        ConstructorMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f).constructorToggleProbability(1.0f);
     genome._mutationRates._constructorMutations[1] =
-        ConstructorMutationDesc().nodeProbability(1.0f).sigma(1.0f).discreteChangeProbability(1.0f).existConstructorProbability(1.0f);
+        ConstructorMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -118,7 +118,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_existProbabilityTogglesCons
 {
     auto genome = createTestGenome();
     genome._genes.at(0)._nodes.at(0)._constructor.reset();  // one node without a constructor
-    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).existConstructorProbability(1.0f);
+    genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -127,7 +127,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_existProbabilityTogglesCons
 
     auto actualGenome = getMutatedGenome();
 
-    // existConstructorProbability alone must toggle whether a node has a constructor.
+    // constructorToggleProbability alone must toggle whether a node has a constructor.
     EXPECT_TRUE(actualGenome._genes.at(0)._nodes.at(0)._constructor.has_value());   // had none -> gained one
     EXPECT_FALSE(actualGenome._genes.at(0)._nodes.at(1)._constructor.has_value());  // had one -> lost it
 }

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -12,12 +12,12 @@ class MetaMutationTests : public MutationTestsBase
 TEST_F(MetaMutationTests, metaMutation_neuronRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.5f).weightSigma(0.5f).biasSigma(0.5f).activationFunctionProbability(0.5f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.5f).weightSigma(0.5f).biasSigma(0.5f).activationFunctionProbability(0.5f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.5f).weightChangeSigma(0.5f).biasChangeSigma(0.5f).actfnChangeProbability(0.5f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.5f).weightChangeSigma(0.5f).biasChangeSigma(0.5f).actfnChangeProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationNeuronsSigma.value = 1.0f;
+    _parameters.neuronsMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -31,32 +31,32 @@ TEST_F(MetaMutationTests, metaMutation_neuronRatesActuallyChange)
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
     bool anyChanged = actualGenome._mutationRates._neuronMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._neuronMutations[0]._weightSigma != 0.5f || actualGenome._mutationRates._neuronMutations[0]._biasSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[0]._activationFunctionProbability != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._nodeProbability != 0.5f || actualGenome._mutationRates._neuronMutations[1]._weightSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._biasSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._activationFunctionProbability != 0.5f;
+        || actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma != 0.5f || actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma != 0.5f
+        || actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability != 0.5f
+        || actualGenome._mutationRates._neuronMutations[1]._nodeProbability != 0.5f || actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma != 0.5f
+        || actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma != 0.5f
+        || actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability != 0.5f;
     EXPECT_TRUE(anyChanged);
 
     EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._weightSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._biasSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._activationFunctionProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._weightSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._biasSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._activationFunctionProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability, 0.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_neuronRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.5f).weightSigma(0.5f).biasSigma(0.5f).activationFunctionProbability(0.5f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.5f).weightSigma(0.5f).biasSigma(0.5f).activationFunctionProbability(0.5f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.5f).weightChangeSigma(0.5f).biasChangeSigma(0.5f).actfnChangeProbability(0.5f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.5f).weightChangeSigma(0.5f).biasChangeSigma(0.5f).actfnChangeProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationNeuronsSigma.value = 0.0f;
+    _parameters.neuronsMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -70,24 +70,24 @@ TEST_F(MetaMutationTests, metaMutation_neuronRatesZeroSigmaNoChange)
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
     EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._weightSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._biasSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._activationFunctionProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._weightSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._biasSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._activationFunctionProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_connectionRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.5f).sigma(0.5f);
-    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.5f).sigma(0.5f);
+    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f);
+    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationConnectionsSigma.value = 1.0f;
+    _parameters.connectionsMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -101,24 +101,24 @@ TEST_F(MetaMutationTests, metaMutation_connectionRatesActuallyChange)
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
     bool anyChanged = actualGenome._mutationRates._connectionMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._connectionMutations[0]._sigma != 0.5f || actualGenome._mutationRates._connectionMutations[1]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._connectionMutations[1]._sigma != 0.5f;
+        || actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma != 0.5f || actualGenome._mutationRates._connectionMutations[1]._nodeProbability != 0.5f
+        || actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma != 0.5f;
     EXPECT_TRUE(anyChanged);
     EXPECT_GE(actualGenome._mutationRates._connectionMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._connectionMutations[0]._sigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._connectionMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._connectionMutations[1]._sigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma, 0.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_connectionRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.5f).sigma(0.5f);
-    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.5f).sigma(0.5f);
+    genome._mutationRates._connectionMutations[0] = ConnectionMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f);
+    genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationConnectionsSigma.value = 0.0f;
+    _parameters.connectionsMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -132,20 +132,20 @@ TEST_F(MetaMutationTests, metaMutation_connectionRatesZeroSigmaNoChange)
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
     EXPECT_EQ(actualGenome._mutationRates._connectionMutations[0]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[0]._sigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._connectionMutations[1]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[1]._sigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(0.5f).sigma(0.5f).discreteChangeProbability(0.5f);
-    genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc().nodeProbability(0.4f).sigma(0.4f).discreteChangeProbability(0.4f);
+    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypePropertiesSigma.value = 1.0f;
+    _parameters.cellTypePropertiesMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -156,29 +156,29 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesActuallyChange)
     auto actualGenome = getMutatedGenome();
 
     bool anyChanged = actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._sigma != 0.5f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._discreteChangeProbability != 0.5f
+        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma != 0.5f
+        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability != 0.5f
         || actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability != 0.4f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._sigma != 0.4f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._discreteChangeProbability != 0.4f;
+        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma != 0.4f
+        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability != 0.4f;
     EXPECT_TRUE(anyChanged);
     EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._sigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._discreteChangeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._sigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._discreteChangeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability, 0.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(0.5f).sigma(0.5f).discreteChangeProbability(0.5f);
-    genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc().nodeProbability(0.4f).sigma(0.4f).discreteChangeProbability(0.4f);
+    genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypePropertiesSigma.value = 0.0f;
+    _parameters.cellTypePropertiesMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -188,11 +188,11 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 
     auto actualGenome = getMutatedGenome();
     EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._sigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._discreteChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._sigma, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._discreteChangeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability, 0.4f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)
@@ -202,7 +202,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypeModeSigma.value = 1.0f;
+    _parameters.cellTypeModeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -223,7 +223,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypeModeSigma.value = 0.0f;
+    _parameters.cellTypeModeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -242,7 +242,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypeSigma.value = 1.0f;
+    _parameters.cellTypeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -263,7 +263,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationCellTypeSigma.value = 0.0f;
+    _parameters.cellTypeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -282,7 +282,7 @@ TEST_F(MetaMutationTests, metaMutation_voidRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationVoidSigma.value = 1.0f;
+    _parameters.voidMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -301,7 +301,7 @@ TEST_F(MetaMutationTests, metaMutation_voidRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationVoidSigma.value = 0.0f;
+    _parameters.voidMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -320,7 +320,7 @@ TEST_F(MetaMutationTests, metaMutation_appendNodeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationAppendNodeSigma.value = 1.0f;
+    _parameters.appendNodeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -341,7 +341,7 @@ TEST_F(MetaMutationTests, metaMutation_appendNodeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationAppendNodeSigma.value = 0.0f;
+    _parameters.appendNodeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -360,7 +360,7 @@ TEST_F(MetaMutationTests, metaMutation_addNodeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationAddNodeSigma.value = 1.0f;
+    _parameters.addNodeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -381,7 +381,7 @@ TEST_F(MetaMutationTests, metaMutation_addNodeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationAddNodeSigma.value = 0.0f;
+    _parameters.addNodeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -400,7 +400,7 @@ TEST_F(MetaMutationTests, metaMutation_trimNodeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationTrimNodeSigma.value = 1.0f;
+    _parameters.trimNodeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -421,7 +421,7 @@ TEST_F(MetaMutationTests, metaMutation_trimNodeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationTrimNodeSigma.value = 0.0f;
+    _parameters.trimNodeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -440,7 +440,7 @@ TEST_F(MetaMutationTests, metaMutation_deleteNodeRatesActuallyChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationDeleteNodeSigma.value = 1.0f;
+    _parameters.deleteNodeMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -461,7 +461,7 @@ TEST_F(MetaMutationTests, metaMutation_deleteNodeRatesZeroSigmaNoChange)
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationDeleteNodeSigma.value = 0.0f;
+    _parameters.deleteNodeMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -477,13 +477,13 @@ TEST_F(MetaMutationTests, metaMutation_constructorRatesActuallyChange)
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] =
-        ConstructorMutationDesc().nodeProbability(0.5f).sigma(0.5f).discreteChangeProbability(0.5f).existConstructorProbability(0.5f);
+        ConstructorMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f).constructorToggleProbability(0.5f);
     genome._mutationRates._constructorMutations[1] =
-        ConstructorMutationDesc().nodeProbability(0.4f).sigma(0.4f).discreteChangeProbability(0.4f).existConstructorProbability(0.4f);
+        ConstructorMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f).constructorToggleProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationConstructorSigma.value = 1.0f;
+    _parameters.constructorMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -494,35 +494,35 @@ TEST_F(MetaMutationTests, metaMutation_constructorRatesActuallyChange)
     auto actualGenome = getMutatedGenome();
 
     bool anyChanged = actualGenome._mutationRates._constructorMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._sigma != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._discreteChangeProbability != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._existConstructorProbability != 0.5f
+        || actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma != 0.5f
+        || actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability != 0.5f
+        || actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability != 0.5f
         || actualGenome._mutationRates._constructorMutations[1]._nodeProbability != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._sigma != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._discreteChangeProbability != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._existConstructorProbability != 0.4f;
+        || actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma != 0.4f
+        || actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability != 0.4f
+        || actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability != 0.4f;
     EXPECT_TRUE(anyChanged);
     EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._sigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._discreteChangeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._existConstructorProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._sigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._discreteChangeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._existConstructorProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability, 0.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_constructorRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
     genome._mutationRates._constructorMutations[0] =
-        ConstructorMutationDesc().nodeProbability(0.5f).sigma(0.5f).discreteChangeProbability(0.5f).existConstructorProbability(0.5f);
+        ConstructorMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f).constructorToggleProbability(0.5f);
     genome._mutationRates._constructorMutations[1] =
-        ConstructorMutationDesc().nodeProbability(0.4f).sigma(0.4f).discreteChangeProbability(0.4f).existConstructorProbability(0.4f);
+        ConstructorMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f).constructorToggleProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.metaMutationConstructorSigma.value = 0.0f;
+    _parameters.constructorMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -532,11 +532,11 @@ TEST_F(MetaMutationTests, metaMutation_constructorRatesZeroSigmaNoChange)
 
     auto actualGenome = getMutatedGenome();
     EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._sigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._discreteChangeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._existConstructorProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._nodeProbability, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._sigma, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._discreteChangeProbability, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._existConstructorProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability, 0.4f);
 }

--- a/source/EngineTests/NeuronMutationTests.cpp
+++ b/source/EngineTests/NeuronMutationTests.cpp
@@ -67,8 +67,8 @@ protected:
 TEST_F(NeuronMutationTests, neuronWeightMutation_keepOtherAttributesUnchanged)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(1.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -88,8 +88,8 @@ TEST_F(NeuronMutationTests, neuronWeightMutation_keepOtherAttributesUnchanged)
 TEST_F(NeuronMutationTests, neuronWeightMutation_weightsActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightSigma(0.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightChangeSigma(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -133,8 +133,8 @@ TEST_F(NeuronMutationTests, neuronWeightMutation_weightsActuallyChange)
 TEST_F(NeuronMutationTests, neuronWeightMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.0f).weightSigma(1.0f).biasSigma(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightSigma(1.0f).biasSigma(1.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(0.0f).weightChangeSigma(1.0f).biasChangeSigma(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightChangeSigma(1.0f).biasChangeSigma(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -164,8 +164,8 @@ TEST_F(NeuronMutationTests, neuronWeightMutation_zeroProbabilityNoChange)
 TEST_F(NeuronMutationTests, neuronBiasMutation_biasesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(0.0f).biasSigma(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightSigma(0.0f).biasSigma(0.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(0.0f).biasChangeSigma(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).weightChangeSigma(0.0f).biasChangeSigma(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -209,8 +209,8 @@ TEST_F(NeuronMutationTests, neuronBiasMutation_biasesActuallyChange)
 TEST_F(NeuronMutationTests, neuronBiasMutation_zeroBiasSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(0.0f).biasSigma(0.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).weightSigma(0.0f).biasSigma(0.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(0.0f).biasChangeSigma(0.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(0.0f).biasChangeSigma(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -237,8 +237,8 @@ TEST_F(NeuronMutationTests, neuronBiasMutation_zeroBiasSigmaNoChange)
 TEST_F(NeuronMutationTests, neuronBiasMutation_keepOtherAttributesUnchanged)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).biasSigma(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).biasSigma(1.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).biasChangeSigma(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).biasChangeSigma(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -258,8 +258,8 @@ TEST_F(NeuronMutationTests, neuronBiasMutation_keepOtherAttributesUnchanged)
 TEST_F(NeuronMutationTests, neuronActivationFunctionMutation_activationFunctionsActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).activationFunctionProbability(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).activationFunctionProbability(0.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).actfnChangeProbability(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(0.0f).actfnChangeProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -303,8 +303,8 @@ TEST_F(NeuronMutationTests, neuronActivationFunctionMutation_activationFunctions
 TEST_F(NeuronMutationTests, neuronActivationFunctionMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).activationFunctionProbability(0.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).activationFunctionProbability(0.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).actfnChangeProbability(0.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).actfnChangeProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -331,8 +331,8 @@ TEST_F(NeuronMutationTests, neuronActivationFunctionMutation_zeroProbabilityNoCh
 TEST_F(NeuronMutationTests, neuronActivationFunctionMutation_keepOtherAttributesUnchanged)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).activationFunctionProbability(1.0f);
-    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).activationFunctionProbability(1.0f);
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).actfnChangeProbability(1.0f);
+    genome._mutationRates._neuronMutations[1] = NeuronMutationDesc().nodeProbability(1.0f).actfnChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -27,8 +27,8 @@ namespace
                     .textWidth(rightColumnWidth),
                 &mutation._nodeProbability);
             AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
-                &mutation._sigma);
+                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._valueChangeSigma);
         }
         AlienGui::EndTreeNode();
     }
@@ -47,21 +47,21 @@ namespace
                     .textWidth(rightColumnWidth),
                 &mutation._nodeProbability);
             AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Weight sigma").id(id).min(0.0f).max(2.0f).logarithmic(true).format("%.2f").textWidth(rightColumnWidth),
-                &mutation._weightSigma);
+                AlienGui::SliderFloatParameters().name("Weight change sigma").id(id).min(0.0f).max(2.0f).logarithmic(true).format("%.2f").textWidth(rightColumnWidth),
+                &mutation._weightChangeSigma);
             AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Bias sigma").id(id).min(0.0f).max(2.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
-                &mutation._biasSigma);
+                AlienGui::SliderFloatParameters().name("Bias change sigma").id(id).min(0.0f).max(2.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._biasChangeSigma);
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters()
-                    .name("ActFn probability")
+                    .name("ActFn change probability")
                     .id(id)
                     .min(0.0f)
                     .max(1.0f)
                     .logarithmic(true)
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
-                &mutation._activationFunctionProbability);
+                &mutation._actfnChangeProbability);
         }
         AlienGui::EndTreeNode();
     }
@@ -80,18 +80,18 @@ namespace
                     .textWidth(rightColumnWidth),
                 &mutation._nodeProbability);
             AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
-                &mutation._sigma);
+                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._valueChangeSigma);
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters()
-                    .name("Discrete change probability")
+                    .name("Enum change probability")
                     .id(id)
                     .min(0.0f)
                     .max(1.0f)
                     .logarithmic(true)
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
-                &mutation._discreteChangeProbability);
+                &mutation._enumChangeProbability);
         }
         AlienGui::EndTreeNode();
     }
@@ -179,28 +179,28 @@ namespace
                     .textWidth(rightColumnWidth),
                 &mutation._nodeProbability);
             AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
-                &mutation._sigma);
+                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._valueChangeSigma);
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters()
-                    .name("Discrete change probability")
+                    .name("Enum change probability")
                     .id(id)
                     .min(0.0f)
                     .max(1.0f)
                     .logarithmic(true)
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
-                &mutation._discreteChangeProbability);
+                &mutation._enumChangeProbability);
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters()
-                    .name("Exist constructor probability")
+                    .name("Constructor toggle probability")
                     .id(id)
                     .min(0.0f)
                     .max(1.0f)
                     .logarithmic(true)
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
-                &mutation._existConstructorProbability);
+                &mutation._constructorToggleProbability);
         }
         AlienGui::EndTreeNode();
     }
@@ -233,18 +233,18 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
 
         mutationRates._connectionMutations[i]._nodeProbability =
             settings.getValue(settingsPrefix + "connection mutation " + indexSuffix + ".node probability", mutationRates._connectionMutations[i]._nodeProbability);
-        mutationRates._connectionMutations[i]._sigma =
-            settings.getValue(settingsPrefix + "connection mutation " + indexSuffix + ".sigma", mutationRates._connectionMutations[i]._sigma);
+        mutationRates._connectionMutations[i]._valueChangeSigma =
+            settings.getValue(settingsPrefix + "connection mutation " + indexSuffix + ".sigma", mutationRates._connectionMutations[i]._valueChangeSigma);
 
         mutationRates._neuronMutations[i]._nodeProbability =
             settings.getValue(settingsPrefix + "neuron mutation " + indexSuffix + ".node probability", mutationRates._neuronMutations[i]._nodeProbability);
-        mutationRates._neuronMutations[i]._weightSigma =
-            settings.getValue(settingsPrefix + "neuron mutation " + indexSuffix + ".weight sigma", mutationRates._neuronMutations[i]._weightSigma);
-        mutationRates._neuronMutations[i]._biasSigma =
-            settings.getValue(settingsPrefix + "neuron mutation " + indexSuffix + ".bias sigma", mutationRates._neuronMutations[i]._biasSigma);
-        mutationRates._neuronMutations[i]._activationFunctionProbability = settings.getValue(
+        mutationRates._neuronMutations[i]._weightChangeSigma =
+            settings.getValue(settingsPrefix + "neuron mutation " + indexSuffix + ".weight sigma", mutationRates._neuronMutations[i]._weightChangeSigma);
+        mutationRates._neuronMutations[i]._biasChangeSigma =
+            settings.getValue(settingsPrefix + "neuron mutation " + indexSuffix + ".bias sigma", mutationRates._neuronMutations[i]._biasChangeSigma);
+        mutationRates._neuronMutations[i]._actfnChangeProbability = settings.getValue(
             settingsPrefix + "neuron mutation " + indexSuffix + ".activation function probability",
-            mutationRates._neuronMutations[i]._activationFunctionProbability);
+            mutationRates._neuronMutations[i]._actfnChangeProbability);
     }
 
     for (auto i = 0; i < 2; ++i) {
@@ -252,10 +252,10 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
 
         mutationRates._cellTypePropertiesMutations[i]._nodeProbability = settings.getValue(
             settingsPrefix + "cell type property mutation" + indexSuffix + ".node probability", mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
-        mutationRates._cellTypePropertiesMutations[i]._sigma =
-            settings.getValue(settingsPrefix + "cell type property mutation" + indexSuffix + ".sigma", mutationRates._cellTypePropertiesMutations[i]._sigma);
-        mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability = settings.getValue(
-            settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability);
+        mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma =
+            settings.getValue(settingsPrefix + "cell type property mutation" + indexSuffix + ".sigma", mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
+        mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability = settings.getValue(
+            settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
     mutationRates._cellTypeModeMutation._nodeProbability =
@@ -278,13 +278,13 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
 
         mutationRates._constructorMutations[i]._nodeProbability = settings.getValue(
             settingsPrefix + "constructor mutation " + indexSuffix + ".node probability", mutationRates._constructorMutations[i]._nodeProbability);
-        mutationRates._constructorMutations[i]._sigma =
-            settings.getValue(settingsPrefix + "constructor mutation " + indexSuffix + ".sigma", mutationRates._constructorMutations[i]._sigma);
-        mutationRates._constructorMutations[i]._discreteChangeProbability = settings.getValue(
-            settingsPrefix + "constructor mutation " + indexSuffix + ".discrete change probability", mutationRates._constructorMutations[i]._discreteChangeProbability);
-        mutationRates._constructorMutations[i]._existConstructorProbability = settings.getValue(
+        mutationRates._constructorMutations[i]._valueChangeSigma =
+            settings.getValue(settingsPrefix + "constructor mutation " + indexSuffix + ".sigma", mutationRates._constructorMutations[i]._valueChangeSigma);
+        mutationRates._constructorMutations[i]._enumChangeProbability = settings.getValue(
+            settingsPrefix + "constructor mutation " + indexSuffix + ".discrete change probability", mutationRates._constructorMutations[i]._enumChangeProbability);
+        mutationRates._constructorMutations[i]._constructorToggleProbability = settings.getValue(
             settingsPrefix + "constructor mutation " + indexSuffix + ".exist constructor probability",
-            mutationRates._constructorMutations[i]._existConstructorProbability);
+            mutationRates._constructorMutations[i]._constructorToggleProbability);
     }
 }
 
@@ -296,14 +296,14 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
         auto const indexSuffix = i == 0 ? "1" : "2";
 
         settings.setValue(settingsPrefix + "connection mutation " + indexSuffix + ".node probability", mutationRates._connectionMutations[i]._nodeProbability);
-        settings.setValue(settingsPrefix + "connection mutation " + indexSuffix + ".sigma", mutationRates._connectionMutations[i]._sigma);
+        settings.setValue(settingsPrefix + "connection mutation " + indexSuffix + ".sigma", mutationRates._connectionMutations[i]._valueChangeSigma);
 
         settings.setValue(settingsPrefix + "neuron mutation " + indexSuffix + ".node probability", mutationRates._neuronMutations[i]._nodeProbability);
-        settings.setValue(settingsPrefix + "neuron mutation " + indexSuffix + ".weight sigma", mutationRates._neuronMutations[i]._weightSigma);
-        settings.setValue(settingsPrefix + "neuron mutation " + indexSuffix + ".bias sigma", mutationRates._neuronMutations[i]._biasSigma);
+        settings.setValue(settingsPrefix + "neuron mutation " + indexSuffix + ".weight sigma", mutationRates._neuronMutations[i]._weightChangeSigma);
+        settings.setValue(settingsPrefix + "neuron mutation " + indexSuffix + ".bias sigma", mutationRates._neuronMutations[i]._biasChangeSigma);
         settings.setValue(
             settingsPrefix + "neuron mutation " + indexSuffix + ".activation function probability",
-            mutationRates._neuronMutations[i]._activationFunctionProbability);
+            mutationRates._neuronMutations[i]._actfnChangeProbability);
     }
 
     for (auto i = 0; i < 2; ++i) {
@@ -311,9 +311,9 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
 
         settings.setValue(
             settingsPrefix + "cell type property mutation " + indexSuffix + ".node probability", mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
-        settings.setValue(settingsPrefix + "cell type property mutation " + indexSuffix + ".sigma", mutationRates._cellTypePropertiesMutations[i]._sigma);
+        settings.setValue(settingsPrefix + "cell type property mutation " + indexSuffix + ".sigma", mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
         settings.setValue(
-            settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._discreteChangeProbability);
+            settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
@@ -328,11 +328,11 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
         auto const indexSuffix = i == 0 ? "1" : "2";
 
         settings.setValue(settingsPrefix + "constructor mutation " + indexSuffix + ".node probability", mutationRates._constructorMutations[i]._nodeProbability);
-        settings.setValue(settingsPrefix + "constructor mutation " + indexSuffix + ".sigma", mutationRates._constructorMutations[i]._sigma);
-        settings.setValue(settingsPrefix + "constructor mutation " + indexSuffix + ".discrete change probability", mutationRates._constructorMutations[i]._discreteChangeProbability);
+        settings.setValue(settingsPrefix + "constructor mutation " + indexSuffix + ".sigma", mutationRates._constructorMutations[i]._valueChangeSigma);
+        settings.setValue(settingsPrefix + "constructor mutation " + indexSuffix + ".discrete change probability", mutationRates._constructorMutations[i]._enumChangeProbability);
         settings.setValue(
             settingsPrefix + "constructor mutation " + indexSuffix + ".exist constructor probability",
-            mutationRates._constructorMutations[i]._existConstructorProbability);
+            mutationRates._constructorMutations[i]._constructorToggleProbability);
     }
 }
 

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -290,16 +290,16 @@ namespace
     auto constexpr Id_Genome_ResistanceToInjection = 6;
 
     auto constexpr Id_NeuronMutation_NodeProbability = 0;
-    auto constexpr Id_NeuronMutation_WeightSigma = 1;
-    auto constexpr Id_NeuronMutation_BiasSigma = 2;
-    auto constexpr Id_NeuronMutation_ActivationFunctionProbability = 3;
+    auto constexpr Id_NeuronMutation_WeightChangeSigma = 1;
+    auto constexpr Id_NeuronMutation_BiasChangeSigma = 2;
+    auto constexpr Id_NeuronMutation_ActfnChangeProbability = 3;
 
     auto constexpr Id_ConnectionMutation_NodeProbability = 0;
-    auto constexpr Id_ConnectionMutation_Sigma = 1;
+    auto constexpr Id_ConnectionMutation_ValueChangeSigma = 1;
 
     auto constexpr Id_CellTypePropertiesMutation_NodeProbability = 0;
-    auto constexpr Id_CellTypePropertiesMutation_Sigma = 1;
-    auto constexpr Id_CellTypePropertiesMutation_DiscreteChangeProbability = 2;
+    auto constexpr Id_CellTypePropertiesMutation_ValueChangeSigma = 1;
+    auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
     auto constexpr Id_CellTypeModeMutation_NodeProbability = 0;
 
@@ -316,9 +316,9 @@ namespace
     auto constexpr Id_DeleteNodeMutation_GeneProbability = 0;
 
     auto constexpr Id_ConstructorMutation_NodeProbability = 0;
-    auto constexpr Id_ConstructorMutation_Sigma = 1;
-    auto constexpr Id_ConstructorMutation_DiscreteChangeProbability = 2;
-    auto constexpr Id_ConstructorMutation_ExistConstructorProbability = 3;
+    auto constexpr Id_ConstructorMutation_ValueChangeSigma = 1;
+    auto constexpr Id_ConstructorMutation_EnumChangeProbability = 2;
+    auto constexpr Id_ConstructorMutation_ConstructorToggleProbability = 3;
 
     auto constexpr Id_Gene_Name = 0;
     auto constexpr Id_Gene_Shape = 1;
@@ -897,9 +897,9 @@ namespace cereal
         NeuronMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_NeuronMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
-        scope.addMember(Id_NeuronMutation_WeightSigma, data._weightSigma, defaultObject._weightSigma);
-        scope.addMember(Id_NeuronMutation_BiasSigma, data._biasSigma, defaultObject._biasSigma);
-        scope.addMember(Id_NeuronMutation_ActivationFunctionProbability, data._activationFunctionProbability, defaultObject._activationFunctionProbability);
+        scope.addMember(Id_NeuronMutation_WeightChangeSigma, data._weightChangeSigma, defaultObject._weightChangeSigma);
+        scope.addMember(Id_NeuronMutation_BiasChangeSigma, data._biasChangeSigma, defaultObject._biasChangeSigma);
+        scope.addMember(Id_NeuronMutation_ActfnChangeProbability, data._actfnChangeProbability, defaultObject._actfnChangeProbability);
     }
     SPLIT_SERIALIZATION(NeuronMutationDesc)
 
@@ -909,7 +909,7 @@ namespace cereal
         ConnectionMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_ConnectionMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
-        scope.addMember(Id_ConnectionMutation_Sigma, data._sigma, defaultObject._sigma);
+        scope.addMember(Id_ConnectionMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
     }
     SPLIT_SERIALIZATION(ConnectionMutationDesc)
 
@@ -919,8 +919,8 @@ namespace cereal
         CellTypePropertiesMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_CellTypePropertiesMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
-        scope.addMember(Id_CellTypePropertiesMutation_Sigma, data._sigma, defaultObject._sigma);
-        scope.addMember(Id_CellTypePropertiesMutation_DiscreteChangeProbability, data._discreteChangeProbability, defaultObject._discreteChangeProbability);
+        scope.addMember(Id_CellTypePropertiesMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
+        scope.addMember(Id_CellTypePropertiesMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
     }
     SPLIT_SERIALIZATION(CellTypePropertiesMutationDesc)
 
@@ -993,9 +993,9 @@ namespace cereal
         ConstructorMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_ConstructorMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
-        scope.addMember(Id_ConstructorMutation_Sigma, data._sigma, defaultObject._sigma);
-        scope.addMember(Id_ConstructorMutation_DiscreteChangeProbability, data._discreteChangeProbability, defaultObject._discreteChangeProbability);
-        scope.addMember(Id_ConstructorMutation_ExistConstructorProbability, data._existConstructorProbability, defaultObject._existConstructorProbability);
+        scope.addMember(Id_ConstructorMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
+        scope.addMember(Id_ConstructorMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
+        scope.addMember(Id_ConstructorMutation_ConstructorToggleProbability, data._constructorToggleProbability, defaultObject._constructorToggleProbability);
     }
     SPLIT_SERIALIZATION(ConstructorMutationDesc)
 


### PR DESCRIPTION
Rename mutation-rate and meta-mutation parameters for clearer, consistent naming across the Desc / TO / Entity layers, serializer, kernel and GUI.

## Genome mutation-rate parameters
- `weightSigma` → `weightChangeSigma`
- `biasSigma` → `biasChangeSigma`
- `activationFunctionProbability` → `actfnChangeProbability`
- `sigma` → `valueChangeSigma`
- `discreteChangeProbability` → `enumChangeProbability`
- `existConstructorProbability` → `constructorToggleProbability`

## Meta-mutation parameters (`metaMutation<X>Sigma` → `<x>MetaMutationsSigma`)
neurons, connections, cellTypeProperties, cellTypeMode, cellType, void, appendNode, addNode, trimNode, deleteNode, constructor.

## Adapted accordingly
- TO (`GenomeTO.cuh`), Desc (`GenomeDesc.h`), Entities (`Genome.cuh`)
- `Id_*` constants in `SerializerService` (names only — numeric ids unchanged, so existing save files still load)
- GUI slider labels in `MutationRatesDialog`

## Deliberately left unchanged
- GlobalSettings string keys in `MutationRatesDialog` (user-config persistence keys)
- `SimulationParameters` `.name()` meta labels (double as settings serialization keys)
- Math `sigma` notation in `HelpStrings.h`

Note: `cellTypeMode` meta uses the plural `cellTypeModeMetaMutationsSigma` for consistency with the other meta params.

## Tests
Build: all 470 targets. EngineInterfaceTests 155, NetworkTests 4, PersisterTests 64, EngineTests 3047 — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)