### PR TITLE
Add test for mutation during offspring construction

### DIFF
--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -74,34 +74,41 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
     EXPECT_TRUE(constructor.value() == ConstructorGenomeDesc());
 }
 
-TEST_F(ConstructorMutationTests, mutatesCreatureWhileOffspringUnderConstruction)
+TEST_F(ConstructorMutationTests, mutatesCreatureWhileOffspringConstructionPending)
 {
-    // The mutation gate in MutationProcessor::process no longer requires constructor.offspring == nullptr,
-    // so a creature is mutated even while its constructor still has an offspring under construction.
-    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
+    // A constructor sets constructor.offspring on trigger but cannot build the first cell because the
+    // offspring node reserves more energy than is available. The mutation gate in MutationProcessor::process
+    // no longer requires constructor.offspring == nullptr, so the creature is mutated even though its offspring
+    // stays unbuilt (with the previous code the mutation was skipped while constructor.offspring != nullptr).
+    auto genome = GenomeDesc().genes(
+        {GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().reservedEnergy(1000000.0f))})});  // first cell can never be afforded
     genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
 
     auto data = Desc().addCreature(
         {ObjectDesc()
              .id(1)
              .pos({100.0f, 100.0f})
-             .type(CellDesc()
-                       .usableEnergy(_parameters.normalCellEnergy.value[0] * 3.5f)  // enough energy for mutation and construction
-                       .constructor(ConstructorDesc().geneIndex(0).separation(false).numBranches(1).numConcatenations(1)))},
+             .type(CellDesc().usableEnergy(0.0f).constructor(ConstructorDesc().autoTriggerInterval(1).geneIndex(0).separation(true)))},
         CreatureDesc().id(1).mutationState(MutationState_NotMutated),
         genome);
 
+    // External energy inflow slowly lifts the creature's energy above the mutation threshold while it keeps
+    // failing to construct the first cell, so the energy gate opens only after constructor.offspring is set.
+    _parameters.externalEnergyControlToggle.value = true;
+    _parameters.externalEnergy.value = 1000000000.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
     _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_calcTimestepWithCellFunctions();
+    for (int i = 0; i < 50; ++i) {
+        _simulationFacade->testOnly_calcTimestepWithCellFunctions();
+    }
 
     auto actualData = _simulationFacade->getSimulationData();
 
-    // The offspring construction has started but is not finished (the gene has two nodes, one built so far).
-    ASSERT_EQ(2, actualData._creatures.size());
-    auto newCreature = actualData.getOtherCreatureRef(1);
-    ASSERT_EQ(1, actualData.getObjectsForCreature(newCreature._id).size());
+    // No offspring cell could be built, so the host cell is still the only object.
+    ASSERT_EQ(1, actualData.getNumObjects());
 
-    // Despite the offspring still being under construction, the host genome must have been mutated.
+    // Despite the offspring construction being stuck, the host genome must have been mutated.
     auto mutatedGenome = getMutatedGenome(1);
     bool anyWeightChanged = false;
     for (size_t g = 0; g < genome._genes.size() && !anyWeightChanged; ++g) {

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -74,6 +74,51 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
     EXPECT_TRUE(constructor.value() == ConstructorGenomeDesc());
 }
 
+TEST_F(ConstructorMutationTests, mutatesCreatureWhileOffspringUnderConstruction)
+{
+    // The mutation gate in MutationProcessor::process no longer requires constructor.offspring == nullptr,
+    // so a creature is mutated even while its constructor still has an offspring under construction.
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
+    genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
+
+    auto data = Desc().addCreature(
+        {ObjectDesc()
+             .id(1)
+             .pos({100.0f, 100.0f})
+             .type(CellDesc()
+                       .usableEnergy(_parameters.normalCellEnergy.value[0] * 3.5f)  // enough energy for mutation and construction
+                       .constructor(ConstructorDesc().geneIndex(0).separation(false).numBranches(1).numConcatenations(1)))},
+        CreatureDesc().id(1).mutationState(MutationState_NotMutated),
+        genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_calcTimestepWithCellFunctions();
+
+    auto actualData = _simulationFacade->getSimulationData();
+
+    // The offspring construction has started but is not finished (the gene has two nodes, one built so far).
+    ASSERT_EQ(2, actualData._creatures.size());
+    auto newCreature = actualData.getOtherCreatureRef(1);
+    ASSERT_EQ(1, actualData.getObjectsForCreature(newCreature._id).size());
+
+    // Despite the offspring still being under construction, the host genome must have been mutated.
+    auto mutatedGenome = getMutatedGenome(1);
+    bool anyWeightChanged = false;
+    for (size_t g = 0; g < genome._genes.size() && !anyWeightChanged; ++g) {
+        for (size_t n = 0; n < genome._genes.at(g)._nodes.size() && !anyWeightChanged; ++n) {
+            auto const& origWeights = genome._genes.at(g)._nodes.at(n)._neuralNetwork._weights;
+            auto const& actualWeights = mutatedGenome._genes.at(g)._nodes.at(n)._neuralNetwork._weights;
+            for (size_t w = 0; w < origWeights.size(); ++w) {
+                if (origWeights.at(w) != actualWeights.at(w)) {
+                    anyWeightChanged = true;
+                    break;
+                }
+            }
+        }
+    }
+    EXPECT_TRUE(anyWeightChanged);
+}
+
 TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -74,26 +74,26 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
     EXPECT_TRUE(constructor.value() == ConstructorGenomeDesc());
 }
 
