### PR TITLE
Add move-node-section mutation

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -895,6 +895,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._mutationRates._duplicateGeneMutation._geneProbability = genomeTO.mutationRates.duplicateGeneMutation.geneProbability;
     result._mutationRates._deleteGeneMutation._geneProbability = genomeTO.mutationRates.deleteGeneMutation.geneProbability;
     result._mutationRates._copyNodeSectionMutation._geneProbability = genomeTO.mutationRates.copyNodeSectionMutation.geneProbability;
+    result._mutationRates._moveNodeSectionMutation._geneProbability = genomeTO.mutationRates.moveNodeSectionMutation.geneProbability;
     result._genes.reserve(genomeTO.numGenes);
 
     CHECK(genomeTO.geneArrayIndex + genomeTO.numGenes <= *to.numGenes);
@@ -1000,6 +1001,7 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.mutationRates.duplicateGeneMutation = {genome._mutationRates._duplicateGeneMutation._geneProbability};
     genomeTO.mutationRates.deleteGeneMutation = {genome._mutationRates._deleteGeneMutation._geneProbability};
     genomeTO.mutationRates.copyNodeSectionMutation = {genome._mutationRates._copyNodeSectionMutation._geneProbability};
+    genomeTO.mutationRates.moveNodeSectionMutation = {genome._mutationRates._moveNodeSectionMutation._geneProbability};
     genomeTO.numGenes = toInt(genome._genes.size());
     genomeTO.geneArrayIndex = geneArrayStartIndex;
     genomeTO.genomeIndexOnGpu = VALUE_NOT_SET_UINT64;

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -59,6 +59,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         std::clamp(genome._mutationRates._deleteGeneMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._copyNodeSectionMutation._geneProbability =
         std::clamp(genome._mutationRates._copyNodeSectionMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._moveNodeSectionMutation._geneProbability =
+        std::clamp(genome._mutationRates._moveNodeSectionMutation._geneProbability, 0.0f, 1.0f);
 
     // Validate each gene
     for (auto& gene : genome._genes) {

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -509,6 +509,13 @@ struct CopyNodeSectionMutationDesc
     MEMBER(CopyNodeSectionMutationDesc, float, geneProbability, 0.0f);
 };
 
+struct MoveNodeSectionMutationDesc
+{
+    auto operator<=>(MoveNodeSectionMutationDesc const&) const = default;
+
+    MEMBER(MoveNodeSectionMutationDesc, float, geneProbability, 0.0f);
+};
+
 struct ConstructorMutationDesc
 {
     auto operator<=>(ConstructorMutationDesc const&) const = default;
@@ -557,6 +564,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, DuplicateGeneMutationDesc, duplicateGeneMutation, DuplicateGeneMutationDesc());
     MEMBER(MutationRatesDesc, DeleteGeneMutationDesc, deleteGeneMutation, DeleteGeneMutationDesc());
     MEMBER(MutationRatesDesc, CopyNodeSectionMutationDesc, copyNodeSectionMutation, CopyNodeSectionMutationDesc());
+    MEMBER(MutationRatesDesc, MoveNodeSectionMutationDesc, moveNodeSectionMutation, MoveNodeSectionMutationDesc());
     MEMBER(
         MutationRatesDesc,
         ConstructorMutationArray,

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -567,6 +567,7 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._mutationRates._duplicateGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._deleteGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._copyNodeSectionMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._moveNodeSectionMutation._geneProbability);
         return seed;
     }
 };

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -523,6 +523,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::copyNodeSectionMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Move node section mutation sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::moveNodeSectionMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("Constructor mutation sigma")
                         .reference(
                             FloatSpec().member(&SimulationParameters::constructorMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -122,6 +122,7 @@ struct SimulationParameters
     BaseParameter<float> duplicateGeneMetaMutationsSigma = {0};
     BaseParameter<float> deleteGeneMetaMutationsSigma = {0};
     BaseParameter<float> copyNodeSectionMetaMutationsSigma = {0};
+    BaseParameter<float> moveNodeSectionMetaMutationsSigma = {0};
     BaseParameter<float> constructorMetaMutationsSigma = {0};
 
     // Cell type: Attacker

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -62,6 +62,7 @@ namespace
             genomeTO.mutationRates.duplicateGeneMutation = {genome->mutationRates.duplicateGeneMutation.geneProbability};
             genomeTO.mutationRates.deleteGeneMutation = {genome->mutationRates.deleteGeneMutation.geneProbability};
             genomeTO.mutationRates.copyNodeSectionMutation = {genome->mutationRates.copyNodeSectionMutation.geneProbability};
+            genomeTO.mutationRates.moveNodeSectionMutation = {genome->mutationRates.moveNodeSectionMutation.geneProbability};
             genomeTO.numGenes = genome->numGenes;
             for (int i = 0; i < sizeof(genomeTO.name); ++i) {
                 genomeTO.name[i] = genome->name[i];

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -118,6 +118,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->mutationRates.duplicateGeneMutation = {genomeTO.mutationRates.duplicateGeneMutation.geneProbability};
     genome->mutationRates.deleteGeneMutation = {genomeTO.mutationRates.deleteGeneMutation.geneProbability};
     genome->mutationRates.copyNodeSectionMutation = {genomeTO.mutationRates.copyNodeSectionMutation.geneProbability};
+    genome->mutationRates.moveNodeSectionMutation = {genomeTO.mutationRates.moveNodeSectionMutation.geneProbability};
     genome->numGenes = genomeTO.numGenes;
     for (int i = 0; i < sizeof(genomeTO.name); ++i) {
         genome->name[i] = genomeTO.name[i];

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -411,6 +411,11 @@ struct CopyNodeSectionMutation
     float geneProbability;
 };
 
+struct MoveNodeSectionMutation
+{
+    float geneProbability;
+};
+
 struct ConstructorMutation
 {
     float nodeProbability;
@@ -432,6 +437,7 @@ struct MutationRates
     TrimNodeMutation trimNodeMutation;
     DeleteNodeMutation deleteNodeMutation;
     CopyNodeSectionMutation copyNodeSectionMutation;
+    MoveNodeSectionMutation moveNodeSectionMutation;
     DuplicateGeneMutation duplicateGeneMutation;
     DeleteGeneMutation deleteGeneMutation;
     ConstructorMutation constructorMutations[2];

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -416,6 +416,11 @@ struct CopyNodeSectionMutationTO
     float geneProbability;
 };
 
+struct MoveNodeSectionMutationTO
+{
+    float geneProbability;
+};
+
 struct ConstructorMutationTO
 {
     float nodeProbability;
@@ -439,6 +444,7 @@ struct MutationRatesTO
     DuplicateGeneMutationTO duplicateGeneMutation;
     DeleteGeneMutationTO deleteGeneMutation;
     CopyNodeSectionMutationTO copyNodeSectionMutation;
+    MoveNodeSectionMutationTO moveNodeSectionMutation;
     ConstructorMutationTO constructorMutations[2];
 };
 

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -38,6 +38,7 @@ private:
     __inline__ __device__ static void applyMutations_duplicateGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_deleteGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_copyNodeSection(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_moveNodeSection(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static int getNumGeneReferences(Genome* genome, int geneIndex);
     __inline__ __device__ static Node* findNthGeneReference(Genome* genome, int geneIndex, int referenceIndex, bool& isInjector);
     __inline__ __device__ static void applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -103,6 +104,14 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     block.sync();
     if (nodeRates.copyNodeSectionMutation.geneProbability > 0) {
         applyMutations_copyNodeSection(data, genome, accumulatedMutations);
+        block.sync();
+        correctGenome(data, genome);
+    }
+
+    // sync since the move-node-section mutation reads whole genes and rebuilds them (changing gene->nodes and numNodes)
+    block.sync();
+    if (nodeRates.moveNodeSectionMutation.geneProbability > 0) {
+        applyMutations_moveNodeSection(data, genome, accumulatedMutations);
         block.sync();
         correctGenome(data, genome);
     }
@@ -1331,6 +1340,147 @@ __inline__ __device__ void MutationProcessor::applyMutations_copyNodeSection(Sim
     block.sync();
 }
 
+__inline__ __device__ void MutationProcessor::applyMutations_moveNodeSection(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    // Each gene is independently a source candidate with probability geneProbability, so several genes can move a section in one
+    // pass. A triggered gene picks a contiguous section of its nodes (length in [1, numNodes - 1], so at least one node is left
+    // behind) and a random insertion slot of a random target gene (possibly itself, possibly another gene); the section is spliced
+    // out of the source and into the target. Multiple sections may target the same gene, and every gene can also lose its own
+    // section, so each gene is rebuilt exactly once. Void nodes that end up at a gene boundary are turned into a non-void type by
+    // the correctGenome() call that follows this mutation.
+    auto block = cg_mutation::this_thread_block();
+    auto laneId = block.thread_rank();
+    auto const& rate = genome->mutationRates.moveNodeSectionMutation;
+    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+        return;
+    }
+
+    __shared__ int numGenes;
+    __shared__ int numOps;
+    __shared__ int* opSourceGene;
+    __shared__ Node** opSourceNodes;  // captured pre-mutation node array of the source gene (never overwritten in place)
+    __shared__ int* opSectionStart;
+    __shared__ int* opSectionLength;
+    __shared__ int* opTargetGene;
+    __shared__ int* opTargetPos;
+    __shared__ bool* opAccepted;
+
+    if (laneId == 0) {
+        numGenes = genome->numGenes;
+        numOps = 0;
+        // At most one section per gene, so numGenes slots are always sufficient.
+        opSourceGene = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opSourceNodes = numGenes > 0 ? data.entities.heap.getTypedSubArray<Node*>(numGenes) : nullptr;
+        opSectionStart = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opSectionLength = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opTargetGene = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opTargetPos = numGenes > 0 ? data.entities.heap.getTypedSubArray<int>(numGenes) : nullptr;
+        opAccepted = numGenes > 0 ? data.entities.heap.getTypedSubArray<bool>(numGenes) : nullptr;
+    }
+    block.sync();
+
+    // Phase 1 (parallel per source gene): decide which genes move a section and where it is inserted. Only reads happen here, so
+    // the genome is not modified yet and every gene still has its original node count.
+    for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // need >= 2 nodes to keep one behind
+            continue;
+        }
+        int sectionLength = data.primaryNumberGen.random(gene.numNodes - 2) + 1;           // [1, numNodes - 1]
+        int sectionStart = data.primaryNumberGen.random(gene.numNodes - sectionLength);    // [0, numNodes - sectionLength]
+        int targetGene = data.primaryNumberGen.random(numGenes - 1);                       // [0, numGenes - 1]
+        int targetPos = data.primaryNumberGen.random(genome->genes[targetGene].numNodes);  // [0, numNodes] => any insertion slot
+
+        int slot = atomicAdd_block(&numOps, 1);
+        opSourceGene[slot] = geneIndex;
+        opSourceNodes[slot] = gene.nodes;
+        opSectionStart[slot] = sectionStart;
+        opSectionLength[slot] = sectionLength;
+        opTargetGene[slot] = targetGene;
+        opTargetPos[slot] = targetPos;
+    }
+    block.sync();
+
+    // Phase 2 (parallel per target gene): decide which incoming sections fit the per-gene cap. Acceptance governs both the removal
+    // at the source and the insertion at the target, so it must be settled before any gene is rebuilt. The cap is checked against
+    // the target's original size only (any nodes the target itself loses as a source can only free up room), so an accepted op can
+    // never overflow MaxNodesPerGene. Each op has exactly one target gene, so opAccepted[op] is written by a single thread.
+    for (int targetIndex = laneId; targetIndex < numGenes; targetIndex += blockDim.x) {
+        auto const oldNumNodes = genome->genes[targetIndex].numNodes;
+        int addedNodes = 0;
+        for (int op = 0; op < numOps; ++op) {
+            if (opTargetGene[op] != targetIndex) {
+                continue;
+            }
+            bool fits = oldNumNodes + addedNodes + opSectionLength[op] <= MaxNodesPerGene;
+            opAccepted[op] = fits;
+            if (fits) {
+                addedNodes += opSectionLength[op];
+                atomicAdd_block(&accumulatedMutations, toFloat(opSectionLength[op]));
+            }
+        }
+    }
+    block.sync();
+
+    // Phase 3 (parallel per gene): rebuild each gene once, removing its own moved-out section (if accepted) and splicing in all
+    // accepted sections destined for it. Incoming sections are read from the captured pre-mutation source pointers, so a gene that
+    // is both a source and a target still contributes its original nodes. Only the thread owning a gene swaps that gene's node
+    // pointer, and the old arrays are never overwritten, so no thread reads an array that another thread is replacing.
+    for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
+        auto& gene = genome->genes[geneIndex];
+        auto const oldNumNodes = gene.numNodes;
+
+        // The accepted op (if any) that moves a section out of this gene; length stays <= oldNumNodes - 1, so a node is kept.
+        int removeStart = -1;
+        int removeLength = 0;
+        for (int op = 0; op < numOps; ++op) {
+            if (opSourceGene[op] == geneIndex && opAccepted[op]) {
+                removeStart = opSectionStart[op];
+                removeLength = opSectionLength[op];
+                break;  // at most one op per source gene
+            }
+        }
+
+        int addedNodes = 0;
+        for (int op = 0; op < numOps; ++op) {
+            if (opTargetGene[op] == geneIndex && opAccepted[op]) {
+                addedNodes += opSectionLength[op];
+            }
+        }
+
+        if (removeLength == 0 && addedNodes == 0) {
+            continue;
+        }
+
+        auto const newNumNodes = oldNumNodes - removeLength + addedNodes;
+        auto newNodes = data.entities.heap.getTypedSubArray<Node>(newNumNodes);
+
+        // Emit pass: walk the insertion slots [0, oldNumNodes]; at each slot emit the accepted incoming sections targeting it, then
+        // the original node unless it belongs to the removed section. Ordering by slot keeps the node order intact.
+        int writeIndex = 0;
+        for (int slot = 0; slot <= oldNumNodes; ++slot) {
+            for (int op = 0; op < numOps; ++op) {
+                if (opTargetGene[op] != geneIndex || opTargetPos[op] != slot || !opAccepted[op]) {
+                    continue;
+                }
+                for (int k = 0; k < opSectionLength[op]; ++k) {
+                    newNodes[writeIndex++] = opSourceNodes[op][opSectionStart[op] + k];
+                }
+            }
+            if (slot < oldNumNodes) {
+                bool removed = removeLength > 0 && slot >= removeStart && slot < removeStart + removeLength;
+                if (!removed) {
+                    newNodes[writeIndex++] = gene.nodes[slot];
+                }
+            }
+        }
+
+        gene.nodes = newNodes;
+        gene.numNodes = newNumNodes;
+    }
+    block.sync();
+}
+
 __inline__ __device__ void MutationProcessor::applyMutations_constructor(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto block = cg_mutation::this_thread_block();
@@ -1510,6 +1660,12 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (copyNodeSectionSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * copyNodeSectionSigma)); };
             mutateFloat(genome->mutationRates.copyNodeSectionMutation.geneProbability);
