### PR TITLE
Rename ObjectDesc flag fixed to isStatic

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -302,7 +302,7 @@ ObjectDesc DescConverterService::createObjectDesc(TOs const& to, int objectIndex
         connections.emplace_back(connection);
     }
     result._connections = connections;
-    result._fixed = objectTO.isFixed();
+    result._isStatic = objectTO.isStatic();
     result._sticky = objectTO.isSticky();
     result._color = objectTO.color;
 
@@ -1278,7 +1278,7 @@ void DescConverterService::convertObjectToTO(
     objectTO.stiffness = objectDesc._stiffness;
     objectTO.numConnections = 0;
     objectTO.flags = 0;
-    objectTO.setFixed(objectDesc._fixed);
+    objectTO.setStatic(objectDesc._isStatic);
     objectTO.setSticky(objectDesc._sticky);
     objectTO.color = objectDesc._color;
 

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -544,7 +544,7 @@ struct ObjectDesc
     MEMBER(ObjectDesc, RealVector2D, vel, RealVector2D());
     MEMBER(ObjectDesc, float, stiffness, 1.0f);
     MEMBER(ObjectDesc, int, color, 0);
-    MEMBER(ObjectDesc, bool, fixed, false);
+    MEMBER(ObjectDesc, bool, isStatic, false);
     MEMBER(ObjectDesc, bool, sticky, false);
     MEMBER(ObjectDesc, ObjectTypeDesc, type, CellDesc());
 

--- a/source/EngineInterface/DescEditService.cpp
+++ b/source/EngineInterface/DescEditService.cpp
@@ -25,7 +25,7 @@ Desc DescEditService::createRect(CreateRectParameters const& parameters) const
                                              .pos({toFloat(i) * parameters._cellDistance, toFloat(j) * parameters._cellDistance})
                                              .stiffness(parameters._stiffness)
                                              .color(parameters._color)
-                                             .fixed(parameters._fixed)
+                                             .isStatic(parameters._isStatic)
                                              .sticky(parameters._sticky)
                                              .type(parameters._objectType));
         }
@@ -49,7 +49,7 @@ Desc DescEditService::createHex(CreateHexParameters const& parameters) const
                                              .stiffness(parameters._stiffness)
                                              .pos({toFloat(i * parameters._cellDistance + j * parameters._cellDistance / 2.0), toFloat(-j * incY)})
                                              .color(parameters._color)
-                                             .fixed(parameters._fixed)
+                                             .isStatic(parameters._isStatic)
                                              .sticky(parameters._sticky)
                                              .type(parameters._objectType));
 
@@ -59,7 +59,7 @@ Desc DescEditService::createHex(CreateHexParameters const& parameters) const
                                                  .stiffness(parameters._stiffness)
                                                  .pos({toFloat(i * parameters._cellDistance + j * parameters._cellDistance / 2.0), toFloat(j * incY)})
                                                  .color(parameters._color)
-                                                 .fixed(parameters._fixed)
+                                                 .isStatic(parameters._isStatic)
                                                  .type(parameters._objectType));
             }
         }
@@ -81,7 +81,7 @@ Desc DescEditService::createCircle(CreateCircleParameters const& parameters) con
                                          .pos(parameters._center)
                                          .stiffness(parameters._stiffness)
                                          .color(parameters._color)
-                                         .fixed(parameters._fixed)
+                                         .isStatic(parameters._isStatic)
                                          .sticky(parameters._sticky)
                                          .type(parameters._type));
         return result;
@@ -104,7 +104,7 @@ Desc DescEditService::createCircle(CreateCircleParameters const& parameters) con
                                              .stiffness(parameters._stiffness)
                                              .pos({parameters._center.x + dxMod, parameters._center.y + dy})
                                              .color(parameters._color)
-                                             .fixed(parameters._fixed)
+                                             .isStatic(parameters._isStatic)
                                              .sticky(parameters._sticky)
                                              .type(parameters._type));
         }

--- a/source/EngineInterface/DescEditService.h
+++ b/source/EngineInterface/DescEditService.h
@@ -21,7 +21,7 @@ public:
         MEMBER(CreateRectParameters, RealVector2D, center, RealVector2D({0, 0}));
         MEMBER(CreateRectParameters, bool, sticky, false);
         MEMBER(CreateRectParameters, int, color, 0);