-TEST_F(ConstructorMutationTests, mutatesCreatureWhileOffspringConstructionPending)
+TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 {
-    // A constructor sets constructor.offspring on trigger but cannot build the first cell because the
-    // offspring node reserves more energy than is available. The mutation gate in MutationProcessor::process
-    // no longer requires constructor.offspring == nullptr, so the creature is mutated even though its offspring
-    // stays unbuilt (with the previous code the mutation was skipped while constructor.offspring != nullptr).
-    auto genome = GenomeDesc().genes(
-        {GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().reservedEnergy(1000000.0f))})});  // first cell can never be afforded
+    // The constructor sets constructor.offspring already on the first (energy-less) trigger. External energy then
+    // flows in slowly until the offspring is actually constructed. Because separation is off, constructor.offspring
+    // is never reset to nullptr. The mutation gate in MutationProcessor::process no longer requires
+    // constructor.offspring == nullptr, so the creature is mutated during this process (with the previous code the
+    // mutation was skipped the whole time because constructor.offspring != nullptr).
+    auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc()})});
     genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
 
     auto data = Desc().addCreature(
         {ObjectDesc()
              .id(1)
              .pos({100.0f, 100.0f})
-             .type(CellDesc().usableEnergy(0.0f).constructor(ConstructorDesc().autoTriggerInterval(1).geneIndex(0).separation(true)))},
+             .type(CellDesc().usableEnergy(0.0f).constructor(ConstructorDesc().autoTriggerInterval(1).geneIndex(0).separation(false)))},
         CreatureDesc().id(1).mutationState(MutationState_NotMutated),
         genome);
 
-    // External energy inflow slowly lifts the creature's energy above the mutation threshold while it keeps
-    // failing to construct the first cell, so the energy gate opens only after constructor.offspring is set.
+    // The creature starts without energy (mutation gate closed) but constructor.offspring is set anyway; external
+    // energy inflow then raises the energy above the mutation threshold while constructor.offspring is already set.
     _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 1000000000.0f;
     _simulationFacade->setSimulationParameters(_parameters);
@@ -105,10 +105,10 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileOffspringConstructionPendin
 
     auto actualData = _simulationFacade->getSimulationData();
 
-    // No offspring cell could be built, so the host cell is still the only object.
-    ASSERT_EQ(1, actualData.getNumObjects());
+    // The offspring cell was actually constructed (host cell + one offspring cell).
+    ASSERT_EQ(2, actualData.getNumObjects());
 
-    // Despite the offspring construction being stuck, the host genome must have been mutated.
+    // The host genome must have been mutated while its constructor.offspring was set.
     auto mutatedGenome = getMutatedGenome(1);
     bool anyWeightChanged = false;
     for (size_t g = 0; g < genome._genes.size() && !anyWeightChanged; ++g) {

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -76,11 +76,9 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
 
 TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 {
-    // The constructor sets constructor.offspring already on the first (energy-less) trigger. External energy then
-    // flows in slowly until the offspring is actually constructed. Because separation is off, constructor.offspring
-    // is never reset to nullptr. The mutation gate in MutationProcessor::process no longer requires
-    // constructor.offspring == nullptr, so the creature is mutated during this process (with the previous code the
-    // mutation was skipped the whole time because constructor.offspring != nullptr).
+    // constructor.offspring is set on the first energy-less trigger and, with separation off, never reset.
+    // External energy inflow then lifts the energy until the offspring is actually constructed and the creature
+    // is mutated - which the previous code skipped while constructor.offspring != nullptr.
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc()})});
     genome._mutationRates._neuronMutations[0] = NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f);
 
