### PR TITLE
Add optional job-count arg to Windows build script

### DIFF
--- a/build-windows-ninja.bat
+++ b/build-windows-ninja.bat
@@ -9,8 +9,15 @@ rem The script sets up the MSVC build environment automatically, so it can be ru
 rem from any prompt (PowerShell or cmd). An identical copy lives in the repository
 rem root and in scripts\; either can be run directly:
 rem
-rem     build-windows-ninja.bat            (Release, default)
+rem     build-windows-ninja.bat            (Release, default, all cores)
 rem     build-windows-ninja.bat Debug
+rem
+rem An optional numeric argument caps the number of parallel build jobs. Without
+rem it Ninja uses all available cores. Automated callers (e.g. a Claude agent)
+rem should pass half the core count to keep the machine responsive:
+rem
+rem     build-windows-ninja.bat 16         (Release, 16 jobs)
+rem     build-windows-ninja.bat Debug 16   (Debug, 16 jobs)
 rem
 setlocal enabledelayedexpansion
 
@@ -48,10 +55,25 @@ rem "No known features for CXX compiler MSVC" when the MSVC toolset is newer.
 set "VSCMAKE=%VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
 if exist "%VSCMAKE%\cmake.exe" set "PATH=%VSCMAKE%;%PATH%"
 
+rem Parse arguments in any order: "Debug"/"Release" selects the config, a numeric
+rem argument caps the parallel build jobs (default: all cores).
 set "BUILD_PRESET=ninja-release"
+set "JOBS="
+:parseargs
+if "%~1"=="" goto :doneargs
 if /i "%~1"=="Debug" set "BUILD_PRESET=ninja-debug"
+if /i "%~1"=="Release" set "BUILD_PRESET=ninja-release"
+echo %~1| findstr /r "^[1-9][0-9]*$" >nul && set "JOBS=%~1"
+shift
+goto :parseargs
+:doneargs
 
 cmake --preset ninja || exit /b 1
-cmake --build --preset %BUILD_PRESET% || exit /b 1
+if defined JOBS (
+    echo [build] Limiting build to %JOBS% parallel jobs.
+    cmake --build --preset %BUILD_PRESET% -j %JOBS% || exit /b 1
+) else (
+    cmake --build --preset %BUILD_PRESET% || exit /b 1
+)
 
 echo [build] Done. Executables are under build-ninja\Release (or build-ninja\Debug).


### PR DESCRIPTION
## Summary
- `build-windows-ninja.bat` keeps defaulting to all cores, but now accepts an optional numeric argument that caps the number of parallel build jobs.
- Useful for automated callers that want to cap parallelism (e.g. half the core count) while leaving manual full-speed builds unchanged.
- Arguments are order-independent: `Debug`/`Release` selects the config, a number sets the job count.

## Usage
```
build-windows-ninja.bat            # Release, all cores (unchanged)
build-windows-ninja.bat 16         # Release, 16 jobs
build-windows-ninja.bat Debug 16   # Debug, 16 jobs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)