### PR TITLE
Add creature object coloring mode

### DIFF
--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -90,6 +90,7 @@ ParametersSpec const& SimulationParameters::getSpec()
                                            {"Customization", {}},
                                            {"Lineage + Customization", {}},
                                            {"Lineage", {}},
+                                           {"Creature", {}},
                                        }))
                         .description(coloringTooltip),
                     ParameterSpec()

--- a/source/EngineInterface/SimulationParametersTypes.h
+++ b/source/EngineInterface/SimulationParametersTypes.h
@@ -152,6 +152,7 @@ enum CellColoring_
     CellColoring_Customization,
     CellColoring_LineageAndCustomization,
     CellColoring_Lineage,
+    CellColoring_Creature,
 };
 
 using CellDeathConsequences = int;

--- a/source/EngineKernels/GeometryKernels.cu
+++ b/source/EngineKernels/GeometryKernels.cu
@@ -158,6 +158,19 @@ namespace
             float v = 0.6f + 0.1f * (static_cast<float>(hash3 & 0xFFFFu) / 65535.0f);
             return hsvToRgb(h, s, v);
         }
+        if (coloring == CellColoring_Creature) {
+            if (object->type != ObjectType_Cell) {
+                return getCustomizationColor(object->color);
+            }
+            auto creatureId = static_cast<uint32_t>(object->typeData.cell.creature->id);
+            uint32_t hash1 = creatureId * 2654435761u;
+            uint32_t hash2 = creatureId * 2246822519u;
+            uint32_t hash3 = creatureId * 3266489917u;
+            float h = static_cast<float>(hash1 & 0xFFFFu) / 65535.0f;
+            float s = 0.7f + 0.3f * (static_cast<float>(hash2 & 0xFFFFu) / 65535.0f);
+            float v = 0.6f + 0.1f * (static_cast<float>(hash3 & 0xFFFFu) / 65535.0f);
+            return hsvToRgb(h, s, v);
+        }
         return getCustomizationColor(object->color);
     }
 


### PR DESCRIPTION
## Summary
- Add new object coloring mode **Creature** alongside Customization, Lineage + Customization and Lineage.
- Cells are colored by hashing the creature id to HSV using the same scheme as the existing lineage coloring (only the id source differs: `creature->id` instead of `creature->lineageId`).
- Non-cell objects fall back to the customization color, matching lineage behavior.

## Changes
- `SimulationParametersTypes.h`: new enum value `CellColoring_Creature`.
- `SimulationParameters.cpp`: `Creature` entry in the "Object coloring" dropdown.
- `GeometryKernels.cu`: new `CellColoring_Creature` branch in `getObjectColor`.

## Testing
- Release build clean (470/470).
- `EngineInterfaceTests` pass (155/155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)