### PR TITLE
Limit meta-mutations to node and gene probabilities

### DIFF
--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -1126,9 +1126,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * neuronSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.neuronMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.neuronMutations[i].weightChangeSigma);
-                mutateFloat(genome->mutationRates.neuronMutations[i].biasChangeSigma);
-                mutateFloat(genome->mutationRates.neuronMutations[i].actfnChangeProbability);
             }
         }
 
@@ -1138,7 +1135,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * connSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.connectionMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.connectionMutations[i].valueChangeSigma);
             }
         }
 
@@ -1147,8 +1143,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma);
-                mutateFloat(genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability);
             }
         }
 
@@ -1199,9 +1193,6 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * constructorSigma)); };
             for (int i = 0; i < 2; ++i) {
                 mutateFloat(genome->mutationRates.constructorMutations[i].nodeProbability);
-                mutateFloat(genome->mutationRates.constructorMutations[i].valueChangeSigma);
-                mutateFloat(genome->mutationRates.constructorMutations[i].enumChangeProbability);
-                mutateFloat(genome->mutationRates.constructorMutations[i].constructorToggleProbability);
             }
         }
     }

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -30,22 +30,19 @@ TEST_F(MetaMutationTests, metaMutation_neuronRatesActuallyChange)
     auto actualCreature = actualData.getCreatureRef(actualCell._creatureId);
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
-    bool anyChanged = actualGenome._mutationRates._neuronMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma != 0.5f || actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._nodeProbability != 0.5f || actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma != 0.5f
-        || actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability != 0.5f;
-    EXPECT_TRUE(anyChanged);
+    bool nodeProbabilityChanged =
+        actualGenome._mutationRates._neuronMutations[0]._nodeProbability != 0.5f || actualGenome._mutationRates._neuronMutations[1]._nodeProbability != 0.5f;
+    EXPECT_TRUE(nodeProbabilityChanged);
 
     EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability, 0.0f);
+
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._weightChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._biasChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[0]._actfnChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._weightChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._biasChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._neuronMutations[1]._actfnChangeProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_neuronRatesZeroSigmaNoChange)
@@ -100,14 +97,13 @@ TEST_F(MetaMutationTests, metaMutation_connectionRatesActuallyChange)
     auto actualCreature = actualData.getCreatureRef(actualCell._creatureId);
     auto actualGenome = actualData.getGenomeRef(actualCreature._genomeId);
 
-    bool anyChanged = actualGenome._mutationRates._connectionMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma != 0.5f || actualGenome._mutationRates._connectionMutations[1]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma != 0.5f;
-    EXPECT_TRUE(anyChanged);
+    bool nodeProbabilityChanged = actualGenome._mutationRates._connectionMutations[0]._nodeProbability != 0.5f
+        || actualGenome._mutationRates._connectionMutations[1]._nodeProbability != 0.5f;
+    EXPECT_TRUE(nodeProbabilityChanged);
     EXPECT_GE(actualGenome._mutationRates._connectionMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._connectionMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma, 0.0f);
+    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._connectionMutations[1]._valueChangeSigma, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_connectionRatesZeroSigmaNoChange)
@@ -155,19 +151,15 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesActuallyChange)
 
     auto actualGenome = getMutatedGenome();
 
-    bool anyChanged = actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma != 0.5f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability != 0.5f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability != 0.4f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma != 0.4f
-        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability != 0.4f;
-    EXPECT_TRUE(anyChanged);
+    bool nodeProbabilityChanged = actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability != 0.5f
+        || actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability != 0.4f;
+    EXPECT_TRUE(nodeProbabilityChanged);
     EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability, 0.0f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability, 0.4f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
@@ -493,23 +485,17 @@ TEST_F(MetaMutationTests, metaMutation_constructorRatesActuallyChange)
 
     auto actualGenome = getMutatedGenome();
 
-    bool anyChanged = actualGenome._mutationRates._constructorMutations[0]._nodeProbability != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability != 0.5f
-        || actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability != 0.5f
-        || actualGenome._mutationRates._constructorMutations[1]._nodeProbability != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability != 0.4f
-        || actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability != 0.4f;
-    EXPECT_TRUE(anyChanged);
+    bool nodeProbabilityChanged = actualGenome._mutationRates._constructorMutations[0]._nodeProbability != 0.5f
+        || actualGenome._mutationRates._constructorMutations[1]._nodeProbability != 0.4f;
+    EXPECT_TRUE(nodeProbabilityChanged);
     EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability, 0.0f);
     EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability, 0.0f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[0]._constructorToggleProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._enumChangeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._constructorMutations[1]._constructorToggleProbability, 0.4f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_constructorRatesZeroSigmaNoChange)


### PR DESCRIPTION
## Summary

Meta-mutations now only perturb the `nodeProbability` / `geneProbability` of each mutation rate. All other mutation-rate attributes (sigmas, enum/toggle probabilities) are left untouched.

Removed from `applyMutations_meta`:
- neuron: `weightChangeSigma`, `biasChangeSigma`, `actfnChangeProbability`
- connection: `valueChangeSigma`
- cell type properties: `valueChangeSigma`, `enumChangeProbability`
- constructor: `valueChangeSigma`, `enumChangeProbability`, `constructorToggleProbability`

Kept: every `nodeProbability` plus the append/add/trim/delete-node `geneProbability` (those already only carried `geneProbability`). The per-category meta-mutation sigma parameters stay; they just affect the probabilities only now.

## Tests

`MetaMutationTests` tightened: the four "ActuallyChange" tests now assert the probability changes **and** that the sigma/enum/toggle fields stay fixed.

- Clean CUDA rebuild: OK
- `EngineTests.exe --gtest_filter=MetaMutationTests.*` → 23/23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)