+        }
+
+        float moveNodeSectionSigma = cudaSimulationParameters.moveNodeSectionMetaMutationsSigma.value;
+        if (moveNodeSectionSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * moveNodeSectionSigma)); };
+            mutateFloat(genome->mutationRates.moveNodeSectionMutation.geneProbability);
         }
 
         float constructorSigma = cudaSimulationParameters.constructorMetaMutationsSigma.value;

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -192,6 +192,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .duplicateGeneMutation(DuplicateGeneMutationDesc().geneProbability(0.45f))
                         .deleteGeneMutation(DeleteGeneMutationDesc().geneProbability(0.46f))
                         .copyNodeSectionMutation(CopyNodeSectionMutationDesc().geneProbability(0.47f))
+                        .moveNodeSectionMutation(MoveNodeSectionMutationDesc().geneProbability(0.48f))
                         .constructorMutations(
                             {ConstructorMutationDesc().nodeProbability(0.12f).valueChangeSigma(0.13f).enumChangeProbability(0.14f).constructorToggleProbability(0.15f),
                              ConstructorMutationDesc().nodeProbability(0.16f).valueChangeSigma(0.17f).enumChangeProbability(0.18f).constructorToggleProbability(0.19f)});

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -38,6 +38,7 @@ PUBLIC
     LayerParameterTests.cpp
     MemoryTests.cpp
     MetaMutationTests.cpp
