### PR TITLE
Remove prevLineageId from creature data model

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -929,7 +929,6 @@ CreatureDesc DescConverterService::createCreatureDesc(TOs const& to, int creatur
     result._mutationState = creatureTO.mutationState;
     result._lineageId = creatureTO.lineageId;
     NumberGenerator::get().adaptMaxLineageId(creatureTO.lineageId);
-    result._prevLineageId = creatureTO.prevLineageId != VALUE_NOT_SET_UINT32 ? std::make_optional(static_cast<int>(creatureTO.prevLineageId)) : std::nullopt;
     result._accumulatedMutations = creatureTO.accumulatedMutations;
     result._headUpdateId = creatureTO.headUpdateId;
 
@@ -1244,7 +1243,6 @@ void DescConverterService::convertCreatureToTO(
     creatureTO.numCells = creatureDesc._numCells;
     creatureTO.mutationState = creatureDesc._mutationState;
     creatureTO.lineageId = creatureDesc._lineageId;
-    creatureTO.prevLineageId = creatureDesc._prevLineageId.value_or(VALUE_NOT_SET_UINT32);
     creatureTO.accumulatedMutations = creatureDesc._accumulatedMutations;
     creatureTO.genomeArrayIndex = genomeTOIndexById.at(creatureDesc._genomeId);
 }

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -589,7 +589,6 @@ struct CreatureDesc
     MEMBER(CreatureDesc, uint64_t, genomeId, 0);
     MEMBER(CreatureDesc, MutationState, mutationState, MutationState_Mutated);
     MEMBER(CreatureDesc, int, lineageId, 0);
-    MEMBER(CreatureDesc, std::optional<int>, prevLineageId, std::nullopt);
     MEMBER(CreatureDesc, float, accumulatedMutations, 0.0f);
 
     // Process data

--- a/source/EngineInterface/DescEditService.cpp
+++ b/source/EngineInterface/DescEditService.cpp
@@ -517,7 +517,6 @@ void DescEditService::randomizeLineageIds(Desc& description) const
 {
     for (auto& creature : description._creatures) {
         creature._lineageId = NumberGenerator::get().getRandomInt();
-        creature._prevLineageId = std::nullopt;
     }
 }
 

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -307,9 +307,6 @@ void DescValidationService::validateAndCorrect(ExtendedObjectDesc& extendedObjec
     if (extendedObject.creature.has_value()) {
         auto& creature = extendedObject.creature.value();
         creature._lineageId = std::max(creature._lineageId, 0);
-        if (creature._prevLineageId.has_value()) {
-            creature._prevLineageId = std::max(creature._prevLineageId.value(), 0);
-        }
         creature._accumulatedMutations = std::max(creature._accumulatedMutations, 0.0f);
     }
 

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -291,7 +291,6 @@ namespace
             creatureTO.numCells = creature->numCells;
             creatureTO.mutationState = creature->mutationState;
             creatureTO.lineageId = creature->lineageId;
-            creatureTO.prevLineageId = creature->prevLineageId;
             creatureTO.accumulatedMutations = creature->accumulatedMutations;
             creatureTO.headUpdateId = creature->headUpdateId;
             creatureTO.genomeArrayIndex = creature->genome->genomeIndex;

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -451,7 +451,6 @@ struct Creature
     MutationState mutationState;
 
     uint32_t lineageId;
-    uint32_t prevLineageId;
     float accumulatedMutations;
 
     // Process data

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -610,7 +610,6 @@ __inline__ __device__ void EntityFactory::changeCreatureFromTO(CreatureTO const&
     creature->numCells = creatureTO.numCells;
     creature->mutationState = creatureTO.mutationState;
     creature->lineageId = creatureTO.lineageId;
-    creature->prevLineageId = creatureTO.prevLineageId;
     creature->accumulatedMutations = creatureTO.accumulatedMutations;
     creature->headUpdateId = creatureTO.headUpdateId;
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -1157,7 +1157,6 @@ MutationProcessor::updateAccumulatedMutationsAndLineageId(SimulationData& data, 
 
         creature->accumulatedMutations += accumulatedMutations / denominator;
         if (creature->accumulatedMutations > cudaSimulationParameters.newLineageThreshold.value) {
-            creature->prevLineageId = creature->lineageId;
             creature->lineageId = data.primaryNumberGen.createLineageId();
             creature->accumulatedMutations = 0;
         }

--- a/source/EngineKernels/TOs.cuh
+++ b/source/EngineKernels/TOs.cuh
@@ -497,7 +497,6 @@ struct CreatureTO
     MutationState mutationState;
 
     uint32_t lineageId;
-    uint32_t prevLineageId;
     float accumulatedMutations;
 
     // Process data

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -218,7 +218,6 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .headUpdateId(42)
                         .mutationState(MutationState_MutationInProgress)
                         .lineageId(502)
-                        .prevLineageId(501)
                         .accumulatedMutations(0.05f)
                         .genomeId(genome._id);
 

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -87,7 +87,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     }
 
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42).prevLineageId(41), genome);
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42), genome);
 
     auto parameters = _parameters;
     parameters.newLineageThreshold.value = 1.0e30f;
