### PR TITLE
Add copy-node-section mutation

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -894,6 +894,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._mutationRates._deleteNodeMutation._geneProbability = genomeTO.mutationRates.deleteNodeMutation.geneProbability;
     result._mutationRates._duplicateGeneMutation._geneProbability = genomeTO.mutationRates.duplicateGeneMutation.geneProbability;
     result._mutationRates._deleteGeneMutation._geneProbability = genomeTO.mutationRates.deleteGeneMutation.geneProbability;
+    result._mutationRates._copyNodeSectionMutation._geneProbability = genomeTO.mutationRates.copyNodeSectionMutation.geneProbability;
     result._genes.reserve(genomeTO.numGenes);
 
     CHECK(genomeTO.geneArrayIndex + genomeTO.numGenes <= *to.numGenes);
@@ -998,6 +999,7 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.mutationRates.deleteNodeMutation = {genome._mutationRates._deleteNodeMutation._geneProbability};
     genomeTO.mutationRates.duplicateGeneMutation = {genome._mutationRates._duplicateGeneMutation._geneProbability};
     genomeTO.mutationRates.deleteGeneMutation = {genome._mutationRates._deleteGeneMutation._geneProbability};
+    genomeTO.mutationRates.copyNodeSectionMutation = {genome._mutationRates._copyNodeSectionMutation._geneProbability};
     genomeTO.numGenes = toInt(genome._genes.size());
     genomeTO.geneArrayIndex = geneArrayStartIndex;
     genomeTO.genomeIndexOnGpu = VALUE_NOT_SET_UINT64;

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -57,6 +57,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         std::clamp(genome._mutationRates._duplicateGeneMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._deleteGeneMutation._geneProbability =
         std::clamp(genome._mutationRates._deleteGeneMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._copyNodeSectionMutation._geneProbability =
+        std::clamp(genome._mutationRates._copyNodeSectionMutation._geneProbability, 0.0f, 1.0f);
 
     // Validate each gene
     for (auto& gene : genome._genes) {

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -502,6 +502,13 @@ struct DeleteGeneMutationDesc
     MEMBER(DeleteGeneMutationDesc, float, geneProbability, 0.0f);
 };
 
+struct CopyNodeSectionMutationDesc
+{
+    auto operator<=>(CopyNodeSectionMutationDesc const&) const = default;
+
+    MEMBER(CopyNodeSectionMutationDesc, float, geneProbability, 0.0f);
+};
+
 struct ConstructorMutationDesc
 {
     auto operator<=>(ConstructorMutationDesc const&) const = default;
@@ -549,6 +556,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, DeleteNodeMutationDesc, deleteNodeMutation, DeleteNodeMutationDesc());
     MEMBER(MutationRatesDesc, DuplicateGeneMutationDesc, duplicateGeneMutation, DuplicateGeneMutationDesc());
     MEMBER(MutationRatesDesc, DeleteGeneMutationDesc, deleteGeneMutation, DeleteGeneMutationDesc());
+    MEMBER(MutationRatesDesc, CopyNodeSectionMutationDesc, copyNodeSectionMutation, CopyNodeSectionMutationDesc());
     MEMBER(
         MutationRatesDesc,
         ConstructorMutationArray,

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -566,6 +566,7 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._mutationRates._deleteNodeMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._duplicateGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._deleteGeneMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._copyNodeSectionMutation._geneProbability);
         return seed;
     }
 };

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -519,6 +519,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::deleteGeneMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Copy node section mutation sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::copyNodeSectionMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("Constructor mutation sigma")
                         .reference(
                             FloatSpec().member(&SimulationParameters::constructorMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -121,6 +121,7 @@ struct SimulationParameters
     BaseParameter<float> deleteNodeMetaMutationsSigma = {0};
     BaseParameter<float> duplicateGeneMetaMutationsSigma = {0};
     BaseParameter<float> deleteGeneMetaMutationsSigma = {0};
+    BaseParameter<float> copyNodeSectionMetaMutationsSigma = {0};
     BaseParameter<float> constructorMetaMutationsSigma = {0};
 
     // Cell type: Attacker

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -61,6 +61,7 @@ namespace
             genomeTO.mutationRates.deleteNodeMutation = {genome->mutationRates.deleteNodeMutation.geneProbability};
             genomeTO.mutationRates.duplicateGeneMutation = {genome->mutationRates.duplicateGeneMutation.geneProbability};
             genomeTO.mutationRates.deleteGeneMutation = {genome->mutationRates.deleteGeneMutation.geneProbability};
+            genomeTO.mutationRates.copyNodeSectionMutation = {genome->mutationRates.copyNodeSectionMutation.geneProbability};
             genomeTO.numGenes = genome->numGenes;
             for (int i = 0; i < sizeof(genomeTO.name); ++i) {
                 genomeTO.name[i] = genome->name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -117,6 +117,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->mutationRates.deleteNodeMutation = {genomeTO.mutationRates.deleteNodeMutation.geneProbability};
     genome->mutationRates.duplicateGeneMutation = {genomeTO.mutationRates.duplicateGeneMutation.geneProbability};
     genome->mutationRates.deleteGeneMutation = {genomeTO.mutationRates.deleteGeneMutation.geneProbability};
+    genome->mutationRates.copyNodeSectionMutation = {genomeTO.mutationRates.copyNodeSectionMutation.geneProbability};
     genome->numGenes = genomeTO.numGenes;
     for (int i = 0; i < sizeof(genomeTO.name); ++i) {
         genome->name[i] = genomeTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -406,6 +406,11 @@ struct DeleteGeneMutation
     float geneProbability;
 };
 
+struct CopyNodeSectionMutation
+{
+    float geneProbability;
+};
+
 struct ConstructorMutation
 {
     float nodeProbability;
@@ -428,6 +433,7 @@ struct MutationRates
     DeleteNodeMutation deleteNodeMutation;
     DuplicateGeneMutation duplicateGeneMutation;
     DeleteGeneMutation deleteGeneMutation;
+    CopyNodeSectionMutation copyNodeSectionMutation;
     ConstructorMutation constructorMutations[2];
 };
 

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -411,6 +411,11 @@ struct DeleteGeneMutationTO
     float geneProbability;
 };
 
+struct CopyNodeSectionMutationTO
+{
+    float geneProbability;
+};
+
 struct ConstructorMutationTO
 {
     float nodeProbability;
@@ -433,6 +438,7 @@ struct MutationRatesTO
     DeleteNodeMutationTO deleteNodeMutation;
     DuplicateGeneMutationTO duplicateGeneMutation;
     DeleteGeneMutationTO deleteGeneMutation;
+    CopyNodeSectionMutationTO copyNodeSectionMutation;
     ConstructorMutationTO constructorMutations[2];
 };
 

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -37,6 +37,7 @@ private:
     __inline__ __device__ static void applyMutations_deleteNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_duplicateGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_deleteGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_copyNodeSection(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static int getNumGeneReferences(Genome* genome, int geneIndex);
     __inline__ __device__ static Node* findNthGeneReference(Genome* genome, int geneIndex, int referenceIndex, bool& isInjector);
     __inline__ __device__ static void applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -94,6 +95,14 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
         applyMutations_addNode(data, genome, accumulatedMutations);
         applyMutations_trimNode(data, genome, accumulatedMutations);
         applyMutations_deleteNode(data, genome, accumulatedMutations);
+        block.sync();
+        correctGenome(data, genome);
+    }
+
+    // sync since the copy-node-section mutation reads whole genes and rebuilds target genes (changing gene->nodes and numNodes)
+    block.sync();
+    if (nodeRates.copyNodeSectionMutation.geneProbability > 0) {
+        applyMutations_copyNodeSection(data, genome, accumulatedMutations);
         block.sync();
         correctGenome(data, genome);
     }
@@ -1214,6 +1223,114 @@ __inline__ __device__ void MutationProcessor::applyMutations_deleteGene(Simulati
     block.sync();
 }
 
+__inline__ __device__ void MutationProcessor::applyMutations_copyNodeSection(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    // Each gene is independently a source candidate with probability geneProbability, so several genes can copy a section in one
+    // pass. A triggered gene picks a contiguous section of its nodes (length in [1, numNodes]) and a random insertion slot of a
+    // random target gene (possibly itself, possibly another gene); the section is spliced in there. Multiple sections may target
+    // the same gene, so each target gene is rebuilt exactly once. Void nodes that end up at a gene boundary are turned into a
+    // non-void type by the correctGenome() call that follows this mutation.
+    auto block = cg_mutation::this_thread_block();
+    auto laneId = block.thread_rank();
+    auto const& rate = genome->mutationRates.copyNodeSectionMutation;
+    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+        return;
+    }
+
+    __shared__ int numGenes;
+    __shared__ int numOps;
+    __shared__ Node** opSourceNodes;  // captured pre-mutation node array of the source gene (never overwritten in place)
+    __shared__ int* opSectionStart;
+    __shared__ int* opSectionLength;
+    __shared__ int* opTargetGene;
+    __shared__ int* opTargetPos;
+    __shared__ bool* opAccepted;
+
+    if (laneId == 0) {
+        numGenes = genome->numGenes;
+        numOps = 0;
+        // At most one section per gene, so numGenes slots are always sufficient.
+        opSourceNodes = numGenes > 0 ? data.entities.heap.getTypedSubArray<Node*>(numGenes) : nullptr;
+        opSectionStart = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opSectionLength = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opTargetGene = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opTargetPos = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opAccepted = numGenes > 0 ? data.entities.heap.getTypedSubArray<bool>(numGenes) : nullptr;
+    }
+    block.sync();
+
+    // Phase 1 (parallel per source gene): decide which genes copy a section and where it is inserted. Only reads happen here, so
+    // the genome is not modified yet and every target gene still has its original node count.
+    for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes <= 0 || data.primaryNumberGen.random() >= rate.geneProbability) {
+            continue;
+        }
+        int sectionLength = data.primaryNumberGen.random(gene.numNodes - 1) + 1;           // [1, numNodes]
+        int sectionStart = data.primaryNumberGen.random(gene.numNodes - sectionLength);    // [0, numNodes - sectionLength]
+        int targetGene = data.primaryNumberGen.random(numGenes - 1);                       // [0, numGenes - 1]
+        int targetPos = data.primaryNumberGen.random(genome->genes[targetGene].numNodes);  // [0, numNodes] => any insertion slot
+
+        int slot = atomicAdd_block(&numOps, 1);
+        opSourceNodes[slot] = gene.nodes;
+        opSectionStart[slot] = sectionStart;
+        opSectionLength[slot] = sectionLength;
+        opTargetGene[slot] = targetGene;
+        opTargetPos[slot] = targetPos;
+    }
+    block.sync();
+
+    // Phase 2 (parallel per target gene): rebuild each target gene once, splicing in all sections destined for it. Sections are
+    // read from the captured pre-mutation source pointers, so a gene that is both a source and a target still contributes its
+    // original nodes. Only the thread owning a gene swaps that gene's node pointer, and the old arrays are never overwritten, so
+    // no thread reads an array that another thread is replacing.
+    for (int targetIndex = laneId; targetIndex < numGenes; targetIndex += blockDim.x) {
+        auto& gene = genome->genes[targetIndex];
+        auto const oldNumNodes = gene.numNodes;
+
+        // Sizing pass (op order): accept sections while the per-gene cap allows and record the decision so the emit pass matches.
+        int addedNodes = 0;
+        for (int op = 0; op < numOps; ++op) {
+            if (opTargetGene[op] != targetIndex) {
+                continue;
+            }
+            bool fits = oldNumNodes + addedNodes + opSectionLength[op] <= MaxNodesPerGene;
+            opAccepted[op] = fits;
+            if (fits) {
+                addedNodes += opSectionLength[op];
+            }
+        }
+        if (addedNodes == 0) {
+            continue;
+        }
+
+        auto const newNumNodes = oldNumNodes + addedNodes;
+        auto newNodes = data.entities.heap.getTypedSubArray<Node>(newNumNodes);
+
+        // Emit pass: walk the insertion slots [0, oldNumNodes]; at each slot emit the accepted sections targeting it, then the
+        // original node. Ordering by slot keeps the target gene's node order intact.
+        int writeIndex = 0;
+        for (int slot = 0; slot <= oldNumNodes; ++slot) {
+            for (int op = 0; op < numOps; ++op) {
+                if (opTargetGene[op] != targetIndex || opTargetPos[op] != slot || !opAccepted[op]) {
+                    continue;
+                }
+                for (int k = 0; k < opSectionLength[op]; ++k) {
+                    newNodes[writeIndex++] = opSourceNodes[op][opSectionStart[op] + k];
+                }
+            }
+            if (slot < oldNumNodes) {
+                newNodes[writeIndex++] = gene.nodes[slot];
+            }
+        }
+
+        gene.nodes = newNodes;
+        gene.numNodes = newNumNodes;
+        atomicAdd_block(&accumulatedMutations, toFloat(addedNodes));
+    }
+    block.sync();
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto block = cg_mutation::this_thread_block();
@@ -1387,6 +1504,12 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (deleteGeneSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * deleteGeneSigma)); };
             mutateFloat(genome->mutationRates.deleteGeneMutation.geneProbability);
