### PR TITLE
Run windows-deploy job daily instead of on every push

### DIFF
--- a/.github/workflows/windows-deploy.yml
+++ b/.github/workflows/windows-deploy.yml
@@ -1,8 +1,8 @@
 name: windows-deploy
 
 on:
-  push:
-    branches: [ develop ]
+  schedule:
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 


### PR DESCRIPTION
Changes the `windows-deploy` workflow trigger from `push: develop` to a daily schedule (cron `0 3 * * *`, 03:00 UTC), keeping `workflow_dispatch` for manual runs.

Follow-up to #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)