### PR TITLE
Color fluid particles like cells and solids

### DIFF
--- a/source/EngineKernels/GeometryKernels.cu
+++ b/source/EngineKernels/GeometryKernels.cu
@@ -389,7 +389,7 @@ cudaExtractFluidParticleData(SimulationData data, FluidParticleVertexData* fluid
                 fluidParticleData[idx].pos[0] = object->pos.x;
                 fluidParticleData[idx].pos[1] = object->pos.y;
                 fluidParticleData[idx].pos[2] = 0.0f;
-                auto color = getCustomizationColor(object->color);
+                auto color = getObjectColor(object);
                 fluidParticleData[idx].color[0] = intensity * toFloat((color >> 16) & 0xff) / 255;
                 fluidParticleData[idx].color[1] = intensity * toFloat((color >> 8) & 0xff) / 255;
                 fluidParticleData[idx].color[2] = intensity * toFloat(color & 0xff) / 255;


### PR DESCRIPTION
Fluid particles in `cudaExtractFluidParticleData` (`source/EngineKernels/GeometryKernels.cu`) now use `getObjectColor(object)` instead of `getCustomizationColor(object->color)`.

They follow the same `objectColoring` scheme (None / LineageId / code) as cells and solids. Energy particles keep their existing fixed blue rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)