### PR TITLE
Rename homogeneCellType to homogeneousCellType and scale its mutation by gene size

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -906,7 +906,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         geneDesc._shape = geneTO->shape;
         geneDesc._stiffness = geneTO->stiffness;
         geneDesc._connectionDistance = geneTO->connectionDistance;
-        geneDesc._homogeneCellType = geneTO->homogeneCellType;
+        geneDesc._homogeneousCellType = geneTO->homogeneousCellType;
 
         CHECK(geneTO->nodeArrayIndex + geneTO->numNodes <= *to.numNodes);
         for (int k = 0; k < geneTO->numNodes; ++k) {
@@ -1007,7 +1007,7 @@ void DescConverterService::convertGenomeToTO(
         geneTO.shape = geneDesc._shape;
         geneTO.stiffness = geneDesc._stiffness;
         geneTO.connectionDistance = geneDesc._connectionDistance;
-        geneTO.homogeneCellType = geneDesc._homogeneCellType;
+        geneTO.homogeneousCellType = geneDesc._homogeneousCellType;
         geneTO.numNodes = toInt(geneDesc._nodes.size());
 
         auto nodeArrayStartIndex = nodeTOs.size();

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -409,7 +409,7 @@ struct GeneDesc
     MEMBER(GeneDesc, ConstructorShape, shape, ConstructorShape_Segment);
     MEMBER(GeneDesc, float, stiffness, 1.0f);
     MEMBER(GeneDesc, float, connectionDistance, 1.0f);
-    MEMBER(GeneDesc, bool, homogeneCellType, false);
+    MEMBER(GeneDesc, bool, homogeneousCellType, false);
 };
 
 struct NeuronMutationDesc

--- a/source/EngineInterface/GenomeDescEditService.cpp
+++ b/source/EngineInterface/GenomeDescEditService.cpp
@@ -501,7 +501,7 @@ namespace
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc();
         for (auto& gene : genome._genes) {
-            gene._homogeneCellType = false;
+            gene._homogeneousCellType = false;
             for (auto& node : gene._nodes) {
                 node._color = PreviewColor;
                 if (!detailSimulation) {

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -525,7 +525,7 @@ struct std::hash<GeneDesc>
         hash_combine(seed, static_cast<int>(desc._shape));
         hash_combine(seed, desc._stiffness);
         hash_combine(seed, desc._connectionDistance);
-        hash_combine(seed, desc._homogeneCellType);
+        hash_combine(seed, desc._homogeneousCellType);
         return seed;
     }
 };

--- a/source/EngineInterface/PreviewDescConverterService.cpp
+++ b/source/EngineInterface/PreviewDescConverterService.cpp
@@ -108,7 +108,7 @@ ConversionResult PreviewDescConverterService::convertToPreviewDesc(
             return CellType_Base;   // Return default
         }
         auto const& gene = genome._genes.at(cell._geneIndex);
-        auto nodeIndex = gene._homogeneCellType ? 0 : cell._nodeIndex;
+        auto nodeIndex = gene._homogeneousCellType ? 0 : cell._nodeIndex;
         if (nodeIndex >= gene._nodes.size()) {
             return CellType_Base;   // Return default
         }

--- a/source/EngineInterfaceTests/PreviewDescConverterServiceTests.cpp
+++ b/source/EngineInterfaceTests/PreviewDescConverterServiceTests.cpp
@@ -140,11 +140,11 @@ TEST_F(PreviewDescConverterServiceTests, convertTwoCellCreature_marksConnectionI
     EXPECT_TRUE(result.description._connections.at(0)._inactive);
 }
 
-TEST_F(PreviewDescConverterServiceTests, convertThreeCellCreature_homogeneCellTypeKeepsVoidCellActive)
+TEST_F(PreviewDescConverterServiceTests, convertThreeCellCreature_homogeneousCellTypeKeepsVoidCellActive)
 {
     // The first and last node of a gene cannot be void, so the void node is placed in the middle.
     auto genome = GenomeDesc().genes({
-        GeneDesc().homogeneCellType(true).nodes({NodeDesc().color(2).cellType(MuscleGenomeDesc()), NodeDesc().cellType(VoidGenomeDesc()), NodeDesc().color(3)}),
+        GeneDesc().homogeneousCellType(true).nodes({NodeDesc().color(2).cellType(MuscleGenomeDesc()), NodeDesc().cellType(VoidGenomeDesc()), NodeDesc().color(3)}),
     });
 
     Desc input;

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -235,7 +235,7 @@ __inline__ __device__ ConstructorProcessor::ConstructionData ConstructorProcesso
     result.lastConstructionObject = ConstructorHelper::getLastConstructedCell(object);
     result.neededUsableEnergy = cudaSimulationParameters.normalCellEnergy.value[object->color];
     result.neededReservedEnergy = result.node->constructorAvailable ? result.node->constructor.reservedEnergy : 0.0f;
-    auto cellTypeNode = result.gene->homogeneCellType ? &result.gene->nodes[0] : result.node;
+    auto cellTypeNode = result.gene->homogeneousCellType ? &result.gene->nodes[0] : result.node;
     result.neededDepotEnergy = cellTypeNode->cellType == CellType_Depot ? cellTypeNode->cellTypeData.depot.initialStoredUsableEnergy : 0.0f;
 
     ShapeGenerator shapeGenerator;
@@ -552,7 +552,7 @@ __inline__ __device__ Object* ConstructorProcessor::constructCellIntern(
         constructionData.creature,
         constructor.geneIndex,
         constructionData.currentNodeIndex,
-        constructionData.gene->homogeneCellType,
+        constructionData.gene->homogeneousCellType,
         hostObject->typeData.cell.nodeIndex,
         constructionData.currentConcatenation,
         constructionData.currentBranch,

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -74,7 +74,7 @@ namespace
                 geneTO.shape = gene.shape;
                 geneTO.stiffness = gene.stiffness;
                 geneTO.connectionDistance = gene.connectionDistance;
-                geneTO.homogeneCellType = gene.homogeneCellType;
+                geneTO.homogeneousCellType = gene.homogeneousCellType;
                 geneTO.numNodes = gene.numNodes;
                 for (int i = 0; i < sizeof(gene.name); ++i) {
                     geneTO.name[i] = gene.name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -130,7 +130,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
         gene.shape = geneTO.shape;
         gene.stiffness = geneTO.stiffness;
         gene.connectionDistance = geneTO.connectionDistance;
-        gene.homogeneCellType = geneTO.homogeneCellType;
+        gene.homogeneousCellType = geneTO.homogeneousCellType;
         gene.numNodes = geneTO.numNodes;
         for (int i = 0; i < sizeof(geneTO.name); ++i) {
             gene.name[i] = geneTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -334,7 +334,7 @@ struct Gene
     ConstructorShape shape;
     float stiffness;
     float connectionDistance;
-    bool homogeneCellType;
+    bool homogeneousCellType;
 
     int numNodes;
     Node* nodes;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -339,7 +339,7 @@ struct GeneTO
     ConstructorShape shape;
     float stiffness;
     float connectionDistance;
-    bool homogeneCellType;
+    bool homogeneousCellType;
 
     int numNodes;
     uint64_t nodeArrayIndex;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -739,8 +739,8 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellType(Simulation
         auto& gene = genome->genes[geneIndex];
 
         if (laneId == 0 && data.primaryNumberGen.random() < rate.nodeProbability) {
-            gene.homogeneCellType = !gene.homogeneCellType;
-            atomicAdd_block(&accumulatedMutations, 1.0f);
+            gene.homogeneousCellType = !gene.homogeneousCellType;
+            atomicAdd_block(&accumulatedMutations, toFloat(gene.numNodes));
         }
 
         for (int nodeIndex = laneId; nodeIndex < gene.numNodes; nodeIndex += blockDim.x) {

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -207,7 +207,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                               .shape(ConstructorShape_Hexagon)
                               .stiffness(0.75f)
                               .connectionDistance(0.8f)
-                              .homogeneCellType(true)
+                              .homogeneousCellType(true)
                               .nodes({
                                   createNonDefaultNodeDesc(nodeParameter),
                               }),

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -12,14 +12,14 @@
 class CellTypeMutationTests : public MutationTestsBase
 {
 protected:
-    bool compareAllExceptCellTypeAndHomogeneFlag(GenomeDesc expected, GenomeDesc actual)
+    bool compareAllExceptCellTypeAndHomogeneousFlag(GenomeDesc expected, GenomeDesc actual)
     {
         auto reset = [](GenomeDesc& genome) {
             genome._lineageId = 0;
             genome._prevLineageId = std::nullopt;
             genome._accumulatedMutations = 0.0f;
             for (auto& gene : genome._genes) {
-                gene._homogeneCellType = false;  // canonicalize: the cell type mutation may also flip this flag
+                gene._homogeneousCellType = false;  // canonicalize: the cell type mutation may also flip this flag
                 for (auto& node : gene._nodes) {
                     node._cellType = BaseGenomeDesc{};  // canonicalize so everything except the cell type is compared
                 }
@@ -50,7 +50,7 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_changesCellTypeToDefaults)
     std::visit([](auto const& cellTypeData) { EXPECT_EQ(cellTypeData, std::decay_t<decltype(cellTypeData)>{}); }, cellType);
 }
 
-TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellTypeAndHomogeneFlag)
+TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellTypeAndHomogeneousFlag)
 {
     auto genome = createTestGenome();
     genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().nodeProbability(1.0f);
@@ -64,7 +64,7 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_doesNotChangeExceptCellTypeAndHom
 
     auto actualGenome = getMutatedGenome();
 
-    EXPECT_TRUE(compareAllExceptCellTypeAndHomogeneFlag(genome, actualGenome));
+    EXPECT_TRUE(compareAllExceptCellTypeAndHomogeneousFlag(genome, actualGenome));
 }
 
 TEST_F(CellTypeMutationTests, cellTypeMutation_keepsVoidNodesVoid)
@@ -120,9 +120,9 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_keepsNonVoidNodesNonVoid)
     }
 }
 
-TEST_F(CellTypeMutationTests, cellTypeMutation_changesHomogeneCellTypeFlag)
+TEST_F(CellTypeMutationTests, cellTypeMutation_changesHomogeneousCellTypeFlag)
 {
-    auto genome = GenomeDesc().genes({GeneDesc().homogeneCellType(false).nodes({NodeDesc().cellType(BaseGenomeDesc())})});
+    auto genome = GenomeDesc().genes({GeneDesc().homogeneousCellType(false).nodes({NodeDesc().cellType(BaseGenomeDesc())})});
     genome._mutationRates._cellTypeMutation = CellTypeMutationDesc().nodeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -132,5 +132,5 @@ TEST_F(CellTypeMutationTests, cellTypeMutation_changesHomogeneCellTypeFlag)
 
     auto actualGenome = getMutatedGenome();
 
-    EXPECT_TRUE(actualGenome._genes.at(0)._homogeneCellType);
+    EXPECT_TRUE(actualGenome._genes.at(0)._homogeneousCellType);
 }

--- a/source/EngineTests/ConstructorTests.cpp
+++ b/source/EngineTests/ConstructorTests.cpp
@@ -3333,12 +3333,12 @@ TEST_P(ConstructorTests_ProvideEnergy, provideEnergy_depotWithInitialStoredEnerg
     }
 }
 
-TEST_F(ConstructorTests, homogeneCellType_inheritsCellTypeFromFirstNode)
+TEST_F(ConstructorTests, homogeneousCellType_inheritsCellTypeFromFirstNode)
 {
     auto const Countdown = 42;
 
     auto genome = GenomeDesc().genes({
-        GeneDesc().homogeneCellType(true).nodes({
+        GeneDesc().homogeneousCellType(true).nodes({
             NodeDesc().cellType(DetonatorGenomeDesc().countdown(Countdown)),
             NodeDesc(),
             NodeDesc(),

--- a/source/Gui/GeneEditorWidget.cpp
+++ b/source/Gui/GeneEditorWidget.cpp
@@ -111,7 +111,7 @@ void _GeneEditorWidget::processHeaderData()
                     .name("Homogeneous cell type")
                     .textWidth(rightColumnWidth)
                     .tooltip("If enabled, every constructed cell of this gene uses the cell type and its properties of the first node."),
-                gene._homogeneCellType);
+                gene._homogeneousCellType);
 
             table.next();
             table.end();
@@ -183,7 +183,7 @@ void _GeneEditorWidget::processNodeList()
                     // Column 1: Node type
                     ImGui::TableNextColumn();
                     {
-                        auto nodeType = gene._homogeneCellType ? gene._nodes.front().getCellType() : node.getCellType();
+                        auto nodeType = gene._homogeneousCellType ? gene._nodes.front().getCellType() : node.getCellType();
                         auto text = Const::CellTypeStrings.at(nodeType);
                         AlienGui::Text(text);
                     }

--- a/source/Gui/NodeEditorWidget.cpp
+++ b/source/Gui/NodeEditorWidget.cpp
@@ -207,7 +207,7 @@ void _NodeEditorWidget::processNodeAttributes()
         auto& node = _editData->getSelectedNodeRef();
 
         // With homogeneous cell type the cell type and its properties of the first node are shown and edited for every node
-        auto& cellTypeNode = gene._homogeneCellType ? gene._nodes.front() : node;
+        auto& cellTypeNode = gene._homogeneousCellType ? gene._nodes.front() : node;
 
         auto const simulationParameters = _SimulationFacade::get()->getSimulationParameters();
         auto const& customizationColors = simulationParameters.customizationColors.value;
@@ -238,7 +238,7 @@ void _NodeEditorWidget::processNodeAttributes()
             // Type
             auto nodeType = cellTypeNode.getCellType();
             if (AlienGui::Combo(AlienGui::ComboParameters().name("Type").values(Const::CellTypeStrings).textWidth(rightColumnWidth), nodeType)) {
-                if (nodeType == CellType_Void && (gene._homogeneCellType || nodeIndex.value() == 0)) {
+                if (nodeType == CellType_Void && (gene._homogeneousCellType || nodeIndex.value() == 0)) {
                     showMessage("Error", "The first node cannot be void.");
                 } else if (nodeType == CellType_Void && nodeIndex.value() == gene._nodes.size() - 1) {
                     showMessage("Error", "The last node cannot be void.");

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -324,7 +324,7 @@ namespace
     auto constexpr Id_Gene_Shape = 1;
     auto constexpr Id_Gene_Stiffness = 5;
     auto constexpr Id_Gene_ConnectionDistance = 6;
-    auto constexpr Id_Gene_HomogeneCellType = 7;
+    auto constexpr Id_Gene_HomogeneousCellType = 7;
 
     auto constexpr Id_Node_ReferenceAngle = 0;
     auto constexpr Id_Node_Color = 1;
@@ -886,7 +886,7 @@ namespace cereal
         scope.addMember(Id_Gene_Shape, data._shape, defaultObject._shape);
         scope.addMember(Id_Gene_Stiffness, data._stiffness, defaultObject._stiffness);
         scope.addMember(Id_Gene_ConnectionDistance, data._connectionDistance, defaultObject._connectionDistance);
-        scope.addMember(Id_Gene_HomogeneCellType, data._homogeneCellType, defaultObject._homogeneCellType);
+        scope.addMember(Id_Gene_HomogeneousCellType, data._homogeneousCellType, defaultObject._homogeneousCellType);
         scope.addDesc(Id_Gene_Nodes, data._nodes);
     }
     SPLIT_SERIALIZATION(GeneDesc)


### PR DESCRIPTION
## Summary
- Rename the gene flag `homogeneCellType` to the grammatically correct `homogeneousCellType` (and `_homogeneCellType` → `_homogeneousCellType`) across engine, interface, GUI, persistence and tests, including the GPU structs `Gene`/`GeneTO` and `GeneDesc`.
- Serializer member id constant renamed (`Id_Gene_HomogeneCellType` → `Id_Gene_HomogeneousCellType`); its numeric id stays `7`, so existing save files remain compatible.
- In `MutationProcessor::applyMutations_cellType`, toggling the homogeneous-cell-type flag now increments `accumulatedMutations` by the gene's node count (`toFloat(gene.numNodes)`) instead of `1.0f`, reflecting that the flag affects all nodes of the gene.

## Tests
- Clean Release rebuild: success.
- EngineInterfaceTests (preview) and PersisterTests (serialization round-trip): pass.
- EngineTests: `CellTypeMutationTests.*` and `ConstructorTests.homogeneousCellType_inheritsCellTypeFromFirstNode`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)