@@ -92,10 +90,9 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
         CreatureDesc().id(1).mutationState(MutationState_NotMutated),
         genome);
 
-    // The creature starts without energy (mutation gate closed) but constructor.offspring is set anyway; external
-    // energy inflow then raises the energy above the mutation threshold while constructor.offspring is already set.
     _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 1000000000.0f;
+    _parameters.newLineageThreshold.value = 1.0e30f;  // keep accumulatedMutations from resetting
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -105,25 +102,9 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 
     auto actualData = _simulationFacade->getSimulationData();
 
-    // The offspring cell was actually constructed (host cell + one offspring cell).
-    ASSERT_EQ(2, actualData.getNumObjects());
-
-    // The host genome must have been mutated while its constructor.offspring was set.
-    auto mutatedGenome = getMutatedGenome(1);
-    bool anyWeightChanged = false;
-    for (size_t g = 0; g < genome._genes.size() && !anyWeightChanged; ++g) {
-        for (size_t n = 0; n < genome._genes.at(g)._nodes.size() && !anyWeightChanged; ++n) {
-            auto const& origWeights = genome._genes.at(g)._nodes.at(n)._neuralNetwork._weights;
-            auto const& actualWeights = mutatedGenome._genes.at(g)._nodes.at(n)._neuralNetwork._weights;
-            for (size_t w = 0; w < origWeights.size(); ++w) {
-                if (origWeights.at(w) != actualWeights.at(w)) {
-                    anyWeightChanged = true;
-                    break;
-                }
-            }
-        }
-    }
-    EXPECT_TRUE(anyWeightChanged);
+    ASSERT_EQ(2, actualData.getNumObjects());  // offspring cell was constructed
+    auto hostCreatureId = actualData.getObjectRef(1).getCellRef()._creatureId;
+    EXPECT_GT(actualData.getCreatureRef(hostCreatureId)._accumulatedMutations, 0.0f);
 }
 
 TEST_F(ConstructorMutationTests, constructorMutation_zeroProbabilityNoChange)

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -76,6 +76,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultV
 
 TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 {
+    // Regression test:
     // constructor.offspring is set on the first energy-less trigger and, with separation off, never reset.
     // External energy inflow then lifts the energy until the offspring is actually constructed and the creature
     // is mutated - which the previous code skipped while constructor.offspring != nullptr.
@@ -91,8 +92,8 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
         genome);
 
     _parameters.externalEnergyControlToggle.value = true;
-    _parameters.externalEnergy.value = 1000000000.0f;
-    _parameters.newLineageThreshold.value = 1.0e30f;  // keep accumulatedMutations from resetting
+    _parameters.externalEnergy.value = 1000.0f;
+    _parameters.newLineageThreshold.value = 100.0f;  // keep accumulatedMutations from resetting
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);


### PR DESCRIPTION
## Summary

Adds an EngineTests regression test for commit 23590d1 (*"Mutate creature independent of constructor.offspring state"*), which removed the `constructor.offspring == nullptr` guard from the mutation gate in `MutationProcessor::process`.

New test `ConstructorMutationTests.mutatesCreatureWhileConstructingOffspring` reproduces the scenario the change fixes:

- A constructor cell starts with **no energy**, but `constructor.offspring` is already set on the first trigger.
- External energy inflow slowly raises the energy until the offspring is actually constructed.
- `separation` is off, so `constructor.offspring` is never reset to `nullptr`.
- Asserts the offspring cell was built (`getNumObjects() == 2`) **and** the host genome was mutated.

With the previous code the mutation was skipped the whole time because `constructor.offspring != nullptr`, so the genome was never mutated.

## Differential verification

- Current code: test **passes**.
- Re-adding the `&& cell.constructor.offspring == nullptr` guard (reverting the commit) + clean kernel rebuild: test **fails** (no mutation).

So the test genuinely guards the behavior the commit introduced.

## Testing

- `EngineTests.exe --gtest_filter=ConstructorMutationTests.*` — all 6 pass
- Release build green (Ninja, 16 threads)
- clang-format 19.1.5 clean