### PR TITLE
Show active mutation rates as read-only fields

### DIFF
--- a/source/Gui/GenomeEditorWidget.cpp
+++ b/source/Gui/GenomeEditorWidget.cpp
@@ -100,7 +100,7 @@ void _GenomeEditorWidget::processHeaderData()
 
             AlienGui::Group(AlienGui::GroupParameters().text("Mutation rates"));
 
-            MutationRatesWidget::process(_editData->genome._mutationRates);
+            MutationRatesWidget::process(_editData->genome._mutationRates, rightColumnWidth);
 
             AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Apply meta-mutations").textWidth(rightColumnWidth), _editData->genome._applyMetaMutations);
             AlienGui::SliderFloat(

--- a/source/Gui/MassOperationsDialog.cpp
+++ b/source/Gui/MassOperationsDialog.cpp
@@ -18,7 +18,7 @@
 
 namespace
 {
-    auto constexpr RightColumnWidth = 120.0f;
+    auto constexpr RightColumnWidth = 140.0f;
     auto constexpr MinColumnWidth = 300.0f;
     auto constexpr SettingsPrefix = "dialogs.mass operations.";
 }

--- a/source/Gui/MassOperationsDialog.cpp
+++ b/source/Gui/MassOperationsDialog.cpp
@@ -210,7 +210,7 @@ void MassOperationsDialog::processIntern()
             ImGui::Checkbox("##mutationRates", &_randomizeMutationRates);
             ImGui::SameLine(0, ImGui::GetStyle().FramePadding.x * 4);
             ImGui::BeginDisabled(!_randomizeMutationRates);
-            MutationRatesWidget::process(_mutationRates, true);
+            MutationRatesWidget::process(_mutationRates, RightColumnWidth, true);
             ImGui::EndDisabled();
 
             table.next();

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -59,9 +59,8 @@ namespace
 
 void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested)
 {
-    // Edit button spanning the field column (same width as the read-only fields) above the first one
-    auto fieldWidth = ImGui::GetContentRegionAvail().x - scale(rightColumnWidth);
-    if (ImGui::Button("Edit", ImVec2(fieldWidth, 0))) {
+    // Edit button spanning the field column, with a label to its right like the read-only fields below
+    if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Click to edit").textWidth(rightColumnWidth))) {
         auto onAdopt = [&mutationRates](MutationRatesDesc const& adoptedRates) { mutationRates = adoptedRates; };
         if (nested) {
             MutationRatesDialog::get().openNested(mutationRates, onAdopt);

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -59,10 +59,8 @@ namespace
 
 void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested)
 {
-    // Keep all rows aligned to the start position even when called after an indenting SameLine (e.g. in MassOperationsDialog)
-    auto startPosX = ImGui::GetCursorPosX();
+    ImGui::BeginGroup();
 
-    // Edit button spanning the field column, with a label to its right like the read-only fields below
     if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Click to edit").textWidth(rightColumnWidth))) {
         auto onAdopt = [&mutationRates](MutationRatesDesc const& adoptedRates) { mutationRates = adoptedRates; };
         if (nested) {
@@ -74,7 +72,7 @@ void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightC
 
     for (auto const& [name, probabilities] : getActiveMutationTypes(mutationRates)) {
         auto value = probabilities;
-        ImGui::SetCursorPosX(startPosX);
         AlienGui::InputText(AlienGui::InputTextParameters().name(name).readOnly(true).textWidth(rightColumnWidth), value);
     }
+    ImGui::EndGroup();
 }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -1,6 +1,5 @@
 #include "MutationRatesWidget.h"
 
-#include <algorithm>
 #include <initializer_list>
 #include <string>
 #include <utility>
@@ -60,11 +59,9 @@ namespace
 
 void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested)
 {
-    // Edit button right-aligned above the first read-only field
+    // Edit button spanning the field column (same width as the read-only fields) above the first one
     auto fieldWidth = ImGui::GetContentRegionAvail().x - scale(rightColumnWidth);
-    auto editButtonWidth = ImGui::CalcTextSize("Edit").x + ImGui::GetStyle().FramePadding.x * 2;
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + std::max(0.0f, fieldWidth - editButtonWidth));
-    if (AlienGui::Button("Edit")) {
+    if (ImGui::Button("Edit", ImVec2(fieldWidth, 0))) {
         auto onAdopt = [&mutationRates](MutationRatesDesc const& adoptedRates) { mutationRates = adoptedRates; };
         if (nested) {
             MutationRatesDialog::get().openNested(mutationRates, onAdopt);

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -1,7 +1,9 @@
 #include "MutationRatesWidget.h"
 
+#include <algorithm>
 #include <initializer_list>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <imgui.h>
@@ -15,7 +17,8 @@
 
 namespace
 {
-    void addActiveMutationType(std::vector<std::string>& result, std::string const& name, std::initializer_list<float> nodeProbabilities)
+    void
+    addActiveMutationType(std::vector<std::pair<std::string, std::string>>& result, std::string const& name, std::initializer_list<float> nodeProbabilities)
     {
         std::string probabilities;
         for (auto const& nodeProbability : nodeProbabilities) {
@@ -27,13 +30,13 @@ namespace
             }
         }
         if (!probabilities.empty()) {
-            result.push_back(name + " (" + probabilities + ")");
+            result.emplace_back(name, probabilities);
         }
     }
 
-    std::vector<std::string> getActiveMutationTypes(MutationRatesDesc const& mutationRates)
+    std::vector<std::pair<std::string, std::string>> getActiveMutationTypes(MutationRatesDesc const& mutationRates)
     {
-        std::vector<std::string> activeMutations;
+        std::vector<std::pair<std::string, std::string>> activeMutations;
         addActiveMutationType(
             activeMutations, "Connection", {mutationRates._connectionMutations[0]._nodeProbability, mutationRates._connectionMutations[1]._nodeProbability});
         addActiveMutationType(
@@ -55,13 +58,12 @@ namespace
     }
 }
 
-void MutationRatesWidget::process(MutationRatesDesc& mutationRates, bool nested)
+void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested)
 {
-    auto buttonWidth = scale(60.0f);
-    auto availableWidth = ImGui::GetContentRegionAvail().x;
-    auto listBoxWidth = availableWidth - buttonWidth - ImGui::GetStyle().ItemSpacing.x;
-    AlienGui::ListBox(AlienGui::ListBoxParameters().items(getActiveMutationTypes(mutationRates)).width(listBoxWidth));
-    ImGui::SameLine();
+    // Edit button right-aligned above the first read-only field
+    auto fieldWidth = ImGui::GetContentRegionAvail().x - scale(rightColumnWidth);
+    auto editButtonWidth = ImGui::CalcTextSize("Edit").x + ImGui::GetStyle().FramePadding.x * 2;
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + std::max(0.0f, fieldWidth - editButtonWidth));
     if (AlienGui::Button("Edit")) {
         auto onAdopt = [&mutationRates](MutationRatesDesc const& adoptedRates) { mutationRates = adoptedRates; };
         if (nested) {
@@ -69,5 +71,10 @@ void MutationRatesWidget::process(MutationRatesDesc& mutationRates, bool nested)
         } else {
             MutationRatesDialog::get().open(mutationRates, onAdopt);
         }
+    }
+
+    for (auto const& [name, probabilities] : getActiveMutationTypes(mutationRates)) {
+        auto value = probabilities;
+        AlienGui::InputText(AlienGui::InputTextParameters().name(name).readOnly(true).textWidth(rightColumnWidth), value);
     }
 }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -59,6 +59,9 @@ namespace
 
 void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested)
 {
+    // Keep all rows aligned to the start position even when called after an indenting SameLine (e.g. in MassOperationsDialog)
+    auto startPosX = ImGui::GetCursorPosX();
+
     // Edit button spanning the field column, with a label to its right like the read-only fields below
     if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Click to edit").textWidth(rightColumnWidth))) {
         auto onAdopt = [&mutationRates](MutationRatesDesc const& adoptedRates) { mutationRates = adoptedRates; };
@@ -71,6 +74,7 @@ void MutationRatesWidget::process(MutationRatesDesc& mutationRates, float rightC
 
     for (auto const& [name, probabilities] : getActiveMutationTypes(mutationRates)) {
         auto value = probabilities;
+        ImGui::SetCursorPosX(startPosX);
         AlienGui::InputText(AlienGui::InputTextParameters().name(name).readOnly(true).textWidth(rightColumnWidth), value);
     }
 }

--- a/source/Gui/MutationRatesWidget.h
+++ b/source/Gui/MutationRatesWidget.h
@@ -5,5 +5,5 @@ struct MutationRatesDesc;
 class MutationRatesWidget
 {
 public:
-    static void process(MutationRatesDesc& mutationRates, bool nested = false);
+    static void process(MutationRatesDesc& mutationRates, float rightColumnWidth, bool nested = false);
 };


### PR DESCRIPTION
## Summary
Improves the mutation rates display in the genome editor (`_GenomeEditorWidget::processHeaderData`).

- Replaces the mutation types **list box** with one **read-only field per active mutation type**, label shown to the right of the value (like "Node count" / "Resulting cells").
- `MutationRatesWidget::process` now takes `rightColumnWidth` so the fields align with the rest of the header column.
- The **Edit** button is placed right-aligned above the first read-only field (experimental placement).
- Probability computation is unchanged; values are just moved into the field while the type name becomes the right-hand label.
- Call sites updated: `GenomeEditorWidget` and `MassOperationsDialog` (shared widget).

## Test
- Release build (Ninja) green; `alien.exe` links.
- clang-format clean on changed widget files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)