### PR TITLE
Keep at least one gene in deleteGeneMutation

### DIFF
--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -1124,8 +1124,9 @@ __inline__ __device__ void MutationProcessor::applyMutations_duplicateGene(Simul
 __inline__ __device__ void MutationProcessor::applyMutations_deleteGene(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     // Each gene (including the root gene) is independently deleted with probability geneProbability, so several genes can be
-    // removed in one pass and the genome may even become empty. Surviving genes are compacted and their references remapped; a
-    // reference to a deleted gene turns off a referencing constructor and redirects a referencing injector to the first gene.
+    // removed in one pass. At least one gene is always kept, so the genome never becomes empty: if every gene is marked for
+    // deletion, the root gene survives. Surviving genes are compacted and their references remapped; a reference to a deleted
+    // gene turns off a referencing constructor and redirects a referencing injector to the first gene.
     auto block = cg_mutation::this_thread_block();
     auto laneId = block.thread_rank();
     auto const& rate = genome->mutationRates.deleteGeneMutation;
@@ -1151,7 +1152,19 @@ __inline__ __device__ void MutationProcessor::applyMutations_deleteGene(Simulati
     block.sync();
 
     if (laneId == 0) {
-        // Assign compacted indices to the survivors and account for the deleted genes. A genome may end up with zero genes.
+        // Keep at least one gene: if every gene is marked for deletion, let the root gene survive so the genome stays non-empty.
+        bool anySurvivor = false;
+        for (int geneIndex = 0; geneIndex < oldNumGenes; ++geneIndex) {
+            if (newGeneIndices[geneIndex] >= 0) {
+                anySurvivor = true;
+                break;
+            }
+        }
+        if (!anySurvivor && oldNumGenes > 0) {
+            newGeneIndices[0] = 0;
+        }
+
+        // Assign compacted indices to the survivors and account for the deleted genes.
         int nextIndex = 0;
         for (int geneIndex = 0; geneIndex < oldNumGenes; ++geneIndex) {
             if (newGeneIndices[geneIndex] >= 0) {

--- a/source/EngineTests/DeleteGeneMutationTests.cpp
+++ b/source/EngineTests/DeleteGeneMutationTests.cpp
@@ -9,9 +9,9 @@
 class DeleteGeneMutationTests : public MutationTestsBase
 {};
 
-TEST_F(DeleteGeneMutationTests, deleteGeneMutation_deletesAllGenesIncludingRoot)
+TEST_F(DeleteGeneMutationTests, deleteGeneMutation_keepsAtLeastOneGene)
 {
-    // With a probability of 1 every gene (including the root gene) is deleted, leaving an empty genome.
+    // Even with a probability of 1, at least one gene must survive so the genome never becomes empty.
     auto genome = GenomeDesc().genes({
         GeneDesc().nodes({NodeDesc()}),
         GeneDesc().nodes({NodeDesc()}),
@@ -22,10 +22,12 @@ TEST_F(DeleteGeneMutationTests, deleteGeneMutation_deletesAllGenesIncludingRoot)
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_mutate(1);
+    for (int i = 0; i < 5; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(0, actualGenome._genes.size());
+    EXPECT_EQ(1, actualGenome._genes.size());
 }
 
 TEST_F(DeleteGeneMutationTests, deleteGeneMutation_zeroProbabilityNoChange)


### PR DESCRIPTION
## Summary
`deleteGeneMutation` now always keeps at least one gene, so a genome can never become empty. If every gene is marked for deletion, the root gene (index 0) survives. Reference remapping and accumulated-mutation accounting are unaffected — the forced survivor is treated as a normal survivor.

`trimNodeMutation` / `deleteNodeMutation` already guard `numNodes <= 1` and already have `keepsAtLeastOneNode` tests, so they cannot produce empty genes; no change needed there.

## Tests
- Replaced `deleteGeneMutation_deletesAllGenesIncludingRoot` (expected empty genome) with `deleteGeneMutation_keepsAtLeastOneGene` (3 genes, probability 1, repeated passes -> expect 1 surviving gene).
- Full build green; node/gene mutation suites pass (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)