### PR TITLE
Count node and gene indices from zero in genome preview

### DIFF
--- a/source/EngineInterface/LocationHelper.cpp
+++ b/source/EngineInterface/LocationHelper.cpp
@@ -100,7 +100,7 @@ std::string LocationHelper::generateLayerName(SimulationParameters const& parame
     std::string result;
     do {
         alreadyUsed = false;
-        result = "Layer " + std::to_string(++counter);
+        result = "Layer " + std::to_string(counter++);
         for (int i = 0; i < parameters.numLayers; ++i) {
             auto name = std::string(parameters.layerName.layerValues[i]);
             if (result == name) {
@@ -120,7 +120,7 @@ std::string LocationHelper::generateSourceName(SimulationParameters const& param
     std::string result;
     do {
         alreadyUsed = false;
-        result = "Radiation " + std::to_string(++counter);
+        result = "Radiation " + std::to_string(counter++);
         for (int i = 0; i < parameters.numSources; ++i) {
             auto name = std::string(parameters.sourceName.sourceValues[i]);
             if (result == name) {

--- a/source/Gui/CreaturePreviewWidget.cpp
+++ b/source/Gui/CreaturePreviewWidget.cpp
@@ -274,7 +274,7 @@ void _CreaturePreviewWidget::processCellGraphAndSelection(ConversionResult const
             auto cellPos = mapWorldToViewPosition(object._pos, windowSize, windowPos);
             std::string text;
             if (_genomeEditData->showNodeIndex) {
-                text = std::to_string(object._nodeIndex + 1);
+                text = std::to_string(object._nodeIndex);
             } else {
                 text = Const::CellTypeStrings.at(object._cellType);
             }
@@ -348,7 +348,7 @@ void _CreaturePreviewWidget::processCellGraphAndSelection(ConversionResult const
         for (auto const& object : desc._cells) {
             if (object._constructorGeneIndex.has_value()) {
                 auto cellPos = mapWorldToViewPosition(object._pos, windowSize, windowPos);
-                auto text = std::to_string(object._constructorGeneIndex.value() + 1);
+                auto text = std::to_string(object._constructorGeneIndex.value());
                 auto textLength = toFloat(text.size());
                 auto truncatedSize = std::min(scale(30.0f), cellSize);
                 drawList->AddRectFilled(
@@ -475,9 +475,9 @@ void _CreaturePreviewWidget::processTitle()
     ImGui::SetCursorPos({scale(7.0f), scale(7.0f)});
     std::vector<std::string> geneIndexStrings;
     auto geneIndices = getGeneIndices();
-    geneIndexStrings.emplace_back(std::to_string(geneIndices.front() + 1) + " (start)");
+    geneIndexStrings.emplace_back(std::to_string(geneIndices.front()) + " (start)");
     for (auto const& geneIndex : geneIndices | boost::adaptors::sliced(1, geneIndices.size())) {
-        geneIndexStrings.emplace_back(std::to_string(geneIndex + 1));
+        geneIndexStrings.emplace_back(std::to_string(geneIndex));
     }
     auto title = "Genes: " + boost::join(geneIndexStrings, ", ");
     if (_subGenome.trimmed) {

--- a/source/Gui/GeneEditorWidget.cpp
+++ b/source/Gui/GeneEditorWidget.cpp
@@ -165,7 +165,7 @@ void _GeneEditorWidget::processNodeList()
 
                     // Column 0: No.
                     ImGui::TableNextColumn();
-                    AlienGui::Text(std::to_string(row + 1));
+                    AlienGui::Text(std::to_string(row));
                     ImGui::SameLine();
                     auto selectedNode = _editData->getSelectedNodeIndex();
                     auto selected = selectedNode ? selectedNode.value() == row : false;
@@ -194,7 +194,7 @@ void _GeneEditorWidget::processNodeList()
                         std::string text;
                         if (node._constructor.has_value()) {
                             auto geneIndex = node._constructor->_geneIndex;
-                            text = "Gene " + std::to_string(geneIndex + 1);
+                            text = "Gene " + std::to_string(geneIndex);
                             auto const& genes = _editData->genome._genes;
                             if (geneIndex >= 0 && geneIndex < static_cast<int>(genes.size()) && !genes.at(geneIndex)._name.empty()) {
                                 text += ": " + genes.at(geneIndex)._name;

--- a/source/Gui/GenomeEditorWidget.cpp
+++ b/source/Gui/GenomeEditorWidget.cpp
@@ -157,7 +157,7 @@ void _GenomeEditorWidget::processGeneList()
 
                     // Column 0: No.
                     ImGui::TableNextColumn();
-                    AlienGui::Text(std::to_string(row + 1));
+                    AlienGui::Text(std::to_string(row));
                     if (row == 0) {
                         ImGui::SameLine();
                         AlienGui::Text(AlienGui::TextParameters().text(" (root)").style(AlienGui::TextStyle::Decent));
@@ -186,7 +186,7 @@ void _GenomeEditorWidget::processGeneList()
                     // Column 2: References
                     ImGui::TableNextColumn();
                     auto references = GenomeDescInfoService::get().getReferences(gene);
-                    auto referencesStrings = references | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex + 1); });
+                    auto referencesStrings = references | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex); });
                     auto referencesString = boost::algorithm::join(std::vector(referencesStrings.begin(), referencesStrings.end()), ", ");
                     AlienGui::Text(referencesString);
 
@@ -194,7 +194,7 @@ void _GenomeEditorWidget::processGeneList()
                     ImGui::TableNextColumn();
                     auto referencedBy = GenomeDescInfoService::get().getReferencedBy(genome, row);
                     if (!referencedBy.empty()) {
-                        auto referencedByStrings = referencedBy | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex + 1); });
+                        auto referencedByStrings = referencedBy | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex); });
                         auto referencedByString = boost::algorithm::join(std::vector(referencedByStrings.begin(), referencedByStrings.end()), ", ");
                         AlienGui::Text(referencedByString);
                     } else {
@@ -308,7 +308,7 @@ void _GenomeEditorWidget::onRemoveGene()
 {
     auto referencedBy = GenomeDescInfoService::get().getReferencedBy(_editData->genome, _editData->selectedGeneIndex.value());
     if (!referencedBy.empty()) {
-        auto referencedByStrings = referencedBy | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex + 1); });
+        auto referencedByStrings = referencedBy | std::views::transform([](auto const& geneIndex) { return std::to_string(geneIndex); });
         auto referencedByString = boost::algorithm::join(std::vector(referencedByStrings.begin(), referencedByStrings.end()), ", ");
         auto text = referencedBy.size() == 1 ? "This gene could not be removed since it is still used by gene "
                                              : "This gene could not be removed since it is still used by genes ";

--- a/source/Gui/GenomeEditorWidget.cpp
+++ b/source/Gui/GenomeEditorWidget.cpp
@@ -56,7 +56,7 @@ _GenomeEditorWidget::_GenomeEditorWidget(GenomeTabEditData const& editData, Geno
             if (name.starts_with(prefix)) {
                 std::string numberPart = name.substr(prefix.size());
                 int number = std::stoi(numberPart);
-                _sequenceNumberForCreatedGenes = std::max(_sequenceNumberForCreatedGenes, number);
+                _sequenceNumberForCreatedGenes = std::max(_sequenceNumberForCreatedGenes, number + 1);
             }
         } catch (...) {
         }
@@ -271,7 +271,7 @@ void _GenomeEditorWidget::processGeneListButtons()
 void _GenomeEditorWidget::onAddGene()
 {
     auto& genome = _editData->genome;
-    auto name = "Gene " + std::to_string(++_sequenceNumberForCreatedGenes);
+    auto name = "Gene " + std::to_string(_sequenceNumberForCreatedGenes++);
     if (genome._genes.empty()) {
         auto newGene = GeneDesc().name(name).nodes({NodeDesc()}).shape(ConstructorShape_Segment);
         GenomeDescEditService::get().addGene(genome, 0, newGene);

--- a/source/Gui/GenomeEditorWidget.h
+++ b/source/Gui/GenomeEditorWidget.h
@@ -27,7 +27,7 @@ private:
 
     GenomeTabEditData _editData;
     GenomeTabLayoutData _layoutData;
-    int _sequenceNumberForCreatedGenes = 0;
+    int _sequenceNumberForCreatedGenes = -1;
 
     std::optional<int> _selectedGeneFromPreviousFrame;
     bool _geneSelectedFromTable = false;

--- a/source/Gui/GenomeEditorWidget.h
+++ b/source/Gui/GenomeEditorWidget.h
@@ -27,7 +27,7 @@ private:
 
     GenomeTabEditData _editData;
     GenomeTabLayoutData _layoutData;
-    int _sequenceNumberForCreatedGenes = -1;
+    int _sequenceNumberForCreatedGenes = 0;
 
     std::optional<int> _selectedGeneFromPreviousFrame;
     bool _geneSelectedFromTable = false;

--- a/source/Gui/GenomeEditorWindow.cpp
+++ b/source/Gui/GenomeEditorWindow.cpp
@@ -352,6 +352,6 @@ GenomeDesc GenomeEditorWindow::getDefaultGenome()
         .name("Draft " + std::to_string(++_sequenceNumberForCreatedGenomes))
         .frontAngle(-180.0f)
         .genes({
-            GeneDesc().name("Gene 1").nodes({NodeDesc()}).shape(ConstructorShape_Segment),
+            GeneDesc().name("Gene 0").nodes({NodeDesc()}).shape(ConstructorShape_Segment),
         });
 }

--- a/source/Gui/NodeEditorWidget.cpp
+++ b/source/Gui/NodeEditorWidget.cpp
@@ -251,7 +251,7 @@ void _NodeEditorWidget::processNodeAttributes()
             std::vector<std::string> genes;
             genes.emplace_back("None");
             for (auto const& [index, gene] : _editData->genome._genes | boost::adaptors::indexed(0)) {
-                auto text = std::to_string(index + 1) + ": " + gene._name;
+                auto text = std::to_string(index) + ": " + gene._name;
                 if (index == 0) {
                     text += " (root)";
                 }


### PR DESCRIPTION
Node and gene indices in the genome preview were displayed starting from 1. Switch the display to count from 0.

- `_nodeIndex` labels
- `_constructorGeneIndex` gene-reference labels
- the "Genes:" header list

InspectionWindow already shows gene indices from 0 (raw `_geneIndex`), so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)