### PR TITLE
Fix constructor auto trigger interval toggle in inspection window

### DIFF
--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -493,7 +493,7 @@ void DescValidationService::validateAndCorrect(ExtendedObjectDesc& extendedObjec
             auto& constructor = cell._constructor.value();
             if (constructor._autoTriggerInterval.has_value()) {
                 auto& value = constructor._autoTriggerInterval.value();
-                value = std::max(value, 0);
+                value = std::max(value, Const::ConstructorAutoTriggerInterval_Min);
             }
             constructor._geneIndex = std::max(constructor._geneIndex, 0);
             constructor._constructionActivationTime = std::clamp(


### PR DESCRIPTION
## Problem

In the InspectionWindow, the constructor **Auto trigger interval** toggle could not be enabled — checking the box snapped it back to OFF on the next frame.

## Root cause

- Enabling the optional widget with no `defaultValue` seeds the value to `0` (`AlienGui::optionalWidgetAdaptor`).
- Cell-desc validation in `DescValidationService` clamped `_autoTriggerInterval` with `std::max(value, 0)`, leaving `0`.
- The TO round-trip in `DescConverterService` writes `value_or(0)` and reads back `> 0 ? value : nullopt`, so `0` is interpreted as *disabled* → the toggle reverts.
- The genome path already worked because its validation clamps to `std::max(value, 1)`.

## Fix

Clamp the cell-desc `_autoTriggerInterval` to `Const::ConstructorAutoTriggerInterval_Min` (1), matching the genome path and the "0 = manual triggering" contract in the TO.

## Testing

- Release build OK
- `EngineInterfaceTests` 159/159 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)