### PR TITLE
Redesign mutation rates dialog with responsive section grid

### DIFF
--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -2772,10 +2772,13 @@ int AlienGui::DynamicTableLayout::calcNumColumns(float tableWidth, float columnW
     return std::max(toInt(tableWidth / scale(columnWidth)), 1);
 }
 
-AlienGui::DynamicTableLayout::DynamicTableLayout(float columnWidth)
+AlienGui::DynamicTableLayout::DynamicTableLayout(float columnWidth, int maxColumns)
     : _columnWidth(columnWidth)
 {
     _numColumns = calcNumColumns(ImGui::GetContentRegionAvail().x, columnWidth);
+    if (maxColumns > 0) {
+        _numColumns = std::min(_numColumns, maxColumns);
+    }
 }
 
 bool AlienGui::DynamicTableLayout::begin()

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -508,7 +508,7 @@ public:
     public:
         static int calcNumColumns(float tableWidth, float columnWidth);
 
-        DynamicTableLayout(float columnWidth);
+        DynamicTableLayout(float columnWidth, int maxColumns = 0);
 
         bool begin();
         void end();

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -9,6 +9,7 @@
 
 namespace
 {
+    auto constexpr MinSectionWidth = 620.0f;
     auto constexpr MinTreeNodeWidth = 300.0f;
     auto constexpr RightColumnWidth = 195.0f;
 
@@ -205,9 +206,9 @@ namespace
     }
 
     template <typename Func>
-    void processConcreteMutationRates(Func&& processMutationRates)
+    void processConcreteMutationRates(int numRates, Func&& processMutationRates)
     {
-        AlienGui::DynamicTableLayout table(MinTreeNodeWidth);
+        AlienGui::DynamicTableLayout table(MinTreeNodeWidth, numRates);
         if (table.begin()) {
             processMutationRates(table);
             table.end();
@@ -346,117 +347,135 @@ void MutationRatesDialog::processIntern()
     // Use a child window with scrolling for the content, reserving space for buttons
     auto buttonAreaHeight = scale(50.0f);
     if (ImGui::BeginChild("MutationRateContent", ImVec2(0, -buttonAreaHeight), false)) {
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Connection weight mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processConnectionMutationRate("Mutation rate 1", "CMR1", _mutation._connectionMutations[0], RightColumnWidth);
-                table.next();
-                processConnectionMutationRate("Mutation rate 2", "CMR2", _mutation._connectionMutations[1], RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+        AlienGui::DynamicTableLayout sectionTable(MinSectionWidth);
+        if (sectionTable.begin()) {
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Connection weight mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processConnectionMutationRate("Mutation rate 1", "CMR1", _mutation._connectionMutations[0], RightColumnWidth);
+                    table.next();
+                    processConnectionMutationRate("Mutation rate 2", "CMR2", _mutation._connectionMutations[1], RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Neuron mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processNeuronMutationRate("Mutation rate 1", "NMR1", _mutation._neuronMutations[0], RightColumnWidth);
-                table.next();
-                processNeuronMutationRate("Mutation rate 2", "NMR2", _mutation._neuronMutations[1], RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Neuron mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processNeuronMutationRate("Mutation rate 1", "NMR1", _mutation._neuronMutations[0], RightColumnWidth);
+                    table.next();
+                    processNeuronMutationRate("Mutation rate 2", "NMR2", _mutation._neuronMutations[1], RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type property mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processCellTypePropertiesMutationRate("Mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], RightColumnWidth);
-                table.next();
-                processCellTypePropertiesMutationRate("Mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type property mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processCellTypePropertiesMutationRate("Mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], RightColumnWidth);
+                    table.next();
+                    processCellTypePropertiesMutationRate("Mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mode mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processCellTypeModeMutationRate("Mutation rate", "CTMM", _mutation._cellTypeModeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mode mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processCellTypeModeMutationRate("Mutation rate", "CTMM", _mutation._cellTypeModeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processCellTypeMutationRate("Mutation rate", "CTM", _mutation._cellTypeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Cell type mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processCellTypeMutationRate("Mutation rate", "CTM", _mutation._cellTypeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Void mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processVoidMutationRate("Mutation rate", "VM", _mutation._voidMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Void mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processVoidMutationRate("Mutation rate", "VM", _mutation._voidMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Append node mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "APNM", _mutation._appendNodeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Append node mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "APNM", _mutation._appendNodeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Add node mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "ADNM", _mutation._addNodeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Add node mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "ADNM", _mutation._addNodeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Trim node mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "TRNM", _mutation._trimNodeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Trim node mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "TRNM", _mutation._trimNodeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete node mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "DLNM", _mutation._deleteNodeMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete node mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "DLNM", _mutation._deleteNodeMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Duplicate gene mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "DPGM", _mutation._duplicateGeneMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Duplicate gene mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "DPGM", _mutation._duplicateGeneMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete gene mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processGeneProbabilityMutationRate("Mutation rate", "DLGM", _mutation._deleteGeneMutation, RightColumnWidth);
-                table.next();
-            });
-        }
-        AlienGui::EndTreeNode();
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete gene mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "DLGM", _mutation._deleteGeneMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
 
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Constructor mutations").rank(AlienGui::TreeNodeRank::High))) {
-            processConcreteMutationRates([&](AlienGui::DynamicTableLayout& table) {
-                processConstructorMutationRate("Mutation rate 1", "COM1", _mutation._constructorMutations[0], RightColumnWidth);
-                table.next();
-                processConstructorMutationRate("Mutation rate 2", "COM2", _mutation._constructorMutations[1], RightColumnWidth);
-                table.next();
-            });
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Constructor mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processConstructorMutationRate("Mutation rate 1", "COM1", _mutation._constructorMutations[0], RightColumnWidth);
+                    table.next();
+                    processConstructorMutationRate("Mutation rate 2", "COM2", _mutation._constructorMutations[1], RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
+
+            sectionTable.end();
         }
-        AlienGui::EndTreeNode();
     }
     ImGui::EndChild();
 


### PR DESCRIPTION
## Problem

The mutation rates dialog wasted horizontal space, especially when maximized: sections were stacked in a single narrow column with a large empty area on the right. Cause: the inner `DynamicTableLayout(300)` created `width / 300` columns, but each section only fills 1–2 mutation-rate blocks, so the surplus columns stayed empty and grew with window width.

## Change

- `AlienGui::DynamicTableLayout` gains an optional `maxColumns` cap.
- The 14 top-level sections are now wrapped in an outer section grid (`MinSectionWidth = 620`). Mutation cards flow into multiple columns as the window widens (2/3/4/… per row) instead of one narrow column.
- The inner rate table is capped to the actual rate count (1 or 2), eliminating the empty inner columns that caused the free space.

## Behaviour

- Narrow: one card per row, rate 1 | 2 side by side filling full width.
- Wider / maximized: cards form a responsive grid — scales dynamically.

Builds clean (Release, Ninja). GUI-only change under `source/Gui/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)