+        }
+
+        float copyNodeSectionSigma = cudaSimulationParameters.copyNodeSectionMetaMutationsSigma.value;
+        if (copyNodeSectionSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * copyNodeSectionSigma)); };
+            mutateFloat(genome->mutationRates.copyNodeSectionMutation.geneProbability);
         }
 
         float constructorSigma = cudaSimulationParameters.constructorMetaMutationsSigma.value;

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -191,6 +191,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .deleteNodeMutation(DeleteNodeMutationDesc().geneProbability(0.44f))
                         .duplicateGeneMutation(DuplicateGeneMutationDesc().geneProbability(0.45f))
                         .deleteGeneMutation(DeleteGeneMutationDesc().geneProbability(0.46f))
+                        .copyNodeSectionMutation(CopyNodeSectionMutationDesc().geneProbability(0.47f))
                         .constructorMutations(
                             {ConstructorMutationDesc().nodeProbability(0.12f).valueChangeSigma(0.13f).enumChangeProbability(0.14f).constructorToggleProbability(0.15f),
                              ConstructorMutationDesc().nodeProbability(0.16f).valueChangeSigma(0.17f).enumChangeProbability(0.18f).constructorToggleProbability(0.19f)});

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -14,6 +14,7 @@ PUBLIC
     ConnectionMutationTests.cpp
     ConstructorMutationTests.cpp
     ConstructorTests.cpp
