### PR TITLE
Set genomeMutationProbability to 1 in mutation tests

### DIFF
--- a/source/EngineTests/MutationTestsBase.h
+++ b/source/EngineTests/MutationTestsBase.h
@@ -15,7 +15,10 @@ class MutationTestsBase : public IntegrationTestFramework
 public:
     MutationTestsBase()
         : IntegrationTestFramework()
-    {}
+    {
+        _parameters.genomeMutationProbability.value = 1.0f;
+        _simulationFacade->setSimulationParameters(_parameters);
+    }
 
     ~MutationTestsBase() = default;
 


### PR DESCRIPTION
## Summary
The new simulation parameter `genomeMutationProbability` (default `0.5`) gates whether a genome mutates per call. With the default, mutation tests became non-deterministic and failed intermittently.

Force `genomeMutationProbability = 1.0` in `MutationTestsBase` (re-applied via `setSimulationParameters`), so all mutation suites always mutate.

## Test
All 80 `*Mutation*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)