@@ -106,7 +106,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
 {
     auto genome = GenomeDesc();
 
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42).prevLineageId(41), genome);
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42), genome);
 
     _parameters.neuronsMetaMutationsSigma.value = 1.0f;
     _parameters.connectionsMetaMutationsSigma.value = 1.0f;
@@ -127,14 +127,13 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     auto actualCreature = getMutatedCreature();
     EXPECT_EQ(actualCreature._accumulatedMutations, 0.0f);
     EXPECT_EQ(actualCreature._lineageId, 42);
-    EXPECT_EQ(actualCreature._prevLineageId, 41);
 }
 
 TEST_F(AccumulatedMutationTests, accumulatedMutations_createsNewLineageId)
 {
     auto genome = createTestGenome();
 
-    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42).prevLineageId(41).accumulatedMutations(11.0f), genome);
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42).accumulatedMutations(11.0f), genome);
 
     _parameters.newLineageThreshold.value = 0.1f;
     _simulationFacade->setSimulationParameters(_parameters);
@@ -143,7 +142,5 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_createsNewLineageId)
     _simulationFacade->testOnly_mutate(1);
 
     auto actualCreature = getMutatedCreature();
-    ASSERT_TRUE(actualCreature._prevLineageId.has_value());
-    EXPECT_EQ(*actualCreature._prevLineageId, 42);
     EXPECT_GT(actualCreature._lineageId, 42);
 }

--- a/source/EngineTests/BalanceTests.cpp
+++ b/source/EngineTests/BalanceTests.cpp
@@ -31,7 +31,7 @@ public:
                 .pos({numberGen.getRandomFloat(0.0f, worldSize.x), numberGen.getRandomFloat(0.0f, worldSize.y)})
                 .type(CellDesc().headCell(true).constructor(ConstructorDesc().provideEnergy(ProvideEnergy_Free).separation(true))),
             },
