### PR TITLE
Add Lineage object-coloring render style

### DIFF
--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -89,6 +89,7 @@ ParametersSpec const& SimulationParameters::getSpec()
                                            {"Energy", {}},
                                            {"Customization", {}},
                                            {"Lineage + Customization", {}},
+                                           {"Lineage", {}},
                                        }))
                         .description(coloringTooltip),
                     ParameterSpec()

--- a/source/EngineInterface/SimulationParametersTypes.h
+++ b/source/EngineInterface/SimulationParametersTypes.h
@@ -151,6 +151,7 @@ enum CellColoring_
     CellColoring_None,
     CellColoring_Customization,
     CellColoring_LineageAndCustomization,
+    CellColoring_Lineage,
 };
 
 using CellDeathConsequences = int;

--- a/source/EngineKernels/GeometryKernels.cu
+++ b/source/EngineKernels/GeometryKernels.cu
@@ -145,6 +145,19 @@ namespace
             h -= floorf(h);
             return hsvToRgb(h, s, v);
         }
+        if (coloring == CellColoring_Lineage) {
+            if (object->type != ObjectType_Cell) {
+                return getCustomizationColor(object->color);
+            }
+            auto lineageId = object->typeData.cell.creature->genome->lineageId;
+            uint32_t hash1 = lineageId * 2654435761u;
+            uint32_t hash2 = lineageId * 2246822519u;
+            uint32_t hash3 = lineageId * 3266489917u;
+            float h = static_cast<float>(hash1 & 0xFFFFu) / 65535.0f;
+            float s = 0.7f + 0.3f * (static_cast<float>(hash2 & 0xFFFFu) / 65535.0f);
+            float v = 0.6f + 0.1f * (static_cast<float>(hash3 & 0xFFFFu) / 65535.0f);
+            return hsvToRgb(h, s, v);
+        }
         return getCustomizationColor(object->color);
     }
 


### PR DESCRIPTION
## Summary

Adds a new **Lineage** option to *Object coloring* (Visualization settings),
alongside the existing *Customization* and *Lineage + Customization*.

In this mode a cell's color is derived purely from its lineage id and is **not**
influenced by the customization color: the hue is randomized over the full
`[0,1]` interval (rather than the relative `[-0.1, 0.1]` offset used by
*Lineage + Customization*). Saturation and value come from independent hashes of
the lineage id. Non-cell objects (which have no lineage) fall back to the
customization color, matching the *Lineage + Customization* branch.

## Changes

- `SimulationParametersTypes.h`: new `CellColoring_Lineage` enum value (appended,
  so existing persisted coloring values stay stable)
- `SimulationParameters.cpp`: new `"Lineage"` alternative in the Object coloring spec
- `GeometryKernels.cu` (`getObjectColor`): new `CellColoring_Lineage` branch

## Testing

- Full Release build clean (Ninja, 362/362)
- `EngineInterfaceTests` 155/155 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)