-        MEMBER(CreateRectParameters, bool, fixed, false);
+        MEMBER(CreateRectParameters, bool, isStatic, false);
     };
     Desc createRect(CreateRectParameters const& parameters) const;
 
@@ -35,7 +35,7 @@ public:
         MEMBER(CreateHexParameters, RealVector2D, center, RealVector2D({0, 0}));
         MEMBER(CreateHexParameters, bool, sticky, false);
         MEMBER(CreateHexParameters, int, color, 0);
-        MEMBER(CreateHexParameters, bool, fixed, false);
+        MEMBER(CreateHexParameters, bool, isStatic, false);
     };
     Desc createHex(CreateHexParameters const& parameters) const;
 
@@ -48,7 +48,7 @@ public:
         MEMBER(CreateCircleParameters, float, stiffness, 1.0f);
         MEMBER(CreateCircleParameters, RealVector2D, center, RealVector2D({0, 0}));
         MEMBER(CreateCircleParameters, int, color, 0);
-        MEMBER(CreateCircleParameters, bool, fixed, false);
+        MEMBER(CreateCircleParameters, bool, isStatic, false);
         MEMBER(CreateCircleParameters, bool, sticky, false);
     };
     Desc createCircle(CreateCircleParameters const& parameters) const;

--- a/source/EngineKernels/AttackerProcessor.cuh
+++ b/source/EngineKernels/AttackerProcessor.cuh
@@ -46,7 +46,7 @@ __device__ __inline__ void AttackerProcessor::process(SimulationData& data, Simu
 
 __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
-    if (object->isFixed()) {
+    if (object->isStatic()) {
         return;
     }
     auto const& cell = &object->typeData.cell;
@@ -116,7 +116,7 @@ __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, 
                 if (otherObject->type == ObjectType_Solid || otherObject->type == ObjectType_Fluid) {
                     return;
                 }
-                if (otherObject->isFixed()) {
+                if (otherObject->isStatic()) {
                     return;
                 }
 

--- a/source/EngineKernels/CellProcessor.cuh
+++ b/source/EngineKernels/CellProcessor.cuh
@@ -61,7 +61,7 @@ __inline__ __device__ void CellProcessor::aging(SimulationData& data)
     auto const partition = calcSystemThreadPartition(data.entities.objects.getNumEntries());
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = data.entities.objects.at(index);
-        if (object->isFixed() || object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {
+        if (object->isStatic() || object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {
             continue;
         }
         uint32_t* age = nullptr;
@@ -116,7 +116,7 @@ __inline__ __device__ void CellProcessor::cellStateTransition_calcFutureState(Si
         auto origCellState = object->typeData.cell.cellState;
         auto cellState = origCellState;
 
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             cellState = CellState_Ready;
         } else {
             if (origCellState == CellState_Activating) {
@@ -409,7 +409,7 @@ __inline__ __device__ void CellProcessor::decay(SimulationData& data, bool isPre
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
 

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -318,7 +318,7 @@ namespace
         objectTO.stiffness = object->stiffness;
         objectTO.color = object->color;
         objectTO.flags = 0;
-        objectTO.setFixed(object->isFixed());
+        objectTO.setStatic(object->isStatic());
         objectTO.setSticky(object->isSticky());
         objectTO.type = object->type;
 

--- a/source/EngineKernels/DetonatorProcessor.cuh
+++ b/source/EngineKernels/DetonatorProcessor.cuh
@@ -48,7 +48,7 @@ __device__ __inline__ void DetonatorProcessor::processCell(SimulationData& data,
                     if (otherObject == object) {
                         return;
                     }
-                    if (otherObject->isFixed()) {
+                    if (otherObject->isStatic()) {
                         return;
                     }
                     auto delta = data.objectMap.getCorrectedDirection(otherObject->pos - object->pos);

--- a/source/EngineKernels/EditKernels.cu
+++ b/source/EngineKernels/EditKernels.cu
@@ -371,7 +371,7 @@ __global__ void cudaSetBarrier(SimulationData data, bool value, bool includeClus
     for (int index = objectPartition.startIndex; index <= objectPartition.endIndex; index += objectPartition.step) {
         auto const& object = data.entities.objects.at(index);
         if (isSelected(object, includeClusters)) {
-            object->setFixed(value);
+            object->setStatic(value);
         }
     }
 }
@@ -423,7 +423,7 @@ __global__ void cudaApplyForce(SimulationData data, ApplyForceData applyData)
             auto pos = object->pos;
             pos += data.objectMap.getCorrectionIncrement(applyData.startPos, pos);
             auto distanceToSegment = Math::calcDistanceToLineSegment(applyData.startPos, applyData.endPos, pos, applyData.radius);
-            if (distanceToSegment < applyData.radius && !object->isFixed()) {
+            if (distanceToSegment < applyData.radius && !object->isStatic()) {
                 auto weightedForce = applyData.force;
                 //*(actionRadius - distanceToSegment) / actionRadius;
                 object->vel = object->vel + weightedForce;

--- a/source/EngineKernels/EnergyProcessor.cuh
+++ b/source/EngineKernels/EnergyProcessor.cuh
@@ -102,7 +102,7 @@ __inline__ __device__ void EnergyProcessor::collision(SimulationData& data)
                 if (object->type == ObjectType_Fluid) {
                     continue;
                 }
-                if (object->isFixed() || object->type == ObjectType_Solid) {
+                if (object->isStatic() || object->type == ObjectType_Solid) {
                     auto vr = particle->vel - object->vel;
                     auto r = data.objectMap.getCorrectedDirection(particle->pos - object->pos);
                     auto dot_vr_r = Math::dot(vr, r);

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -561,18 +561,18 @@ struct Object
     uint8_t numConnections;
     uint8_t color;
     uint8_t selected;  // 0 = no, 1 = selected, 2 = cluster selected
-    uint8_t flags;     // bit0 = fixed, bit1 = detached, bit2 = sticky
+    uint8_t flags;     // bit0 = isStatic, bit1 = detached, bit2 = sticky
     int locked;        // 0 = unlocked, 1 = locked
 
     // General
     uint64_t id;
     ObjectConnection connections[MAX_OBJECT_CONNECTIONS];
 
-    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ bool isStatic() const { return flags & 1; }
     __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
     __device__ __inline__ bool isSticky() const { return flags & 4; }
 
-    __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
+    __device__ __inline__ void setStatic(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
     __device__ __inline__ void setDetached(bool value) { flags = value ? (flags | 2) : (flags & ~2); }
     __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 
@@ -694,9 +694,9 @@ struct __align__(8) LightObject
     Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
     int nextObjectIndex;  // next object in the same cell, -1 = end of chain
     uint8_t numConnections;
-    uint8_t flags;  // bit0 = fixed, bit1 = detached, bit2 = sticky
+    uint8_t flags;  // bit0 = isStatic, bit1 = detached, bit2 = sticky
 
-    __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __device__ __inline__ bool isStatic() const { return flags & 1; }
     __device__ __inline__ int detached() const { return (flags >> 1) & 1; }
     __device__ __inline__ bool isSticky() const { return flags & 4; }
 

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -374,7 +374,7 @@ __inline__ __device__ void EntityFactory::changeObjectFromTO(TOs const& to, Obje
     object->vel = objectTO.vel;
     object->stiffness = objectTO.stiffness;
     object->color = objectTO.color;
-    object->setFixed(objectTO.isFixed());
+    object->setStatic(objectTO.isStatic());
     object->setSticky(objectTO.isSticky());
     object->type = objectTO.type;
 

--- a/source/EngineKernels/ForceFieldKernels.cu
+++ b/source/EngineKernels/ForceFieldKernels.cu
@@ -148,7 +148,7 @@ __global__ void cudaApplyForceFields(SimulationData data)
 
         for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
             auto& object = objects.at(index);
-            if (object->isFixed()) {
+            if (object->isStatic()) {
                 continue;
             }
             object->vel += calcResultingAcceleration(object->pos, getMassForSPH(object));

--- a/source/EngineKernels/InjectorProcessor.cuh
+++ b/source/EngineKernels/InjectorProcessor.cuh
@@ -44,7 +44,7 @@ __inline__ __device__ void InjectorProcessor::processCell(SimulationData& data, 
                 if (object->typeData.cell.isSameCreature(&otherObject->typeData.cell)) {
                     return;
                 }
-                if (otherObject->isFixed()) {
+                if (otherObject->isStatic()) {
                     return;
                 }
                 if (!otherObject->typeData.cell.constructorAvailable) {

--- a/source/EngineKernels/MuscleProcessor.cuh
+++ b/source/EngineKernels/MuscleProcessor.cuh
@@ -101,7 +101,7 @@ __device__ __inline__ void MuscleProcessor::restoreInitialAngleFromPrevious(Obje
 
 __device__ __inline__ void MuscleProcessor::processCell(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
-    if (object->isFixed()) {
+    if (object->isStatic()) {
         return;
     }
     object->typeData.cell.cellTypeData.muscle.lastMovementX = 0;

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -188,14 +188,14 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                         adaptedDistance *= 2.0f;  // Reduce range of cell repulsion within creature by scaling distance
                     }
 
-                    if (other->isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached() + other->detached() != 1) {
+                    if (other->isStatic() && adaptedDistance <= smoothingLength * 2 && object->detached() + other->detached() != 1) {
                         auto index = atomicAdd(&numFixedObjects, 1);
                         if (index < MaxBarrierCellsForCollision) {
                             fixedCells[index] = other->self;
                         }
                     }
 
-                    if (!other->isFixed() && adaptedDistance <= smoothingLength * 2 && object->detached() + other->detached() != 1) {
+                    if (!other->isStatic() && adaptedDistance <= smoothingLength * 2 && object->detached() + other->detached() != 1) {
 
                         // Calc density
                         auto otherMass = getMassForSPH(other);
@@ -204,7 +204,7 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
                         if (object != other->self) {
 
                             // Overlap correction
-                            if (!object->isFixed() && origDistance < cudaSimulationParameters.minObjectDistance.value) {
+                            if (!object->isStatic() && origDistance < cudaSimulationParameters.minObjectDistance.value) {
                                 localCellPosDelta.x += posDelta.x * cudaSimulationParameters.minObjectDistance.value / 5;
                                 localCellPosDelta.y += posDelta.y * cudaSimulationParameters.minObjectDistance.value / 5;
                             }
@@ -240,8 +240,8 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
 
                             // Fusion
                             if (Math::length(velDelta) >= cellFusionVelocity && object->numConnections < MAX_OBJECT_CONNECTIONS
-                                && other->numConnections < MAX_OBJECT_CONNECTIONS && (object->isSticky() || other->isSticky()) && !object->isFixed()
-                                && !other->isFixed()) {
+                                && other->numConnections < MAX_OBJECT_CONNECTIONS && (object->isSticky() || other->isSticky()) && !object->isStatic()
+                                && !other->isStatic()) {
                                 ObjectConnectionProcessor::scheduleAddConnectionPair(data, object, other->self);
                             }
                         }
@@ -430,7 +430,7 @@ __inline__ __device__ void ObjectProcessor::checkForces(SimulationData& data)
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
         object->density = object->tempValue2.as_float2.x;
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
 
@@ -450,7 +450,7 @@ __inline__ __device__ void ObjectProcessor::applyForces(SimulationData& data)
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         auto acceleration = object->tempValue1.as_float2 / max(0.05f, object->density) * 0.5f;
@@ -472,7 +472,7 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (0 == object->numConnections /* || object->isFixed()*/) {
+        if (0 == object->numConnections /* || object->isStatic()*/) {
             continue;
         }
         float2 force{0, 0};
@@ -538,7 +538,7 @@ __inline__ __device__ void ObjectProcessor::checkConnections(SimulationData& dat
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
 
@@ -566,7 +566,7 @@ __inline__ __device__ void ObjectProcessor::verletPositionUpdate(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             object->pos += object->vel * cudaSimulationParameters.timestepSize.value;
             data.objectMap.correctPosition(object->pos);
         } else {
@@ -586,7 +586,7 @@ __inline__ __device__ void ObjectProcessor::verletVelocityUpdate(SimulationData&
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         auto acceleration = (object->tempValue1.as_float2 + object->tempValue2.as_float2) / 2;
@@ -602,12 +602,12 @@ __inline__ __device__ void ObjectProcessor::applyInnerFriction(SimulationData& d
     auto const innerFriction = cudaSimulationParameters.innerFriction.value;
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         for (int index = 0; index < object->numConnections; ++index) {
             auto connectedObject = object->connections[index].object;
-            if (connectedObject->isFixed()) {
+            if (connectedObject->isStatic()) {
                 continue;
             }
             auto posDelta = object->pos - connectedObject->pos;
@@ -634,7 +634,7 @@ __inline__ __device__ void ObjectProcessor::applyFriction(SimulationData& data)
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
 
@@ -650,7 +650,7 @@ __inline__ __device__ void ObjectProcessor::radiation(SimulationData& data)
     auto partition = calcSystemThreadPartition(objects.getNumEntries());
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         if (object->type == ObjectType_Solid || object->type == ObjectType_Fluid) {

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -78,7 +78,7 @@ __global__ void cudaUpdateHistogramData_substep2(SimulationData data, Simulation
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         if (object->type == ObjectType_Cell) {
@@ -97,7 +97,7 @@ __global__ void cudaUpdateHistogramData_substep3(SimulationData data, Simulation
     auto maxAge = statistics.getMaxAge();
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
-        if (object->isFixed()) {
+        if (object->isStatic()) {
             continue;
         }
         if (object->type == ObjectType_Cell) {

--- a/source/EngineKernels/TOs.cuh
+++ b/source/EngineKernels/TOs.cuh
@@ -471,17 +471,17 @@ struct ObjectTO
     float2 vel;
     float stiffness;
     uint8_t color;
-    uint8_t flags;  // bit0 = fixed, bit2 = sticky
+    uint8_t flags;  // bit0 = isStatic, bit2 = sticky
     ObjectType type;
     ObjectTypeDataTO typeData;
 
     // Editing data
     uint8_t selected;
 
-    __host__ __device__ __inline__ bool isFixed() const { return flags & 1; }
+    __host__ __device__ __inline__ bool isStatic() const { return flags & 1; }
     __host__ __device__ __inline__ bool isSticky() const { return flags & 4; }
 
-    __host__ __device__ __inline__ void setFixed(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
+    __host__ __device__ __inline__ void setStatic(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
     __host__ __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
 };
 

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -49,11 +49,11 @@ ObjectDesc DescTestDataFactory::createNonDefaultObjectDesc(ObjectParameter objec
 {
     switch (objectParameter.objectType) {
     case ObjectType_Solid:
-        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).fixed(true).type(SolidDesc().energy(42.0f));
+        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).isStatic(true).type(SolidDesc().energy(42.0f));
     case ObjectType_Fluid:
-        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).fixed(true).type(FluidDesc().energy(42.0f).glow(1.0f));
+        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).isStatic(true).type(FluidDesc().energy(42.0f).glow(1.0f));
     case ObjectType_FreeCell:
-        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).fixed(true).type(FreeCellDesc().energy(42.0f).age(7));
+        return ObjectDesc().pos({0.5f, 0.8f}).vel({-0.3f, 0.7f}).color(3).isStatic(true).type(FreeCellDesc().energy(42.0f).age(7));
     case ObjectType_Cell: {
         auto cellTypeDesc = createNonDefaultCellTypeDesc(objectParameter);
         NeuralNetDesc nn;
@@ -66,7 +66,7 @@ ObjectDesc DescTestDataFactory::createNonDefaultObjectDesc(ObjectParameter objec
             .pos({0.5f, 0.8f})
             .vel({-0.3f, 0.7f})
             .color(3)
-            .fixed(true)
+            .isStatic(true)
             .type(CellDesc()
                       .neuralNetwork(nn)
                       .usableEnergy(150.0f)

--- a/source/EngineTests/AttackerTests.cpp
+++ b/source/EngineTests/AttackerTests.cpp
@@ -70,7 +70,7 @@ protected:
     {
         auto data = Desc().addCreature(
             {
-                ObjectDesc().id(100).pos(pos).color(color).fixed(fixed).type(CellDesc().usableEnergy(usableEnergy)),
+                ObjectDesc().id(100).pos(pos).color(color).isStatic(fixed).type(CellDesc().usableEnergy(usableEnergy)),
             },
             CreatureDesc().id(creatureId));
         return data;

--- a/source/EngineTests/CellStateTransitionTests.cpp
+++ b/source/EngineTests/CellStateTransitionTests.cpp
@@ -42,8 +42,8 @@ TEST_F(CellStateTransitionTests, ready_ready)
 {
     Desc data;
     data.addCreature({
-        ObjectDesc().id(1).pos({10.0f, 10.0f}).fixed(true).type(CellDesc().cellState(CellState_Ready)),
-        ObjectDesc().id(2).pos({11.0f, 10.0f}).fixed(true).type(CellDesc().cellState(CellState_Ready)),
+        ObjectDesc().id(1).pos({10.0f, 10.0f}).isStatic(true).type(CellDesc().cellState(CellState_Ready)),
+        ObjectDesc().id(2).pos({11.0f, 10.0f}).isStatic(true).type(CellDesc().cellState(CellState_Ready)),
     });
     data.addConnection(1, 2);
 
@@ -89,7 +89,7 @@ TEST_F(CellStateTransitionTests, underConstruction_activating)
 
 TEST_F(CellStateTransitionTests, noDyingForFixedCells)
 {
-    auto data = Desc().addCreature({ObjectDesc().id(1).fixed(true).pos({10.0f, 10.0f})});
+    auto data = Desc().addCreature({ObjectDesc().id(1).isStatic(true).pos({10.0f, 10.0f})});
 
     _simulationFacade->setSimulationData(data);
     _simulationFacade->calcTimesteps(1);
@@ -119,7 +119,7 @@ TEST_F(CellStateTransitionTests, cellStaysAliveWhenLastUpdateBelowInterval)
 
 TEST_F(CellStateTransitionTests, fixedCellDoesNotDieFromLastUpdate)
 {
-    auto data = Desc().addCreature({ObjectDesc().id(1).fixed(true).pos({10.0f, 10.0f}).type(CellDesc().lastUpdate(2 * CELL_UPDATE_INTERVAL + 2))});
+    auto data = Desc().addCreature({ObjectDesc().id(1).isStatic(true).pos({10.0f, 10.0f}).type(CellDesc().lastUpdate(2 * CELL_UPDATE_INTERVAL + 2))});
 
     _simulationFacade->setSimulationData(data);
     _simulationFacade->calcTimesteps(1);

--- a/source/EngineTests/InjectorTests.cpp
+++ b/source/EngineTests/InjectorTests.cpp
@@ -143,8 +143,8 @@ TEST_F(InjectorTests, noInjectionOnFixedCells)
     // Add target creature with fixed constructor
     data.addCreature(
         {
-            ObjectDesc().id(100).pos({100.0f, 103.0f}).fixed(true).type(CellDesc().constructor(ConstructorDesc().geneIndex(0))),
-            ObjectDesc().id(101).pos({101.0f, 103.0f}).fixed(true),
+            ObjectDesc().id(100).pos({100.0f, 103.0f}).isStatic(true).type(CellDesc().constructor(ConstructorDesc().geneIndex(0))),
+            ObjectDesc().id(101).pos({101.0f, 103.0f}).isStatic(true),
         },
         CreatureDesc().id(2));
     data.addConnection(100, 101);

--- a/source/EngineTests/PhysicsTests.cpp
+++ b/source/EngineTests/PhysicsTests.cpp
@@ -175,8 +175,8 @@ TEST_F(PhysicsTests, noGhostMovements)
 TEST_F(PhysicsTests, angularForcesBetweenFixedAndNonFixedObject)
 {
     auto data = Desc().addCreature({
-        ObjectDesc().id(1).pos({10.0f, 10.0f}).fixed(true),
-        ObjectDesc().id(2).pos({10.0f, 11.0f}).fixed(true),
+        ObjectDesc().id(1).pos({10.0f, 10.0f}).isStatic(true),
+        ObjectDesc().id(2).pos({10.0f, 11.0f}).isStatic(true),
         ObjectDesc().id(3).pos({11.0f, 11.0f}).type(CellDesc().headCell(true)),
     });
     data.addConnection(2, 1);

--- a/source/EngineTests/RadiationTests.cpp
+++ b/source/EngineTests/RadiationTests.cpp
@@ -31,7 +31,7 @@ TEST_F(RadiationTests, fixedCells_shouldNotRadiate)
     auto initialEnergy = 200.0f;
 
     auto data =
-        Desc().addCreature({ObjectDesc().id(1).pos({100.0f, 100.0f}).vel({0.0f, 0.0f}).fixed(true).color(0).type(CellDesc().usableEnergy(initialEnergy))});
+        Desc().addCreature({ObjectDesc().id(1).pos({100.0f, 100.0f}).vel({0.0f, 0.0f}).isStatic(true).color(0).type(CellDesc().usableEnergy(initialEnergy))});
 
     _simulationFacade->setSimulationData(data);
 

--- a/source/Gui/CreatorWindow.cpp
+++ b/source/Gui/CreatorWindow.cpp
@@ -42,7 +42,7 @@ void CreatorWindow::initIntern()
 {
     _energy = GlobalSettings::get().getValue("editors.creator.energy", _energy);
     _stiffness = GlobalSettings::get().getValue("editors.creator.stiffness", _stiffness);
-    _fixed = GlobalSettings::get().getValue("editors.creator.fixed", _fixed);
+    _static = GlobalSettings::get().getValue("editors.creator.static", _static);
     _objectDistance = GlobalSettings::get().getValue("editors.creator.object distance", _objectDistance);
     _glow = GlobalSettings::get().getValue("editors.creator.glow", _glow);
     _makeSticky = GlobalSettings::get().getValue("editors.creator.make sticky", _makeSticky);
@@ -59,7 +59,7 @@ void CreatorWindow::shutdownIntern()
 {
     GlobalSettings::get().setValue("editors.creator.energy", _energy);
     GlobalSettings::get().setValue("editors.creator.stiffness", _stiffness);
-    GlobalSettings::get().setValue("editors.creator.fixed", _fixed);
+    GlobalSettings::get().setValue("editors.creator.static", _static);
     GlobalSettings::get().setValue("editors.creator.object distance", _objectDistance);
     GlobalSettings::get().setValue("editors.creator.glow", _glow);
     GlobalSettings::get().setValue("editors.creator.make sticky", _makeSticky);
@@ -170,7 +170,7 @@ void CreatorWindow::processIntern()
             AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Sticky").textWidth(RightColumnWidth).tooltip(Const::CreatorStickyTooltip), _makeSticky);
         }
         if (!isEnergyMaterial()) {
-            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Fixed").textWidth(RightColumnWidth).tooltip(Const::CellFixedTooltip), _fixed);
+            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Static").textWidth(RightColumnWidth).tooltip(Const::CellStaticTooltip), _static);
         }
     }
     ImGui::EndChild();
@@ -223,7 +223,7 @@ void CreatorWindow::onDrawing()
                                                             .sticky(_makeSticky)
                                                             .cellDistance(1.0f)
                                                             .color(EditorModel::get().getDefaultColorCode())
-                                                            .fixed(_fixed)
+                                                            .isStatic(_static)
                                                             .connectObjects(false));
         return isEnergyMaterial() ? convertToEnergyParticles(desc) : desc;
     };
@@ -290,7 +290,7 @@ void CreatorWindow::createEntity()
                                               .pos(getRandomPos())
                                               .stiffness(_stiffness)
                                               .color(EditorModel::get().getDefaultColorCode())
-                                              .fixed(_fixed)
+                                              .isStatic(_static)
                                               .sticky(_makeSticky)
                                               .type(getObjectTypeDesc()));
     }
@@ -312,7 +312,7 @@ void CreatorWindow::createRectangle()
                                                              .sticky(_makeSticky)
                                                              .color(EditorModel::get().getDefaultColorCode())
                                                              .center(getRandomPos())
-                                                             .fixed(_fixed));
+                                                             .isStatic(_static));
     if (isEnergyMaterial()) {
         description = convertToEnergyParticles(description);
     }
@@ -333,7 +333,7 @@ void CreatorWindow::createHexagon()
                                                             .sticky(_makeSticky)
                                                             .color(EditorModel::get().getDefaultColorCode())
                                                             .center(getRandomPos())
-                                                            .fixed(_fixed));
+                                                            .isStatic(_static));
     if (isEnergyMaterial()) {
         description = convertToEnergyParticles(description);
     } else {
@@ -368,7 +368,7 @@ void CreatorWindow::createDisc()
                                                   .sticky(_makeSticky)
                                                   .pos(relPos)
                                                   .color(color)
-                                                  .fixed(_fixed)
+                                                  .isStatic(_static)
                                                   .type(objectType));
         }
     }

--- a/source/Gui/CreatorWindow.h
+++ b/source/Gui/CreatorWindow.h
@@ -59,7 +59,7 @@ private:
 
     float _energy = 100.0f;
     float _stiffness = 1.0f;
-    bool _fixed = false;
+    bool _static = false;
     float _objectDistance = 1.0f;
     float _glow = 0.0f;
     bool _makeSticky = false;

--- a/source/Gui/HelpStrings.h
+++ b/source/Gui/HelpStrings.h
@@ -321,7 +321,7 @@ namespace Const
 
     std::string const CellMaxConnectionTooltip = "The maximum number of bonds a cell can form with other cells.";
 
-    std::string const CellFixedTooltip = "When a cell is set as fixed, it becomes immortal, resistant to external forces, but still "
+    std::string const CellStaticTooltip = "When a cell is set as static, it becomes immortal, resistant to external forces, but still "
                                          "capable of linear movement. Furthermore, unconnected "
                                          "normal cells and energy particles bounce off from indestructible ones.";
 

--- a/source/Gui/ImageToPatternDialog.cpp
+++ b/source/Gui/ImageToPatternDialog.cpp
@@ -101,7 +101,7 @@ void ImageToPatternDialog::show()
                                                        .id(NumberGenerator::get().createEntityId())
                                                        .pos({toFloat(x) + xOffset, toFloat(y)})
                                                        .color(matchedCellColor)
-                                                       .fixed(false)
+                                                       .isStatic(false)
                                                        .type(SolidDesc()));
                 }
             }

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -394,7 +394,7 @@ void _InspectionWindow::processObjectNode(ObjectDesc& object)
                     .name("Color")
                     .textWidth(TextWidth),
                 object._color);
-            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Fixed").textWidth(TextWidth), object._fixed);
+            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Static").textWidth(TextWidth), object._isStatic);
             AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Sticky").textWidth(TextWidth), object._sticky);
 
             auto objectType = object.getObjectType();

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -1095,7 +1095,7 @@ namespace
     auto constexpr Id_Object_Vel = 3;
     auto constexpr Id_Object_Stiffness = 4;
     auto constexpr Id_Object_Color = 5;
-    auto constexpr Id_Object_Fixed = 6;
+    auto constexpr Id_Object_Static = 6;
     auto constexpr Id_Object_Sticky = 17;
 
     auto constexpr Id_Signal_Channels = 0;
@@ -1770,7 +1770,7 @@ namespace cereal
         scope.addMember(Id_Object_Vel, data._vel, defaultObject._vel);
         scope.addMember(Id_Object_Stiffness, data._stiffness, defaultObject._stiffness);
         scope.addMember(Id_Object_Color, data._color, defaultObject._color);
-        scope.addMember(Id_Object_Fixed, data._fixed, defaultObject._fixed);
+        scope.addMember(Id_Object_Static, data._isStatic, defaultObject._isStatic);
         scope.addMember(Id_Object_Sticky, data._sticky, defaultObject._sticky);
         scope.addDesc(Id_Object_Connections, data._connections);
         scope.addDesc(Id_Object_Type, data._type);


### PR DESCRIPTION
## Summary
Rename the `fixed` flag of `ObjectDesc` to `isStatic` across the whole stack.

- `ObjectDesc`: `fixed` → `isStatic` (field `_isStatic`, setter `isStatic()`)
- TOs (`TOs.cuh`) and Entities (`Entities.cuh`, all 3 structs): getter/setter `isFixed()/setFixed()` → `isStatic()/setStatic()`; flag-bit comments updated
- All CUDA kernel call sites updated (`object->isStatic()` etc.)
- Converters updated: `DescConverterService`, `DataAccessKernels`, `EntityFactory`, `EditKernels`
- `DescEditService` Create*Parameters: `fixed` → `isStatic`
- GUI now speaks only of **static** (not `isStatic`/`fixed`): checkbox label `"Static"`, member `_static`, settings key `editors.creator.static`, tooltip `CellStaticTooltip`

## Compatibility
Serialization key keeps value 6 (`Id_Object_Fixed` → `Id_Object_Static`), so existing save files stay compatible.

## Tests
- Clean from-scratch build: 470/470 OK
- EngineInterfaceTests 155, PersisterTests 64, NetworkTests 4 — all pass
- GPU static-flag tests (Attacker, Injector, Physics, Radiation, CellStateTransition): 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)