+    MoveNodeSectionMutationTests.cpp
     MuscleTests.cpp
     MutationTestsBase.h
     NeuronMutationTests.cpp

--- a/source/EngineTests/MoveNodeSectionMutationTests.cpp
+++ b/source/EngineTests/MoveNodeSectionMutationTests.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class MoveNodeSectionMutationTests : public MutationTestsBase
+{
+protected:
+    int countNodes(GenomeDesc const& genome) const
+    {
+        int result = 0;
+        for (auto const& gene : genome._genes) {
+            result += toInt(gene._nodes.size());
+        }
+        return result;
+    }
+};
+
+TEST_F(MoveNodeSectionMutationTests, moveNodeSectionMutation_zeroProbabilityNoChange)
+{
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()}),
+        GeneDesc().nodes({NodeDesc()}),
+    });
+    genome._mutationRates._moveNodeSectionMutation = MoveNodeSectionMutationDesc().geneProbability(0.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+}
+
+TEST_F(MoveNodeSectionMutationTests, moveNodeSectionMutation_singleGeneConservesNodeCount)
+{
+    // A move never adds or removes nodes overall; in a single gene the section can only be relocated within the same gene, so the
+    // node count is preserved and at least one node is always left behind.
+    int constexpr numNodes = 5;
+    std::vector<NodeDesc> nodes(numNodes);
+    auto genome = GenomeDesc().genes({GeneDesc().nodes(nodes)});
+    genome._mutationRates._moveNodeSectionMutation = MoveNodeSectionMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_mutate(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(1, actualGenome._genes.size());
+    EXPECT_EQ(numNodes, countNodes(actualGenome));
+}
+
+TEST_F(MoveNodeSectionMutationTests, moveNodeSectionMutation_repeatedMutationConservesNodesAndGenes)
+{
+    // Repeated move-node-section mutations keep the total node count constant, never remove genes, never leave a gene empty and
+    // never produce void boundary nodes.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc(), NodeDesc()}),
+        GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()}),
+    });
+    genome._mutationRates._moveNodeSectionMutation = MoveNodeSectionMutationDesc().geneProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 5; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(2, actualGenome._genes.size());
+    EXPECT_EQ(countNodes(genome), countNodes(actualGenome));
+    for (auto const& gene : actualGenome._genes) {
+        ASSERT_FALSE(gene._nodes.empty());
+        EXPECT_NE(CellType_Void, gene._nodes.front().getCellType());
+        EXPECT_NE(CellType_Void, gene._nodes.back().getCellType());
+    }
+}

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -278,6 +278,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
         settings.getValue(settingsPrefix + "delete gene mutation.gene probability", mutationRates._deleteGeneMutation._geneProbability);
     mutationRates._copyNodeSectionMutation._geneProbability =
         settings.getValue(settingsPrefix + "copy node section mutation.gene probability", mutationRates._copyNodeSectionMutation._geneProbability);