+    CopyNodeSectionMutationTests.cpp
     CreatureTests.cpp
     DataTransferTests.cpp
     DefenderTests.cpp

--- a/source/EngineTests/CopyNodeSectionMutationTests.cpp
+++ b/source/EngineTests/CopyNodeSectionMutationTests.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class CopyNodeSectionMutationTests : public MutationTestsBase
+{};
+
+namespace
+{
+    int countNodes(GenomeDesc const& genome)
+    {
+        int result = 0;
+        for (auto const& gene : genome._genes) {
+            result += static_cast<int>(gene._nodes.size());
+        }
+        return result;
+    }
+}
+
+TEST_F(CopyNodeSectionMutationTests, copyNodeSectionMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()}),
+        GeneDesc().nodes({NodeDesc()}),
+    });
+    genome._mutationRates._copyNodeSectionMutation = CopyNodeSectionMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+}
+
+TEST_F(CopyNodeSectionMutationTests, copyNodeSectionMutation_insertsSectionIntoSingleGene)
+{
+    // With a probability of 1 the single gene always copies a section (length in [1, numNodes]) into itself, so the node count
+    // grows by at least one node and by at most the gene's length.
+    int constexpr numNodes = 5;
+    std::vector<NodeDesc> nodes(numNodes);
+    auto genome = GenomeDesc().genes({GeneDesc().nodes(nodes)});
+    genome._mutationRates._copyNodeSectionMutation = CopyNodeSectionMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(1, actualGenome._genes.size());
+    auto actualNumNodes = countNodes(actualGenome);
+    EXPECT_GT(actualNumNodes, numNodes);
+    EXPECT_LE(actualNumNodes, 2 * numNodes);
+}
+
+TEST_F(CopyNodeSectionMutationTests, copyNodeSectionMutation_repeatedMutationGrowsGenome)
+{
+    // Repeated copy-node-section mutations keep growing the genome without ever removing genes or producing void boundary nodes.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()}),
+        GeneDesc().nodes({NodeDesc(), NodeDesc()}),
+    });
+    genome._mutationRates._copyNodeSectionMutation = CopyNodeSectionMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 5; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(2, actualGenome._genes.size());
+    EXPECT_GT(countNodes(actualGenome), countNodes(genome));
+    for (auto const& gene : actualGenome._genes) {
+        ASSERT_FALSE(gene._nodes.empty());
+        EXPECT_NE(CellType_Void, gene._nodes.front().getCellType());
+        EXPECT_NE(CellType_Void, gene._nodes.back().getCellType());
+    }
+}