-            CreatureDesc().lineageId(0).prevLineageId(0),
+            CreatureDesc().lineageId(0),
             GenomeDesc().frontAngle(225.0f).genes(
             {
                 GeneDesc()
@@ -73,7 +73,7 @@ public:
                 .pos({numberGen.getRandomFloat(0.0f, worldSize.x), numberGen.getRandomFloat(0.0f, worldSize.y)})
                 .type(CellDesc().headCell(true).constructor(ConstructorDesc().provideEnergy(ProvideEnergy_Free).separation(true))),
             },
-            CreatureDesc().lineageId(1).prevLineageId(1),
+            CreatureDesc().lineageId(1),
             GenomeDesc().frontAngle(225.0f).genes(
             {
                 GeneDesc()

--- a/source/EngineTests/DataTransferTests.cpp
+++ b/source/EngineTests/DataTransferTests.cpp
@@ -323,26 +323,20 @@ TEST_F(DataTransferTests, changeCell_creatureLineage)
     auto extended = std::get<ExtendedObjectDesc>(objects.front());
     ASSERT_TRUE(extended.creature.has_value());
     EXPECT_EQ(5, extended.creature->_lineageId);
-    EXPECT_FALSE(extended.creature->_prevLineageId.has_value());  // unset optional round-trips through the TO sentinel
 
     extended.creature->_lineageId = 9;
-    extended.creature->_prevLineageId = 7;
     extended.creature->_accumulatedMutations = 3.5f;
     _simulationFacade->changeCell(extended);
 
     auto after = _simulationFacade->getSimulationData();
     auto creature = after.getCreatureRef(1);
     EXPECT_EQ(9, creature._lineageId);
-    ASSERT_TRUE(creature._prevLineageId.has_value());
-    EXPECT_EQ(7, *creature._prevLineageId);
     EXPECT_EQ(3.5f, creature._accumulatedMutations);
 
     // Same readback path the GUI uses for its periodic refresh
     auto reinspected = _simulationFacade->getInspectedSimulationData({1});
     auto creature2 = reinspected.getCreatureRef(1);
     EXPECT_EQ(9, creature2._lineageId);
-    ASSERT_TRUE(creature2._prevLineageId.has_value());
-    EXPECT_EQ(7, *creature2._prevLineageId);
     EXPECT_EQ(3.5f, creature2._accumulatedMutations);
 }
 

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -575,7 +575,6 @@ void _InspectionWindow::processCreatureProperties(ExtendedObjectDesc& extendedOb
     inspectorText("Generation", std::to_string(creature._generation));
     inspectorText("Num cells", std::to_string(creature._numCells));
     AlienGui::InputInt(AlienGui::InputIntParameters().name("Lineage id").textWidth(TextWidth), creature._lineageId);
-    AlienGui::InputOptionalInt(AlienGui::InputIntParameters().name("Prev lineage id").textWidth(TextWidth), creature._prevLineageId);
     AlienGui::InputFloat(AlienGui::InputFloatParameters().name("Accumulated mutations").format("%.5f").textWidth(TextWidth), creature._accumulatedMutations);
     auto& genome = extendedObject.genome.value();
     inspectorText("Genome name", genome._name);

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -1055,7 +1055,6 @@ namespace
     auto constexpr Id_Creature_GenomeId = 6;
     auto constexpr Id_Creature_MutationState = 7;
     auto constexpr Id_Creature_LineageId = 3;
-    auto constexpr Id_Creature_PrevLineageId = 8;
     auto constexpr Id_Creature_AccumulatedMutations = 9;
 
     auto constexpr Id_Solid_Energy = 0;
@@ -1787,7 +1786,6 @@ namespace cereal
         scope.addMember(Id_Creature_GenomeId, data._genomeId, defaultObject._genomeId);
         scope.addMember(Id_Creature_MutationState, data._mutationState, defaultObject._mutationState);
         scope.addMember(Id_Creature_LineageId, data._lineageId, defaultObject._lineageId);
-        scope.addMember(Id_Creature_PrevLineageId, data._prevLineageId, defaultObject._prevLineageId);
         scope.addMember(Id_Creature_AccumulatedMutations, data._accumulatedMutations, defaultObject._accumulatedMutations);
     }
     SPLIT_SERIALIZATION(CreatureDesc)


### PR DESCRIPTION
Removes the unused `prevLineageId` field from the creature data model.

## Why
Lineage matching (`Creature::isSameLineage`) already compares `lineageId` only, so `prevLineageId` was dead in all relatedness logic — it was merely stored, transferred, serialized, and written at the new-lineage threshold without affecting behavior.

## Changes
- Engine: drop field from `Creature` (Entities.cuh) and `CreatureTO` (TOs.cuh); remove copies in DataAccessKernels/EntityFactory and the threshold write in MutationProcessor
- Model: remove `CreatureDesc::prevLineageId`, converter both directions, validation clamp, `randomizeLineageIds` reset
- Persistence: drop `Id_Creature_PrevLineageId` member
- GUI: remove "Prev lineage id" inspector field
- Tests/test data: clean up affected expectations

## Verification
- Release build green
- EngineInterfaceTests 159/159, PersisterTests 64/64
- EngineTests GPU subset (Accumulated/Balance/DataTransfer/Mutation/Sensor) 413/413

🤖 Generated with [Claude Code](https://claude.com/claude-code)