### PR TITLE
Add "Inspect creatures" feature

### DIFF
--- a/source/Gui/EditorController.cpp
+++ b/source/Gui/EditorController.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <imgui.h>
 
@@ -112,10 +113,23 @@ void EditorController::onInspectSelectedGenomes()
 
 void EditorController::onInspectSelectedCreatures()
 {
-    Desc selectedData = _SimulationFacade::get()->getSelectedSimulationData(true);
-    auto entities = DescEditService::get().getObjects(selectedData);
+    // Collect the creature ids of the directly selected cells
+    Desc directlySelectedData = _SimulationFacade::get()->getSelectedSimulationData(false);
+    std::unordered_set<uint64_t> selectedCreatureIds;
+    for (auto const& object : directlySelectedData._objects) {
+        if (object.getObjectType() == ObjectType_Cell) {
+            selectedCreatureIds.insert(object.getCellRef()._creatureId);
+        }
+    }
+    if (selectedCreatureIds.empty()) {
+        return;
+    }
 
-    // For each creature, pick the head cell with smallest branch index, then smallest concatenation index
+    // Consider all cells of those creatures and pick the head cell of each
+    // (head cell with the smallest branch index, then smallest concatenation index)
+    Desc creatureData = _SimulationFacade::get()->getSelectedSimulationData(true);
+    auto entities = DescEditService::get().getObjects(creatureData);
+
     std::unordered_map<uint64_t, ExtendedObjectDesc> headCellByCreatureId;
     for (auto const& entity : entities) {
         if (!std::holds_alternative<ExtendedObjectDesc>(entity)) {
@@ -126,13 +140,12 @@ void EditorController::onInspectSelectedCreatures()
             continue;
         }
         auto const& cell = extendedObject.object.getCellRef();
-        if (!cell._headCell) {
+        if (!cell._headCell || selectedCreatureIds.find(cell._creatureId) == selectedCreatureIds.end()) {
             continue;
         }
-        auto creatureId = extendedObject.creature->_id;
-        auto it = headCellByCreatureId.find(creatureId);
+        auto it = headCellByCreatureId.find(cell._creatureId);
         if (it == headCellByCreatureId.end()) {
-            headCellByCreatureId.emplace(creatureId, extendedObject);
+            headCellByCreatureId.emplace(cell._creatureId, extendedObject);
         } else {
             auto const& bestCell = it->second.object.getCellRef();
             if (cell._branchIndex < bestCell._branchIndex

--- a/source/Gui/EditorController.cpp
+++ b/source/Gui/EditorController.cpp
@@ -1,11 +1,13 @@
 #include "EditorController.h"
 
 #include <memory>
+#include <unordered_map>
 
 #include <imgui.h>
 
 #include <Base/Math.h>
 
+#include <EngineInterface/CellTypeConstants.h>
 #include <EngineInterface/DescEditService.h>
 #include <EngineInterface/InspectedEntityIds.h>
 #include <EngineInterface/SimulationFacade.h>
@@ -108,7 +110,52 @@ void EditorController::onInspectSelectedGenomes()
     printOverlayMessage(std::to_string(uniqueGenomes.size()) + (uniqueGenomes.size() == 1 ? " genome" : " genomes") + " inspected");
 }
 
-bool EditorController::onInspectObjects(std::vector<ExtendedObjectOrEnergyDesc> const& entities, bool selectGenomeTab)
+void EditorController::onInspectSelectedCreatures()
+{
+    Desc selectedData = _SimulationFacade::get()->getSelectedSimulationData(true);
+    auto entities = DescEditService::get().getObjects(selectedData);
+
+    // For each creature, pick the head cell with smallest branch index, then smallest concatenation index
+    std::unordered_map<uint64_t, ExtendedObjectDesc> headCellByCreatureId;
+    for (auto const& entity : entities) {
+        if (!std::holds_alternative<ExtendedObjectDesc>(entity)) {
+            continue;
+        }
+        auto const& extendedObject = std::get<ExtendedObjectDesc>(entity);
+        if (extendedObject.object.getObjectType() != ObjectType_Cell || !extendedObject.creature.has_value()) {
+            continue;
+        }
+        auto const& cell = extendedObject.object.getCellRef();
+        if (!cell._headCell) {
+            continue;
+        }
+        auto creatureId = extendedObject.creature->_id;
+        auto it = headCellByCreatureId.find(creatureId);
+        if (it == headCellByCreatureId.end()) {
+            headCellByCreatureId.emplace(creatureId, extendedObject);
+        } else {
+            auto const& bestCell = it->second.object.getCellRef();
+            if (cell._branchIndex < bestCell._branchIndex
+                || (cell._branchIndex == bestCell._branchIndex && cell._concatenationIndex < bestCell._concatenationIndex)) {
+                it->second = extendedObject;
+            }
+        }
+    }
+
+    std::vector<ExtendedObjectOrEnergyDesc> headCells;
+    for (auto const& [creatureId, headCell] : headCellByCreatureId) {
+        headCells.emplace_back(headCell);
+    }
+
+    if (!onInspectObjects(headCells, true)) {
+        std::string message = "Too many creatures are selected for inspection. A maximum of ";
+        message += std::to_string(Const::MaxInspectedObjects);
+        message += " creatures are allowed.";
+        showMessage("Inspection not possible", message);
+    }
+}
+
+bool EditorController::onInspectObjects(std::vector<ExtendedObjectOrEnergyDesc> const& entities, bool creatureMode)
 {
     if (entities.empty()) {
         return true;
@@ -183,7 +230,7 @@ bool EditorController::onInspectObjects(std::vector<ExtendedObjectOrEnergyDesc> 
         auto windowPosY = (entityPos.y - center.y) * factorY + center.y;
         windowPosX = std::min(std::max(windowPosX, 0.0f), toFloat(viewSize.x) - 300.0f) + 40.0f;
         windowPosY = std::min(std::max(windowPosY, 0.0f), toFloat(viewSize.y) - 500.0f) + 40.0f;
-        _inspectorWindows.emplace_back(std::make_shared<_InspectionWindow>(id, RealVector2D{windowPosX, windowPosY}, selectGenomeTab));
+        _inspectorWindows.emplace_back(std::make_shared<_InspectionWindow>(id, RealVector2D{windowPosX, windowPosY}, creatureMode));
     }
     return true;
 }

--- a/source/Gui/EditorController.h
+++ b/source/Gui/EditorController.h
@@ -22,7 +22,8 @@ public:
 
     void onInspectSelectedObjects();
     void onInspectSelectedGenomes();
-    bool onInspectObjects(std::vector<ExtendedObjectOrEnergyDesc> const& entities, bool selectGenomeTab);
+    void onInspectSelectedCreatures();
+    bool onInspectObjects(std::vector<ExtendedObjectOrEnergyDesc> const& entities, bool creatureMode);
 
     bool isCopyingPossible() const;
     void onCopy();

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -234,7 +234,7 @@ void _InspectionWindow::process()
     auto width = calcWindowWidth();
     float height;
     if (_creatureMode) {
-        height = StyleRepository::get().scale(230.0f);
+        height = StyleRepository::get().scale(260.0f);
     } else if (isObject()) {
         height = StyleRepository::get().scale(500.0f);
     } else {
@@ -306,11 +306,10 @@ std::string _InspectionWindow::generateTitle() const
 void _InspectionWindow::processObject(ExtendedObjectDesc& extendedObject)
 {
     if (_creatureMode) {
-        if (extendedObject.creature.has_value()) {
+        if (extendedObject.creature.has_value() && extendedObject.genome.has_value()) {
             AlienGui::DynamicTableLayout table(TableColumnWidth);
             if (table.begin()) {
-                processCreatureNode(extendedObject, true);
-                table.next();
+                processCreatureProperties(extendedObject);
                 table.end();
             }
         }
@@ -562,26 +561,29 @@ void _InspectionWindow::processConstructorNode(ConstructorDesc& constructor)
 }
 
 
-void _InspectionWindow::processCreatureNode(ExtendedObjectDesc& extendedObject, bool defaultOpen)
+void _InspectionWindow::processCreatureProperties(ExtendedObjectDesc& extendedObject)
 {
-    if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Creature").rank(AlienGui::TreeNodeRank::High).defaultOpen(defaultOpen))) {
-        processPropertiesSubNode("Creature", [&] {
-            auto& creature = extendedObject.creature.value();
-            inspectorHexId("Creature id", creature._id);
-            inspectorText("Generation", std::to_string(creature._generation));
-            inspectorText("Num cells", std::to_string(creature._numCells));
-            auto& genome = extendedObject.genome.value();
-            std::stringstream frontAngle;
-            frontAngle << std::fixed << std::setprecision(1) << genome._frontAngle;
-            inspectorText("Front angle", frontAngle.str());
-            inspectorText("Genome name", genome._name);
-            inspectorText("Lineage id", std::to_string(genome._lineageId));
-            inspectorText("Resistance to injection", genome._resistanceToInjection ? "Yes" : "No");
-            inspectorText("Apply meta-mutations", genome._applyMetaMutations ? "Yes" : "No");
-            if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Edit genome").textWidth(TextWidth))) {
-                GenomeEditorWindow::get().openTab(genome, false);
-            }
-        });
+    auto& creature = extendedObject.creature.value();
+    inspectorHexId("Creature id", creature._id);
+    inspectorText("Generation", std::to_string(creature._generation));
+    inspectorText("Num cells", std::to_string(creature._numCells));
+    auto& genome = extendedObject.genome.value();
+    std::stringstream frontAngle;
+    frontAngle << std::fixed << std::setprecision(1) << genome._frontAngle;
+    inspectorText("Front angle", frontAngle.str());
+    inspectorText("Genome name", genome._name);
+    inspectorText("Lineage id", std::to_string(genome._lineageId));
+    inspectorText("Resistance to injection", genome._resistanceToInjection ? "Yes" : "No");
+    inspectorText("Apply meta-mutations", genome._applyMetaMutations ? "Yes" : "No");
+    if (AlienGui::Button(AlienGui::ButtonParameters().buttonText("Edit").name("Edit genome").textWidth(TextWidth))) {
+        GenomeEditorWindow::get().openTab(genome, false);
+    }
+}
+
+void _InspectionWindow::processCreatureNode(ExtendedObjectDesc& extendedObject)
+{
+    if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Creature").rank(AlienGui::TreeNodeRank::High).defaultOpen(false))) {
+        processPropertiesSubNode("Creature", [&] { processCreatureProperties(extendedObject); });
     }
     AlienGui::EndTreeNode();
 }

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -235,7 +235,7 @@ void _InspectionWindow::process()
     auto width = calcWindowWidth();
     float height;
     if (_creatureMode) {
-        height = StyleRepository::get().scale(320.0f);
+        height = StyleRepository::get().scale(280.0f);
     } else if (isObject()) {
         height = StyleRepository::get().scale(500.0f);
     } else {

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -216,10 +216,10 @@ namespace
     }
 }
 
-_InspectionWindow::_InspectionWindow(uint64_t entityId, RealVector2D const& initialPos, bool selectGenomeTab)
+_InspectionWindow::_InspectionWindow(uint64_t entityId, RealVector2D const& initialPos, bool creatureMode)
     : _entityId(entityId)
     , _initialPos(initialPos)
-    , _selectGenomeTab(selectGenomeTab)
+    , _creatureMode(creatureMode)
 {
     _neuralNetWidget = _NeuralNetEditorWidget::create();
 }
@@ -232,7 +232,14 @@ void _InspectionWindow::process()
         return;
     }
     auto width = calcWindowWidth();
-    auto height = isObject() ? StyleRepository::get().scale(500.0f) : StyleRepository::get().scale(180.0f);
+    float height;
+    if (_creatureMode) {
+        height = StyleRepository::get().scale(230.0f);
+    } else if (isObject()) {
+        height = StyleRepository::get().scale(500.0f);
+    } else {
+        height = StyleRepository::get().scale(180.0f);
+    }
     auto borderlessRendering = _SimulationFacade::get()->getSimulationParameters().borderlessRendering.value;
     ImGui::SetNextWindowBgAlpha(Const::WindowAlpha * ImGui::GetStyle().Alpha);
     ImGui::SetNextWindowSize({width, height}, ImGuiCond_Appearing);
@@ -284,7 +291,11 @@ bool _InspectionWindow::isObject() const
 std::string _InspectionWindow::generateTitle() const
 {
     std::stringstream ss;
-    if (isObject()) {
+    if (_creatureMode) {
+        auto entity = EditorModel::get().getInspectedEntity(_entityId);
+        auto const& creature = std::get<ExtendedObjectDesc>(entity).creature;
+        ss << "Creature with id 0x" << std::hex << std::uppercase << (creature.has_value() ? creature->_id : _entityId);
+    } else if (isObject()) {
         ss << "Cell with id 0x" << std::hex << std::uppercase << _entityId;
     } else {
         ss << "Energy particle with id 0x" << std::hex << std::uppercase << _entityId;
@@ -294,6 +305,18 @@ std::string _InspectionWindow::generateTitle() const
 
 void _InspectionWindow::processObject(ExtendedObjectDesc& extendedObject)
 {
+    if (_creatureMode) {
+        if (extendedObject.creature.has_value()) {
+            AlienGui::DynamicTableLayout table(TableColumnWidth);
+            if (table.begin()) {
+                processCreatureNode(extendedObject, true);
+                table.next();
+                table.end();
+            }
+        }
+        return;
+    }
+
     auto& object = extendedObject.object;
     auto origObject = object;
 
@@ -539,9 +562,9 @@ void _InspectionWindow::processConstructorNode(ConstructorDesc& constructor)
 }
 
 
-void _InspectionWindow::processCreatureNode(ExtendedObjectDesc& extendedObject)
+void _InspectionWindow::processCreatureNode(ExtendedObjectDesc& extendedObject, bool defaultOpen)
 {
-    if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Creature").rank(AlienGui::TreeNodeRank::High).defaultOpen(false))) {
+    if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Creature").rank(AlienGui::TreeNodeRank::High).defaultOpen(defaultOpen))) {
         processPropertiesSubNode("Creature", [&] {
             auto& creature = extendedObject.creature.value();
             inspectorHexId("Creature id", creature._id);

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -27,6 +27,7 @@ std::optional<float> _InspectionWindow::_savedScrollY;
 namespace
 {
     auto constexpr CellWindowWidth = 420.0f;
+    auto constexpr CreatureWindowWidth = 300.0f;
     auto constexpr ParticleWindowWidth = 320.0f;
     auto constexpr TableColumnWidth = 380.0f;
     auto constexpr TextWidth = 160.0f;
@@ -234,7 +235,7 @@ void _InspectionWindow::process()
     auto width = calcWindowWidth();
     float height;
     if (_creatureMode) {
-        height = StyleRepository::get().scale(260.0f);
+        height = StyleRepository::get().scale(320.0f);
     } else if (isObject()) {
         height = StyleRepository::get().scale(500.0f);
     } else {
@@ -307,11 +308,7 @@ void _InspectionWindow::processObject(ExtendedObjectDesc& extendedObject)
 {
     if (_creatureMode) {
         if (extendedObject.creature.has_value() && extendedObject.genome.has_value()) {
-            AlienGui::DynamicTableLayout table(TableColumnWidth);
-            if (table.begin()) {
-                processCreatureProperties(extendedObject);
-                table.end();
-            }
+            processCreatureProperties(extendedObject);
         }
         return;
     }
@@ -871,6 +868,9 @@ void _InspectionWindow::processCellTypeNode(CellDesc& cell)
 
 float _InspectionWindow::calcWindowWidth() const
 {
+    if (_creatureMode) {
+        return StyleRepository::get().scale(CreatureWindowWidth);
+    }
     if (isObject()) {
         return StyleRepository::get().scale(CellWindowWidth);
     }

--- a/source/Gui/InspectionWindow.h
+++ b/source/Gui/InspectionWindow.h
@@ -12,7 +12,7 @@
 class _InspectionWindow
 {
 public:
-    _InspectionWindow(uint64_t entityId, RealVector2D const& initialPos, bool selectGenomeTab);
+    _InspectionWindow(uint64_t entityId, RealVector2D const& initialPos, bool creatureMode);
     ~_InspectionWindow();
 
     void process();
@@ -33,7 +33,7 @@ private:
     void processFluidNode(ObjectDesc& object);
     void processFreeCellNode(ObjectDesc& object);
     void processCellNode(ObjectDesc& object);
-    void processCreatureNode(ExtendedObjectDesc& extendedObject);
+    void processCreatureNode(ExtendedObjectDesc& extendedObject, bool defaultOpen = false);
     void processSignalsNode(CellDesc& cell);
     void processNeuralNetNode(CellDesc& cell);
     void processCellTypeNode(CellDesc& cell);
@@ -45,7 +45,7 @@ private:
 
     bool _on = true;
     uint64_t _entityId = 0;
-    bool _selectGenomeTab = false;
+    bool _creatureMode = false;
     bool _isFirstFrame = true;
     std::optional<std::vector<SignalEntryDesc>> _pendingSignalEntries;
 

--- a/source/Gui/InspectionWindow.h
+++ b/source/Gui/InspectionWindow.h
@@ -33,7 +33,8 @@ private:
     void processFluidNode(ObjectDesc& object);
     void processFreeCellNode(ObjectDesc& object);
     void processCellNode(ObjectDesc& object);
-    void processCreatureNode(ExtendedObjectDesc& extendedObject, bool defaultOpen = false);
+    void processCreatureNode(ExtendedObjectDesc& extendedObject);
+    void processCreatureProperties(ExtendedObjectDesc& extendedObject);
     void processSignalsNode(CellDesc& cell);
     void processNeuralNetNode(CellDesc& cell);
     void processCellTypeNode(CellDesc& cell);

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -490,6 +490,13 @@ void MainLoopController::processMenubar()
         [&] { EditorController::get().onInspectSelectedGenomes(); });
     AlienGui::MenuItem(
         AlienGui::MenuItemParameters()
+            .name("Inspect creatures")
+            .keyAlt(true)
+            .key(ImGuiKey_R)
+            .disabled(!SimulationInteractionController::get().isEditMode() || !PatternEditorWindow::get().isCreatureInspectionPossible()),
+        [&] { EditorController::get().onInspectSelectedCreatures(); });
+    AlienGui::MenuItem(
+        AlienGui::MenuItemParameters()
             .name("Close inspections")
             .key(ImGuiKey_Escape)
             .disabled(!SimulationInteractionController::get().isEditMode() || !EditorController::get().areInspectionWindowsActive()),

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -492,7 +492,7 @@ void MainLoopController::processMenubar()
         AlienGui::MenuItemParameters()
             .name("Inspect creatures")
             .keyAlt(true)
-            .key(ImGuiKey_R)
+            .key(ImGuiKey_P)
             .disabled(!SimulationInteractionController::get().isEditMode() || !PatternEditorWindow::get().isCreatureInspectionPossible()),
         [&] { EditorController::get().onInspectSelectedCreatures(); });
     AlienGui::MenuItem(

--- a/source/Gui/PatternEditorWindow.cpp
+++ b/source/Gui/PatternEditorWindow.cpp
@@ -115,6 +115,15 @@ void PatternEditorWindow::processIntern()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Inspect genomes");
 
+    //inspect creatures button
+    ImGui::SameLine();
+    ImGui::BeginDisabled(!isCreatureInspectionPossible());
+    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PAW))) {
+        EditorController::get().onInspectSelectedCreatures();
+    }
+    ImGui::EndDisabled();
+    AlienGui::Tooltip("Inspect creatures");
+
     if (ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar)) {
 
         ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
@@ -301,6 +310,11 @@ bool PatternEditorWindow::isObjectInspectionPossible() const
 }
 
 bool PatternEditorWindow::isGenomeInspectionPossible() const
+{
+    return EditorModel::get().getSelectionShallowData().numCreatures > 0;
+}
+
+bool PatternEditorWindow::isCreatureInspectionPossible() const
 {
     return EditorModel::get().getSelectionShallowData().numCreatures > 0;
 }

--- a/source/Gui/PatternEditorWindow.h
+++ b/source/Gui/PatternEditorWindow.h
@@ -16,6 +16,7 @@ class PatternEditorWindow : public AlienWindow
 public:
     bool isObjectInspectionPossible() const;
     bool isGenomeInspectionPossible() const;
+    bool isCreatureInspectionPossible() const;
 
     bool isCopyingPossible() const;
     void onCopy();


### PR DESCRIPTION
## Summary

Adds an **Inspect creatures** function alongside the existing *Inspect objects* / *Inspect genomes*. The user selects a region, triggers the action, and one inspection window opens per creature in the selection — each showing only the **Creature** tree node and drawing its connector line to that creature's **head cell**.

Head-cell selection per creature: the cell with `headCell == true`; on ties the smallest `branchIndex`, then the smallest `concatenationIndex` (no further ambiguity possible).

## Changes

- **`InspectionWindow`** — new `creatureMode`: renders only the `Creature` node (open by default), smaller window, title `Creature with id 0x…`; the window stays keyed to the head cell so the line points at it. (Renamed the unused `selectGenomeTab` plumbing to `creatureMode`.)
- **`EditorController::onInspectSelectedCreatures()`** — groups selected cells by `creatureId`, picks the head cell with the tie-break rule, and opens one creature window per creature via the existing `onInspectObjects(..., creatureMode=true)` (reuses window spreading + `MaxInspectedObjects` limit). Uses `getSelectedSimulationData(true)` (rollout to clusters) so each creature's head cell is available even if it lies outside the selection box.
- **`PatternEditorWindow`** — toolbar button (`ICON_FA_PAW`), enabled when `numCreatures > 0`.
- **`MainLoopController`** — menu item *Inspect creatures*, hotkey **Alt+R**.

## Testing

- Release build (Ninja Multi-Config) green: `470/470`, `alien.exe` linked.
- clang-format 19.1.5 clean on all modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)