--- a/source/EngineTests/CopyNodeSectionMutationTests.cpp
+++ b/source/EngineTests/CopyNodeSectionMutationTests.cpp
@@ -7,19 +7,17 @@
 #include "MutationTestsBase.h"
 
 class CopyNodeSectionMutationTests : public MutationTestsBase
-{};
-
-namespace
 {
-    int countNodes(GenomeDesc const& genome)
+protected:
+    int countNodes(GenomeDesc const& genome) const
     {
         int result = 0;
         for (auto const& gene : genome._genes) {
-            result += static_cast<int>(gene._nodes.size());
+            result += toInt(gene._nodes.size());
         }
         return result;
     }
-}
+};
 
 TEST_F(CopyNodeSectionMutationTests, copyNodeSectionMutation_zeroProbabilityNoChange)
 {

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -276,6 +276,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
         settings.getValue(settingsPrefix + "duplicate gene mutation.gene probability", mutationRates._duplicateGeneMutation._geneProbability);
     mutationRates._deleteGeneMutation._geneProbability =
         settings.getValue(settingsPrefix + "delete gene mutation.gene probability", mutationRates._deleteGeneMutation._geneProbability);
+    mutationRates._copyNodeSectionMutation._geneProbability =
+        settings.getValue(settingsPrefix + "copy node section mutation.gene probability", mutationRates._copyNodeSectionMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -329,6 +331,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     settings.setValue(settingsPrefix + "delete node mutation.gene probability", mutationRates._deleteNodeMutation._geneProbability);
     settings.setValue(settingsPrefix + "duplicate gene mutation.gene probability", mutationRates._duplicateGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "delete gene mutation.gene probability", mutationRates._deleteGeneMutation._geneProbability);
+    settings.setValue(settingsPrefix + "copy node section mutation.gene probability", mutationRates._copyNodeSectionMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -457,6 +460,15 @@ void MutationRatesDialog::processIntern()
             if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Delete gene mutations").rank(AlienGui::TreeNodeRank::High))) {
                 processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
                     processGeneProbabilityMutationRate("Mutation rate", "DLGM", _mutation._deleteGeneMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
+
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Copy node section mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "CNSM", _mutation._copyNodeSectionMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -53,6 +53,7 @@ namespace
         addActiveMutationType(activeMutations, "Delete node mutations", {mutationRates._deleteNodeMutation._geneProbability});
         addActiveMutationType(activeMutations, "Duplicate gene mutations", {mutationRates._duplicateGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Delete gene mutations", {mutationRates._deleteGeneMutation._geneProbability});
+        addActiveMutationType(activeMutations, "Copy node section mutations", {mutationRates._copyNodeSectionMutation._geneProbability});
         addActiveMutationType(
             activeMutations, "Constructor", {mutationRates._constructorMutations[0]._nodeProbability, mutationRates._constructorMutations[1]._nodeProbability});
         return activeMutations;

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -317,6 +317,8 @@ namespace
 
     auto constexpr Id_DeleteGeneMutation_GeneProbability = 0;
 
+    auto constexpr Id_CopyNodeSectionMutation_GeneProbability = 0;
+
     auto constexpr Id_ConstructorMutation_NodeProbability = 0;
     auto constexpr Id_ConstructorMutation_ValueChangeSigma = 1;
     auto constexpr Id_ConstructorMutation_EnumChangeProbability = 2;
@@ -455,6 +457,7 @@ namespace
     auto constexpr Id_MutationRates_DeleteNodeMutation = 15;
     auto constexpr Id_MutationRates_DuplicateGeneMutation = 16;
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
+    auto constexpr Id_MutationRates_CopyNodeSectionMutation = 18;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -1010,6 +1013,15 @@ namespace cereal
     SPLIT_SERIALIZATION(DeleteGeneMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, CopyNodeSectionMutationDesc& data)
+    {
+        CopyNodeSectionMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_CopyNodeSectionMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(CopyNodeSectionMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, ConstructorMutationDesc& data)
     {
         ConstructorMutationDesc defaultObject;
@@ -1041,6 +1053,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_DeleteNodeMutation, data._deleteNodeMutation);
         scope.addDesc(Id_MutationRates_DuplicateGeneMutation, data._duplicateGeneMutation);
         scope.addDesc(Id_MutationRates_DeleteGeneMutation, data._deleteGeneMutation);
+        scope.addDesc(Id_MutationRates_CopyNodeSectionMutation, data._copyNodeSectionMutation);
         scope.addDesc(Id_MutationRates_ConstructorMutation1, data._constructorMutations[0]);
         scope.addDesc(Id_MutationRates_ConstructorMutation2, data._constructorMutations[1]);
     }


### PR DESCRIPTION
## Summary
New per-gene mutation type `CopyNodeSectionMutation`, modeled on `DeleteGeneMutation`.

When it triggers for a gene (probability given per gene, like delete-gene), a contiguous section of that gene's nodes (length in `[1, gene length]`) is copied and inserted at an arbitrary position anywhere in the genome — including into other genes. Void nodes never end up at a gene's first or last position.

## Implementation
- **Kernel** (`MutationProcessor.cuh`): `applyMutations_copyNodeSection`, parallel over the thread block like the other gene mutations:
  - *Phase 1* (thread per source gene): decide trigger, pick section + random target gene + insertion slot (reads only).
  - *Phase 2* (thread per target gene): rebuild each target gene once, splicing in all sections aimed at it. Sections are read from captured pre-mutation node pointers, so a gene that is both source and target still contributes its original nodes and there is no cross-thread read/write hazard.
  - `correctGenome()` afterwards guarantees no void node at a gene boundary.
  - Respects `MaxNodesPerGene`, feeds `accumulatedMutations`, and has a meta-mutation (`copyNodeSectionMetaMutationsSigma`).
- Wired through the full stack: desc / TO / device structs, converter (both directions), validation clamp, hash, GPU↔TO copy, simulation + meta parameter, serializer (id 18), GUI rates dialog + widget, and the test data factory.

## Tests
- New `CopyNodeSectionMutationTests` (3 cases): zero-probability no-op, single-gene section insert grows node count, repeated mutation grows the genome while keeping all genes and non-void boundaries.
- Build (Ninja Release) exit 0. EngineInterfaceTests (159), PersisterTests (64) and the filtered engine mutation suite (47, incl. the 3 new ones) all pass — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)