+    mutationRates._moveNodeSectionMutation._geneProbability =
+        settings.getValue(settingsPrefix + "move node section mutation.gene probability", mutationRates._moveNodeSectionMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -332,6 +334,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     settings.setValue(settingsPrefix + "duplicate gene mutation.gene probability", mutationRates._duplicateGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "delete gene mutation.gene probability", mutationRates._deleteGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "copy node section mutation.gene probability", mutationRates._copyNodeSectionMutation._geneProbability);
+    settings.setValue(settingsPrefix + "move node section mutation.gene probability", mutationRates._moveNodeSectionMutation._geneProbability);
 
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
@@ -469,6 +472,15 @@ void MutationRatesDialog::processIntern()
             if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Copy node section mutations").rank(AlienGui::TreeNodeRank::High))) {
                 processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
                     processGeneProbabilityMutationRate("Mutation rate", "CNSM", _mutation._copyNodeSectionMutation, RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
+
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Move node section mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeneProbabilityMutationRate("Mutation rate", "MNSM", _mutation._moveNodeSectionMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -54,6 +54,7 @@ namespace
         addActiveMutationType(activeMutations, "Duplicate gene mutations", {mutationRates._duplicateGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Delete gene mutations", {mutationRates._deleteGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Copy node section mutations", {mutationRates._copyNodeSectionMutation._geneProbability});
+        addActiveMutationType(activeMutations, "Move node section mutations", {mutationRates._moveNodeSectionMutation._geneProbability});
         addActiveMutationType(
             activeMutations, "Constructor", {mutationRates._constructorMutations[0]._nodeProbability, mutationRates._constructorMutations[1]._nodeProbability});
         return activeMutations;

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -319,6 +319,8 @@ namespace
 
     auto constexpr Id_CopyNodeSectionMutation_GeneProbability = 0;
 
+    auto constexpr Id_MoveNodeSectionMutation_GeneProbability = 0;
+
     auto constexpr Id_ConstructorMutation_NodeProbability = 0;
     auto constexpr Id_ConstructorMutation_ValueChangeSigma = 1;
     auto constexpr Id_ConstructorMutation_EnumChangeProbability = 2;
@@ -458,6 +460,7 @@ namespace
     auto constexpr Id_MutationRates_DuplicateGeneMutation = 16;
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
     auto constexpr Id_MutationRates_CopyNodeSectionMutation = 18;
+    auto constexpr Id_MutationRates_MoveNodeSectionMutation = 19;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -1022,6 +1025,15 @@ namespace cereal
     SPLIT_SERIALIZATION(CopyNodeSectionMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, MoveNodeSectionMutationDesc& data)
+    {
+        MoveNodeSectionMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_MoveNodeSectionMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+    }
+    SPLIT_SERIALIZATION(MoveNodeSectionMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, ConstructorMutationDesc& data)
     {
         ConstructorMutationDesc defaultObject;
@@ -1054,6 +1066,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_DuplicateGeneMutation, data._duplicateGeneMutation);
         scope.addDesc(Id_MutationRates_DeleteGeneMutation, data._deleteGeneMutation);
         scope.addDesc(Id_MutationRates_CopyNodeSectionMutation, data._copyNodeSectionMutation);
+        scope.addDesc(Id_MutationRates_MoveNodeSectionMutation, data._moveNodeSectionMutation);
         scope.addDesc(Id_MutationRates_ConstructorMutation1, data._constructorMutations[0]);
         scope.addDesc(Id_MutationRates_ConstructorMutation2, data._constructorMutations[1]);
     }


### PR DESCRIPTION
Adds a `MoveNodeSectionMutation`, analogous to `CopyNodeSectionMutation`, but the picked node section is **moved** (removed from the source gene and inserted elsewhere) instead of copied.

## Behavior
Each gene is independently a source candidate with probability `geneProbability`. A triggered gene (with at least 2 nodes) picks a contiguous section of length `[1, numNodes-1]` — so at least one node is always left behind — and a random insertion slot of a random target gene (possibly itself, possibly another gene). The section is spliced out of the source and into the target.

Implemented as three block-parallel phases in `MutationProcessor::applyMutations_moveNodeSection`:
1. **Decide** (per source gene): pick section + target/slot; read-only.
2. **Accept** (per target gene): cap incoming sections at `MaxNodesPerGene`. Acceptance governs both the source removal and the target insertion, so an accepted op can never overflow.
3. **Rebuild** (per gene): rebuild each gene once, dropping its own moved-out section and splicing in accepted incoming sections read from captured pre-mutation pointers.

The total node count is conserved, genes never become empty, and void boundary nodes are fixed by the following `correctGenome()` call.

## Coverage
Mirrors every `CopyNodeSectionMutation` touch point: Desc/TO structs and conversions, validation, hash, simulation-parameter meta-mutation sigma, GUI dialog/widget, serializer, and test-data factory. Adds `MoveNodeSectionMutationTests` (node-count conservation, non-empty genes, no void boundaries).

## Tests
Move (3) + Copy (3) + DataTransfer (13) + EngineInterface (159) + Persister (64) + Meta/Accumulated all pass. Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)