### PR TITLE
Round in StringHelper::format instead of truncating

### DIFF
--- a/source/Base/StringHelper.cpp
+++ b/source/Base/StringHelper.cpp
@@ -1,6 +1,7 @@
 #include "StringHelper.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
 
@@ -29,13 +30,13 @@ std::string StringHelper::format(float v, int fracPartDecimals)
         result = "-";
         v = -v;
     }
-    result += format(static_cast<uint64_t>(v));
+    auto const scale = static_cast<uint64_t>(std::llround(std::pow(10.0, fracPartDecimals)));
+    auto const scaled = static_cast<uint64_t>(std::llround(static_cast<double>(v) * scale));
+    result += format(scaled / scale);
     if (fracPartDecimals > 0) {
         result += ".";
-    }
-    while (fracPartDecimals-- > 0) {
-        v *= 10;
-        result += std::to_string(static_cast<uint64_t>(v) % 10);
+        auto const fracPart = std::to_string(scaled % scale);
+        result += std::string(fracPartDecimals - static_cast<int>(fracPart.length()), '0') + fracPart;
     }
     return result;
 }

--- a/source/Base/StringHelper.cpp
+++ b/source/Base/StringHelper.cpp
@@ -30,12 +30,12 @@ std::string StringHelper::format(float v, int fracPartDecimals)
         result = "-";
         v = -v;
     }
-    auto const scale = static_cast<uint64_t>(std::llround(std::pow(10.0, fracPartDecimals)));
-    auto const scaled = static_cast<uint64_t>(std::llround(static_cast<double>(v) * scale));
+    auto scale = static_cast<uint64_t>(std::llround(std::pow(10.0, fracPartDecimals)));
+    auto scaled = static_cast<uint64_t>(std::llround(static_cast<double>(v) * scale));
     result += format(scaled / scale);
     if (fracPartDecimals > 0) {
         result += ".";
-        auto const fracPart = std::to_string(scaled % scale);
+        auto fracPart = std::to_string(scaled % scale);
         result += std::string(fracPartDecimals - static_cast<int>(fracPart.length()), '0') + fracPart;
     }
     return result;

--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -641,7 +641,7 @@ void SimulationParametersMainWindow::updateLocations()
     _locations = std::vector<Location>(1 + parameters.numLayers + parameters.numSources);
     auto radiationStrength = ParametersEditService::get().getRadiationStrengths(parameters);
     auto pinnedString = radiationStrength.pinned.contains(0) ? ICON_FA_THUMBTACK " " : " ";
-    _locations.at(0) = Location{"Base", LocationType::Base, "-", pinnedString + StringHelper::format(radiationStrength.values.front() * 100 + 0.05f, 1) + "%"};
+    _locations.at(0) = Location{"Base", LocationType::Base, "-", pinnedString + StringHelper::format(radiationStrength.values.front() * 100, 1) + "%"};
     for (int i = 0; i < parameters.numLayers; ++i) {
         auto position = "(" + StringHelper::format(parameters.layerPosition.layerValues[i].x, 0) + ", "
             + StringHelper::format(parameters.layerPosition.layerValues[i].y, 0) + ")";
@@ -649,7 +649,7 @@ void SimulationParametersMainWindow::updateLocations()
             .name = parameters.layerName.layerValues[i],
             .type = LocationType::Layer,
             .position = position,
-            .strength = " " + StringHelper::format(parameters.layerOpacity.layerValues[i] * 100 + 0.05f, 1) + "%"};
+            .strength = " " + StringHelper::format(parameters.layerOpacity.layerValues[i] * 100, 1) + "%"};
     }
     for (int i = 0; i < parameters.numSources; ++i) {
         auto position = "(" + StringHelper::format(parameters.sourcePosition.sourceValues[i].x, 0) + ", "
@@ -659,7 +659,7 @@ void SimulationParametersMainWindow::updateLocations()
             parameters.sourceName.sourceValues[i],
             LocationType::Source,
             position,
-            pinnedString + StringHelper::format(radiationStrength.values.at(i + 1) * 100 + 0.05f, 1) + "%"};
+            pinnedString + StringHelper::format(radiationStrength.values.at(i + 1) * 100, 1) + "%"};
     }
 }
 


### PR DESCRIPTION
## Problem

Mutation rates (and other formatted floats) were rendered wrong, e.g. a probability of `0.01` showed as `0.00999`.

## Cause

`StringHelper::format(float, int)` extracted decimal digits by **truncation**, with no rounding. `0.01f` is stored as `0.00999999…`, so digit-by-digit truncation yields `0.00999`.

## Fix

- Round to the requested number of decimals before extracting digits (`llround(v * 10^n)`), preserving the thousands separator on the integer part.
- Remove three now-redundant `+ 0.05f` truncation workarounds in `SimulationParametersMainWindow` (radiation/opacity percentages) — equivalent to true rounding, so display is unchanged.

## Verification

- Standalone check: `0.01,5 → 0.01000`, `0.001,5 → 0.00100`, `12345.678,2 → 12,345.68`.
- Full Windows Ninja release build passes (links `alien.exe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)