### PR TITLE
Add geometry mutation

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -879,6 +879,9 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma;
         result._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability =
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability;
+        result._mutationRates._geometryMutations[i]._nodeProbability = genomeTO.mutationRates.geometryMutations[i].nodeProbability;
+        result._mutationRates._geometryMutations[i]._valueChangeSigma = genomeTO.mutationRates.geometryMutations[i].valueChangeSigma;
+        result._mutationRates._geometryMutations[i]._enumChangeProbability = genomeTO.mutationRates.geometryMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._nodeProbability = genomeTO.mutationRates.constructorMutations[i].nodeProbability;
         result._mutationRates._constructorMutations[i]._valueChangeSigma = genomeTO.mutationRates.constructorMutations[i].valueChangeSigma;
         result._mutationRates._constructorMutations[i]._enumChangeProbability = genomeTO.mutationRates.constructorMutations[i].enumChangeProbability;
@@ -985,6 +988,10 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._nodeProbability,
             genome._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability};
+        genomeTO.mutationRates.geometryMutations[i] = {
+            genome._mutationRates._geometryMutations[i]._nodeProbability,
+            genome._mutationRates._geometryMutations[i]._valueChangeSigma,
+            genome._mutationRates._geometryMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.constructorMutations[i] = {
             genome._mutationRates._constructorMutations[i]._nodeProbability,
             genome._mutationRates._constructorMutations[i]._valueChangeSigma,

--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -879,13 +879,15 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma;
         result._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability =
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability;
+        result._mutationRates._geometryMutations[i]._nodeProbability = genomeTO.mutationRates.geometryMutations[i].nodeProbability;
+        result._mutationRates._geometryMutations[i]._valueChangeSigma = genomeTO.mutationRates.geometryMutations[i].valueChangeSigma;
+        result._mutationRates._geometryMutations[i]._enumChangeProbability = genomeTO.mutationRates.geometryMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._nodeProbability = genomeTO.mutationRates.constructorMutations[i].nodeProbability;
         result._mutationRates._constructorMutations[i]._valueChangeSigma = genomeTO.mutationRates.constructorMutations[i].valueChangeSigma;
         result._mutationRates._constructorMutations[i]._enumChangeProbability = genomeTO.mutationRates.constructorMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._constructorToggleProbability =
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability;
     }
-    result._mutationRates._geometryMutation._geneProbability = genomeTO.mutationRates.geometryMutation.geneProbability;
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
@@ -986,13 +988,16 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._nodeProbability,
             genome._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability};
+        genomeTO.mutationRates.geometryMutations[i] = {
+            genome._mutationRates._geometryMutations[i]._nodeProbability,
+            genome._mutationRates._geometryMutations[i]._valueChangeSigma,
+            genome._mutationRates._geometryMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.constructorMutations[i] = {
             genome._mutationRates._constructorMutations[i]._nodeProbability,
             genome._mutationRates._constructorMutations[i]._valueChangeSigma,
             genome._mutationRates._constructorMutations[i]._enumChangeProbability,
             genome._mutationRates._constructorMutations[i]._constructorToggleProbability};
     }
-    genomeTO.mutationRates.geometryMutation = {genome._mutationRates._geometryMutation._geneProbability};
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};

--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -879,15 +879,13 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma;
         result._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability =
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability;
-        result._mutationRates._geometryMutations[i]._nodeProbability = genomeTO.mutationRates.geometryMutations[i].nodeProbability;
-        result._mutationRates._geometryMutations[i]._valueChangeSigma = genomeTO.mutationRates.geometryMutations[i].valueChangeSigma;
-        result._mutationRates._geometryMutations[i]._enumChangeProbability = genomeTO.mutationRates.geometryMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._nodeProbability = genomeTO.mutationRates.constructorMutations[i].nodeProbability;
         result._mutationRates._constructorMutations[i]._valueChangeSigma = genomeTO.mutationRates.constructorMutations[i].valueChangeSigma;
         result._mutationRates._constructorMutations[i]._enumChangeProbability = genomeTO.mutationRates.constructorMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._constructorToggleProbability =
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability;
     }
+    result._mutationRates._geometryMutation._nodeProbability = genomeTO.mutationRates.geometryMutation.nodeProbability;
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
@@ -988,16 +986,13 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._nodeProbability,
             genome._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability};
-        genomeTO.mutationRates.geometryMutations[i] = {
-            genome._mutationRates._geometryMutations[i]._nodeProbability,
-            genome._mutationRates._geometryMutations[i]._valueChangeSigma,
-            genome._mutationRates._geometryMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.constructorMutations[i] = {
             genome._mutationRates._constructorMutations[i]._nodeProbability,
             genome._mutationRates._constructorMutations[i]._valueChangeSigma,
             genome._mutationRates._constructorMutations[i]._enumChangeProbability,
             genome._mutationRates._constructorMutations[i]._constructorToggleProbability};
     }
+    genomeTO.mutationRates.geometryMutation = {genome._mutationRates._geometryMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};

--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -885,7 +885,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._constructorMutations[i]._constructorToggleProbability =
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability;
     }
-    result._mutationRates._geometryMutation._nodeProbability = genomeTO.mutationRates.geometryMutation.nodeProbability;
+    result._mutationRates._geometryMutation._geneProbability = genomeTO.mutationRates.geometryMutation.geneProbability;
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
@@ -992,7 +992,7 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._constructorMutations[i]._enumChangeProbability,
             genome._mutationRates._constructorMutations[i]._constructorToggleProbability};
     }
-    genomeTO.mutationRates.geometryMutation = {genome._mutationRates._geometryMutation._nodeProbability};
+    genomeTO.mutationRates.geometryMutation = {genome._mutationRates._geometryMutation._geneProbability};
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};

--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -879,7 +879,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
         result._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma = genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma;
         result._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability =
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability;
-        result._mutationRates._geometryMutations[i]._nodeProbability = genomeTO.mutationRates.geometryMutations[i].nodeProbability;
+        result._mutationRates._geometryMutations[i]._geneProbability = genomeTO.mutationRates.geometryMutations[i].geneProbability;
         result._mutationRates._geometryMutations[i]._valueChangeSigma = genomeTO.mutationRates.geometryMutations[i].valueChangeSigma;
         result._mutationRates._geometryMutations[i]._enumChangeProbability = genomeTO.mutationRates.geometryMutations[i].enumChangeProbability;
         result._mutationRates._constructorMutations[i]._nodeProbability = genomeTO.mutationRates.constructorMutations[i].nodeProbability;
@@ -989,7 +989,7 @@ void DescConverterService::convertGenomeToTO(
             genome._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma,
             genome._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.geometryMutations[i] = {
-            genome._mutationRates._geometryMutations[i]._nodeProbability,
+            genome._mutationRates._geometryMutations[i]._geneProbability,
             genome._mutationRates._geometryMutations[i]._valueChangeSigma,
             genome._mutationRates._geometryMutations[i]._enumChangeProbability};
         genomeTO.mutationRates.constructorMutations[i] = {

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -159,6 +159,17 @@ namespace Const
     std::vector<std::string> const ProvideEnergyStrings = {"Reduce cell energy", "Free"};
 }
 
+//******************
+//* Gene constants *
+//******************
+namespace Const
+{
+    auto constexpr GeneStiffness_Min = 0.05f;
+    auto constexpr GeneStiffness_Max = 1.0f;
+    auto constexpr GeneConnectionDistance_Min = 0.5f;
+    auto constexpr GeneConnectionDistance_Max = 1.5f;
+}
+
 //**********************
 //* Mutation constants *
 //**********************

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -20,7 +20,7 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };
     auto validateGeometryMutation = [](GeometryMutationDesc& mutation) {
-        mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
+        mutation._geneProbability = std::clamp(mutation._geneProbability, 0.0f, 1.0f);
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
         mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -39,7 +39,7 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
         validateConstructorMutation(genome._mutationRates._constructorMutations[i]);
     }
-    genome._mutationRates._geometryMutation._nodeProbability = std::clamp(genome._mutationRates._geometryMutation._nodeProbability, 0.0f, 1.0f);
+    genome._mutationRates._geometryMutation._geneProbability = std::clamp(genome._mutationRates._geometryMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeModeMutation._nodeProbability =
         std::clamp(genome._mutationRates._cellTypeModeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeMutation._nodeProbability =

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -19,11 +19,6 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
         mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };
-    auto validateGeometryMutation = [](GeometryMutationDesc& mutation) {
-        mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
-        mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
-        mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
-    };
     auto validateConstructorMutation = [](ConstructorMutationDesc& mutation) {
         mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
@@ -42,9 +37,9 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         connectionMutation._valueChangeSigma = std::max(connectionMutation._valueChangeSigma, 0.0f);
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
-        validateGeometryMutation(genome._mutationRates._geometryMutations[i]);
         validateConstructorMutation(genome._mutationRates._constructorMutations[i]);
     }
+    genome._mutationRates._geometryMutation._nodeProbability = std::clamp(genome._mutationRates._geometryMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeModeMutation._nodeProbability =
         std::clamp(genome._mutationRates._cellTypeModeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeMutation._nodeProbability =

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -19,6 +19,11 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
         mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };
+    auto validateGeometryMutation = [](GeometryMutationDesc& mutation) {
+        mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
+        mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
+        mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
+    };
     auto validateConstructorMutation = [](ConstructorMutationDesc& mutation) {
         mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
@@ -37,6 +42,7 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         connectionMutation._valueChangeSigma = std::max(connectionMutation._valueChangeSigma, 0.0f);
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
+        validateGeometryMutation(genome._mutationRates._geometryMutations[i]);
         validateConstructorMutation(genome._mutationRates._constructorMutations[i]);
     }
     genome._mutationRates._cellTypeModeMutation._nodeProbability =

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -19,6 +19,11 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
         mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
     };
+    auto validateGeometryMutation = [](GeometryMutationDesc& mutation) {
+        mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
+        mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
+        mutation._enumChangeProbability = std::clamp(mutation._enumChangeProbability, 0.0f, 1.0f);
+    };
     auto validateConstructorMutation = [](ConstructorMutationDesc& mutation) {
         mutation._nodeProbability = std::clamp(mutation._nodeProbability, 0.0f, 1.0f);
         mutation._valueChangeSigma = std::clamp(mutation._valueChangeSigma, 0.0f, 1.0f);
@@ -37,9 +42,9 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         connectionMutation._valueChangeSigma = std::max(connectionMutation._valueChangeSigma, 0.0f);
 
         validateCellTypePropertiesMutation(genome._mutationRates._cellTypePropertiesMutations[i]);
+        validateGeometryMutation(genome._mutationRates._geometryMutations[i]);
         validateConstructorMutation(genome._mutationRates._constructorMutations[i]);
     }
-    genome._mutationRates._geometryMutation._geneProbability = std::clamp(genome._mutationRates._geometryMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeModeMutation._nodeProbability =
         std::clamp(genome._mutationRates._cellTypeModeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._cellTypeMutation._nodeProbability =

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -443,7 +443,7 @@ struct GeometryMutationDesc
 {
     auto operator<=>(GeometryMutationDesc const&) const = default;
 
-    MEMBER(GeometryMutationDesc, float, nodeProbability, 0.0f);
+    MEMBER(GeometryMutationDesc, float, geneProbability, 0.0f);
     MEMBER(GeometryMutationDesc, float, valueChangeSigma, 0.0f);
     MEMBER(GeometryMutationDesc, float, enumChangeProbability, 0.0f);
 };

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -569,8 +569,8 @@ struct MutationRatesDesc
         GeometryMutationArray,
         geometryMutations,
         (GeometryMutationArray{
-            {GeometryMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
-             GeometryMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
+            {GeometryMutationDesc().valueChangeSigma(0.2f).enumChangeProbability(0.2f),
+             GeometryMutationDesc().valueChangeSigma(1.0f).enumChangeProbability(0.5f)}}));
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -443,7 +443,9 @@ struct GeometryMutationDesc
 {
     auto operator<=>(GeometryMutationDesc const&) const = default;
 
-    MEMBER(GeometryMutationDesc, float, geneProbability, 0.0f);
+    MEMBER(GeometryMutationDesc, float, nodeProbability, 0.0f);
+    MEMBER(GeometryMutationDesc, float, valueChangeSigma, 0.0f);
+    MEMBER(GeometryMutationDesc, float, enumChangeProbability, 0.0f);
 };
 
 struct CellTypeModeMutationDesc
@@ -538,6 +540,7 @@ struct MutationRatesDesc
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
     using ConnectionMutationArray = std::array<ConnectionMutationDesc, 2>;
     using CellTypePropertiesMutationArray = std::array<CellTypePropertiesMutationDesc, 2>;
+    using GeometryMutationArray = std::array<GeometryMutationDesc, 2>;
     using ConstructorMutationArray = std::array<ConstructorMutationDesc, 2>;
 
     auto operator<=>(MutationRatesDesc const&) const = default;
@@ -561,7 +564,13 @@ struct MutationRatesDesc
         (CellTypePropertiesMutationArray{
             {CellTypePropertiesMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
              CellTypePropertiesMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
-    MEMBER(MutationRatesDesc, GeometryMutationDesc, geometryMutation, GeometryMutationDesc());
+    MEMBER(
+        MutationRatesDesc,
+        GeometryMutationArray,
+        geometryMutations,
+        (GeometryMutationArray{
+            {GeometryMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
+             GeometryMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -444,8 +444,6 @@ struct GeometryMutationDesc
     auto operator<=>(GeometryMutationDesc const&) const = default;
 
     MEMBER(GeometryMutationDesc, float, nodeProbability, 0.0f);
-    MEMBER(GeometryMutationDesc, float, valueChangeSigma, 0.0f);
-    MEMBER(GeometryMutationDesc, float, enumChangeProbability, 0.0f);
 };
 
 struct CellTypeModeMutationDesc
@@ -540,7 +538,6 @@ struct MutationRatesDesc
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
     using ConnectionMutationArray = std::array<ConnectionMutationDesc, 2>;
     using CellTypePropertiesMutationArray = std::array<CellTypePropertiesMutationDesc, 2>;
-    using GeometryMutationArray = std::array<GeometryMutationDesc, 2>;
     using ConstructorMutationArray = std::array<ConstructorMutationDesc, 2>;
 
     auto operator<=>(MutationRatesDesc const&) const = default;
@@ -564,13 +561,7 @@ struct MutationRatesDesc
         (CellTypePropertiesMutationArray{
             {CellTypePropertiesMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
              CellTypePropertiesMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
-    MEMBER(
-        MutationRatesDesc,
-        GeometryMutationArray,
-        geometryMutations,
-        (GeometryMutationArray{
-            {GeometryMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
-             GeometryMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
+    MEMBER(MutationRatesDesc, GeometryMutationDesc, geometryMutation, GeometryMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -439,6 +439,15 @@ struct CellTypePropertiesMutationDesc
     MEMBER(CellTypePropertiesMutationDesc, float, enumChangeProbability, 0.0f);
 };
 
+struct GeometryMutationDesc
+{
+    auto operator<=>(GeometryMutationDesc const&) const = default;
+
+    MEMBER(GeometryMutationDesc, float, nodeProbability, 0.0f);
+    MEMBER(GeometryMutationDesc, float, valueChangeSigma, 0.0f);
+    MEMBER(GeometryMutationDesc, float, enumChangeProbability, 0.0f);
+};
+
 struct CellTypeModeMutationDesc
 {
     auto operator<=>(CellTypeModeMutationDesc const&) const = default;
@@ -531,6 +540,7 @@ struct MutationRatesDesc
     using NeuronMutationArray = std::array<NeuronMutationDesc, 2>;
     using ConnectionMutationArray = std::array<ConnectionMutationDesc, 2>;
     using CellTypePropertiesMutationArray = std::array<CellTypePropertiesMutationDesc, 2>;
+    using GeometryMutationArray = std::array<GeometryMutationDesc, 2>;
     using ConstructorMutationArray = std::array<ConstructorMutationDesc, 2>;
 
     auto operator<=>(MutationRatesDesc const&) const = default;
@@ -554,6 +564,13 @@ struct MutationRatesDesc
         (CellTypePropertiesMutationArray{
             {CellTypePropertiesMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
              CellTypePropertiesMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
+    MEMBER(
+        MutationRatesDesc,
+        GeometryMutationArray,
+        geometryMutations,
+        (GeometryMutationArray{
+            {GeometryMutationDesc().valueChangeSigma(0.05f).enumChangeProbability(0.05f),
+             GeometryMutationDesc().valueChangeSigma(0.5f).enumChangeProbability(0.5f)}}));
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -443,7 +443,7 @@ struct GeometryMutationDesc
 {
     auto operator<=>(GeometryMutationDesc const&) const = default;
 
-    MEMBER(GeometryMutationDesc, float, nodeProbability, 0.0f);
+    MEMBER(GeometryMutationDesc, float, geneProbability, 0.0f);
 };
 
 struct CellTypeModeMutationDesc

--- a/source/EngineInterface/GenomeDescEditService.cpp
+++ b/source/EngineInterface/GenomeDescEditService.cpp
@@ -498,7 +498,8 @@ namespace
         genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc();
-        genome._mutationRates._geometryMutation = GeometryMutationDesc();
+        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc();
+        genome._mutationRates._geometryMutations[1] = GeometryMutationDesc();
         for (auto& gene : genome._genes) {
             gene._homogeneousCellType = false;
             for (auto& node : gene._nodes) {

--- a/source/EngineInterface/GenomeDescEditService.cpp
+++ b/source/EngineInterface/GenomeDescEditService.cpp
@@ -498,8 +498,7 @@ namespace
         genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc();
-        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc();
-        genome._mutationRates._geometryMutations[1] = GeometryMutationDesc();
+        genome._mutationRates._geometryMutation = GeometryMutationDesc();
         for (auto& gene : genome._genes) {
             gene._homogeneousCellType = false;
             for (auto& node : gene._nodes) {

--- a/source/EngineInterface/GenomeDescEditService.cpp
+++ b/source/EngineInterface/GenomeDescEditService.cpp
@@ -498,6 +498,8 @@ namespace
         genome._mutationRates._connectionMutations[1] = ConnectionMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc();
         genome._mutationRates._cellTypePropertiesMutations[1] = CellTypePropertiesMutationDesc();
+        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc();
+        genome._mutationRates._geometryMutations[1] = GeometryMutationDesc();
         for (auto& gene : genome._genes) {
             gene._homogeneousCellType = false;
             for (auto& node : gene._nodes) {

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,6 +552,9 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._nodeProbability);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._valueChangeSigma);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._enumChangeProbability);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,14 +552,12 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
-            hash_combine(seed, desc._mutationRates._geometryMutations[i]._nodeProbability);
-            hash_combine(seed, desc._mutationRates._geometryMutations[i]._valueChangeSigma);
-            hash_combine(seed, desc._mutationRates._geometryMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._constructorToggleProbability);
         }
+        hash_combine(seed, desc._mutationRates._geometryMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,7 +552,7 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
-            hash_combine(seed, desc._mutationRates._geometryMutations[i]._nodeProbability);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._geneProbability);
             hash_combine(seed, desc._mutationRates._geometryMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._geometryMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._nodeProbability);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -557,7 +557,7 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._constructorToggleProbability);
         }
-        hash_combine(seed, desc._mutationRates._geometryMutation._nodeProbability);
+        hash_combine(seed, desc._mutationRates._geometryMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -552,12 +552,14 @@ struct std::hash<GenomeDesc>
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._nodeProbability);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._valueChangeSigma);
+            hash_combine(seed, desc._mutationRates._geometryMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._nodeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._valueChangeSigma);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._enumChangeProbability);
             hash_combine(seed, desc._mutationRates._constructorMutations[i]._constructorToggleProbability);
         }
-        hash_combine(seed, desc._mutationRates._geometryMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -483,6 +483,10 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::cellTypePropertiesMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
+                        .name("Geometry mutation sigma")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::geometryMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                    ParameterSpec()
                         .name("Cell type mode mutation sigma")
                         .reference(
                             FloatSpec().member(&SimulationParameters::cellTypeModeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -112,6 +112,7 @@ struct SimulationParameters
     BaseParameter<float> neuronsMetaMutationsSigma = {0};
     BaseParameter<float> connectionsMetaMutationsSigma = {0};
     BaseParameter<float> cellTypePropertiesMetaMutationsSigma = {0};
+    BaseParameter<float> geometryMetaMutationsSigma = {0};
     BaseParameter<float> cellTypeModeMetaMutationsSigma = {0};
     BaseParameter<float> cellTypeMetaMutationsSigma = {0};
     BaseParameter<float> voidMetaMutationsSigma = {0};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -52,7 +52,7 @@ namespace
                     genome->mutationRates.constructorMutations[i].enumChangeProbability,
                     genome->mutationRates.constructorMutations[i].constructorToggleProbability};
             }
-            genomeTO.mutationRates.geometryMutation = {genome->mutationRates.geometryMutation.nodeProbability};
+            genomeTO.mutationRates.geometryMutation = {genome->mutationRates.geometryMutation.geneProbability};
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -46,6 +46,10 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability,
                     genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
+                genomeTO.mutationRates.geometryMutations[i] = {
+                    genome->mutationRates.geometryMutations[i].nodeProbability,
+                    genome->mutationRates.geometryMutations[i].valueChangeSigma,
+                    genome->mutationRates.geometryMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.constructorMutations[i] = {
                     genome->mutationRates.constructorMutations[i].nodeProbability,
                     genome->mutationRates.constructorMutations[i].valueChangeSigma,

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -46,16 +46,13 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability,
                     genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
-                genomeTO.mutationRates.geometryMutations[i] = {
-                    genome->mutationRates.geometryMutations[i].nodeProbability,
-                    genome->mutationRates.geometryMutations[i].valueChangeSigma,
-                    genome->mutationRates.geometryMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.constructorMutations[i] = {
                     genome->mutationRates.constructorMutations[i].nodeProbability,
                     genome->mutationRates.constructorMutations[i].valueChangeSigma,
                     genome->mutationRates.constructorMutations[i].enumChangeProbability,
                     genome->mutationRates.constructorMutations[i].constructorToggleProbability};
             }
+            genomeTO.mutationRates.geometryMutation = {genome->mutationRates.geometryMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -46,13 +46,16 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].nodeProbability,
                     genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
+                genomeTO.mutationRates.geometryMutations[i] = {
+                    genome->mutationRates.geometryMutations[i].nodeProbability,
+                    genome->mutationRates.geometryMutations[i].valueChangeSigma,
+                    genome->mutationRates.geometryMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.constructorMutations[i] = {
                     genome->mutationRates.constructorMutations[i].nodeProbability,
                     genome->mutationRates.constructorMutations[i].valueChangeSigma,
                     genome->mutationRates.constructorMutations[i].enumChangeProbability,
                     genome->mutationRates.constructorMutations[i].constructorToggleProbability};
             }
-            genomeTO.mutationRates.geometryMutation = {genome->mutationRates.geometryMutation.geneProbability};
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -47,7 +47,7 @@ namespace
                     genome->mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
                     genome->mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.geometryMutations[i] = {
-                    genome->mutationRates.geometryMutations[i].nodeProbability,
+                    genome->mutationRates.geometryMutations[i].geneProbability,
                     genome->mutationRates.geometryMutations[i].valueChangeSigma,
                     genome->mutationRates.geometryMutations[i].enumChangeProbability};
                 genomeTO.mutationRates.constructorMutations[i] = {

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -108,7 +108,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.constructorMutations[i].enumChangeProbability,
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability};
     }
-    genome->mutationRates.geometryMutation = {genomeTO.mutationRates.geometryMutation.nodeProbability};
+    genome->mutationRates.geometryMutation = {genomeTO.mutationRates.geometryMutation.geneProbability};
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -102,6 +102,10 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].nodeProbability,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
+        genome->mutationRates.geometryMutations[i] = {
+            genomeTO.mutationRates.geometryMutations[i].nodeProbability,
+            genomeTO.mutationRates.geometryMutations[i].valueChangeSigma,
+            genomeTO.mutationRates.geometryMutations[i].enumChangeProbability};
         genome->mutationRates.constructorMutations[i] = {
             genomeTO.mutationRates.constructorMutations[i].nodeProbability,
             genomeTO.mutationRates.constructorMutations[i].valueChangeSigma,

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -102,13 +102,16 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].nodeProbability,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
+        genome->mutationRates.geometryMutations[i] = {
+            genomeTO.mutationRates.geometryMutations[i].nodeProbability,
+            genomeTO.mutationRates.geometryMutations[i].valueChangeSigma,
+            genomeTO.mutationRates.geometryMutations[i].enumChangeProbability};
         genome->mutationRates.constructorMutations[i] = {
             genomeTO.mutationRates.constructorMutations[i].nodeProbability,
             genomeTO.mutationRates.constructorMutations[i].valueChangeSigma,
             genomeTO.mutationRates.constructorMutations[i].enumChangeProbability,
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability};
     }
-    genome->mutationRates.geometryMutation = {genomeTO.mutationRates.geometryMutation.geneProbability};
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -102,16 +102,13 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].nodeProbability,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
-        genome->mutationRates.geometryMutations[i] = {
-            genomeTO.mutationRates.geometryMutations[i].nodeProbability,
-            genomeTO.mutationRates.geometryMutations[i].valueChangeSigma,
-            genomeTO.mutationRates.geometryMutations[i].enumChangeProbability};
         genome->mutationRates.constructorMutations[i] = {
             genomeTO.mutationRates.constructorMutations[i].nodeProbability,
             genomeTO.mutationRates.constructorMutations[i].valueChangeSigma,
             genomeTO.mutationRates.constructorMutations[i].enumChangeProbability,
             genomeTO.mutationRates.constructorMutations[i].constructorToggleProbability};
     }
+    genome->mutationRates.geometryMutation = {genomeTO.mutationRates.geometryMutation.nodeProbability};
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -103,7 +103,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
             genomeTO.mutationRates.cellTypePropertiesMutations[i].valueChangeSigma,
             genomeTO.mutationRates.cellTypePropertiesMutations[i].enumChangeProbability};
         genome->mutationRates.geometryMutations[i] = {
-            genomeTO.mutationRates.geometryMutations[i].nodeProbability,
+            genomeTO.mutationRates.geometryMutations[i].geneProbability,
             genomeTO.mutationRates.geometryMutations[i].valueChangeSigma,
             genomeTO.mutationRates.geometryMutations[i].enumChangeProbability};
         genome->mutationRates.constructorMutations[i] = {

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -361,6 +361,13 @@ struct CellTypePropertiesMutation
     float enumChangeProbability;
 };
 
+struct GeometryMutation
+{
+    float nodeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
+};
+
 struct CellTypeModeMutation
 {
     float nodeProbability;
@@ -429,6 +436,7 @@ struct MutationRates
     NeuronMutation neuronMutations[2];
     ConnectionMutation connectionMutations[2];
     CellTypePropertiesMutation cellTypePropertiesMutations[2];
+    GeometryMutation geometryMutations[2];
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -363,7 +363,7 @@ struct CellTypePropertiesMutation
 
 struct GeometryMutation
 {
-    float nodeProbability;
+    float geneProbability;
     float valueChangeSigma;
     float enumChangeProbability;
 };

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -363,7 +363,7 @@ struct CellTypePropertiesMutation
 
 struct GeometryMutation
 {
-    float nodeProbability;
+    float geneProbability;
 };
 
 struct CellTypeModeMutation

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -363,7 +363,9 @@ struct CellTypePropertiesMutation
 
 struct GeometryMutation
 {
-    float geneProbability;
+    float nodeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
 };
 
 struct CellTypeModeMutation
@@ -434,7 +436,7 @@ struct MutationRates
     NeuronMutation neuronMutations[2];
     ConnectionMutation connectionMutations[2];
     CellTypePropertiesMutation cellTypePropertiesMutations[2];
-    GeometryMutation geometryMutation;
+    GeometryMutation geometryMutations[2];
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -364,8 +364,6 @@ struct CellTypePropertiesMutation
 struct GeometryMutation
 {
     float nodeProbability;
-    float valueChangeSigma;
-    float enumChangeProbability;
 };
 
 struct CellTypeModeMutation
@@ -436,7 +434,7 @@ struct MutationRates
     NeuronMutation neuronMutations[2];
     ConnectionMutation connectionMutations[2];
     CellTypePropertiesMutation cellTypePropertiesMutations[2];
-    GeometryMutation geometryMutations[2];
+    GeometryMutation geometryMutation;
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -368,7 +368,7 @@ struct CellTypePropertiesMutationTO
 
 struct GeometryMutationTO
 {
-    float nodeProbability;
+    float geneProbability;
     float valueChangeSigma;
     float enumChangeProbability;
 };

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -368,7 +368,9 @@ struct CellTypePropertiesMutationTO
 
 struct GeometryMutationTO
 {
-    float geneProbability;
+    float nodeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
 };
 
 struct CellTypeModeMutationTO
@@ -439,7 +441,7 @@ struct MutationRatesTO
     NeuronMutationTO neuronMutations[2];
     ConnectionMutationTO connectionMutations[2];
     CellTypePropertiesMutationTO cellTypePropertiesMutations[2];
-    GeometryMutationTO geometryMutation;
+    GeometryMutationTO geometryMutations[2];
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -368,7 +368,7 @@ struct CellTypePropertiesMutationTO
 
 struct GeometryMutationTO
 {
-    float nodeProbability;
+    float geneProbability;
 };
 
 struct CellTypeModeMutationTO

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -369,8 +369,6 @@ struct CellTypePropertiesMutationTO
 struct GeometryMutationTO
 {
     float nodeProbability;
-    float valueChangeSigma;
-    float enumChangeProbability;
 };
 
 struct CellTypeModeMutationTO
@@ -441,7 +439,7 @@ struct MutationRatesTO
     NeuronMutationTO neuronMutations[2];
     ConnectionMutationTO connectionMutations[2];
     CellTypePropertiesMutationTO cellTypePropertiesMutations[2];
-    GeometryMutationTO geometryMutations[2];
+    GeometryMutationTO geometryMutation;
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -366,6 +366,13 @@ struct CellTypePropertiesMutationTO
     float enumChangeProbability;
 };
 
+struct GeometryMutationTO
+{
+    float nodeProbability;
+    float valueChangeSigma;
+    float enumChangeProbability;
+};
+
 struct CellTypeModeMutationTO
 {
     float nodeProbability;
@@ -434,6 +441,7 @@ struct MutationRatesTO
     NeuronMutationTO neuronMutations[2];
     ConnectionMutationTO connectionMutations[2];
     CellTypePropertiesMutationTO cellTypePropertiesMutations[2];
+    GeometryMutationTO geometryMutations[2];
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -1649,6 +1649,14 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             }
         }
 
+        float geometrySigma = cudaSimulationParameters.geometryMetaMutationsSigma.value;
+        if (geometrySigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * geometrySigma)); };
+            for (int i = 0; i < 2; ++i) {
+                mutateFloat(genome->mutationRates.geometryMutations[i].nodeProbability);
+            }
+        }
+
         float cellTypeModeSigma = cudaSimulationParameters.cellTypeModeMetaMutationsSigma.value;
         if (cellTypeModeSigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * cellTypeModeSigma)); };

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -493,13 +493,13 @@ __inline__ __device__ void MutationProcessor::applyMutations_geometry(Simulation
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
     auto const& rate = genome->mutationRates.geometryMutation;
-    if (rate.nodeProbability <= 0) {
+    if (rate.geneProbability <= 0) {
         return;
     }
 
     // Genes are independent, so each thread mutates whole genes on its own.
     for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
-        if (data.primaryNumberGen.random() >= rate.nodeProbability) {
+        if (data.primaryNumberGen.random() >= rate.geneProbability) {
             continue;
         }
         auto& gene = genome->genes[geneIndex];
@@ -1631,7 +1631,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         float geometrySigma = cudaSimulationParameters.geometryMetaMutationsSigma.value;
         if (geometrySigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * geometrySigma)); };
-            mutateFloat(genome->mutationRates.geometryMutation.nodeProbability);
+            mutateFloat(genome->mutationRates.geometryMutation.geneProbability);
         }
 
         float cellTypeModeSigma = cudaSimulationParameters.cellTypeModeMetaMutationsSigma.value;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -28,6 +28,7 @@ private:
     __inline__ __device__ static void applyMutations_neurons(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_connections(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeProperties(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_geometry(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -81,6 +82,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_neurons(data, genome, accumulatedMutations);
     applyMutations_connections(data, genome, accumulatedMutations);
     applyMutations_cellTypeProperties(data, genome, accumulatedMutations);
+    applyMutations_geometry(data, genome, accumulatedMutations);
     applyMutations_cellTypeMode(data, genome, accumulatedMutations);
     applyMutations_cellType(data, genome, accumulatedMutations);
     applyMutations_void(data, genome, accumulatedMutations);
@@ -483,6 +485,51 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                     break;
                 }
             }
+        }
+    }
+}
+
+__inline__ __device__ void MutationProcessor::applyMutations_geometry(SimulationData& data, Genome* genome, float& accumulatedMutations)
+{
+    auto laneId = cg_mutation::this_thread_block().thread_rank();
+    GeometryMutation rates[2] = {genome->mutationRates.geometryMutations[0], genome->mutationRates.geometryMutations[1]};
+
+    for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
+        auto const& rate = rates[rateIndex];
+        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
+            continue;
+        }
+
+        // Genes are independent, so each thread mutates whole genes on its own.
+        for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+            if (data.primaryNumberGen.random() >= rate.nodeProbability) {
+                continue;
+            }
+            auto& gene = genome->genes[geneIndex];
+
+            auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
+                using ValueType = std::decay_t<decltype(value)>;
+                if (rate.valueChangeSigma <= 0) {
+                    return;
+                }
+                auto relDelta = generateGaussian(data) * rate.valueChangeSigma;
+                auto delta = relDelta * (maxValue - minValue);
+                value = max(static_cast<ValueType>(minValue), min(static_cast<ValueType>(maxValue), value + delta));
+                atomicAdd_block(&accumulatedMutations, std::abs(relDelta) * 4);
+            };
+
+            if (rate.enumChangeProbability > 0 && data.primaryNumberGen.random() < rate.enumChangeProbability) {
+                auto currentValue = gene.shape;
+                auto newValue = data.primaryNumberGen.random(ConstructorShape_Count - 2);
+                if (newValue >= currentValue) {
+                    ++newValue;
+                }
+                gene.shape = newValue;
+                atomicAdd_block(&accumulatedMutations, 1.0f);
+            }
+
+            mutateNumber(gene.stiffness, Const::GeneStiffness_Min, Const::GeneStiffness_Max);
+            mutateNumber(gene.connectionDistance, Const::GeneConnectionDistance_Min, Const::GeneConnectionDistance_Max);
         }
     }
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -492,24 +492,45 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 __inline__ __device__ void MutationProcessor::applyMutations_geometry(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
-    auto const& rate = genome->mutationRates.geometryMutation;
-    if (rate.geneProbability <= 0) {
-        return;
-    }
+    GeometryMutation rates[2] = {genome->mutationRates.geometryMutations[0], genome->mutationRates.geometryMutations[1]};
 
-    // Genes are independent, so each thread mutates whole genes on its own.
-    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
-        if (data.primaryNumberGen.random() >= rate.geneProbability) {
+    for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
+        auto const& rate = rates[rateIndex];
+        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
             continue;
         }
-        auto& gene = genome->genes[geneIndex];
 
-        // Re-roll all 3 attributes uniformly within their valid range.
-        gene.shape = data.primaryNumberGen.random(ConstructorShape_Count - 1);
-        gene.stiffness = Const::GeneStiffness_Min + data.primaryNumberGen.random() * (Const::GeneStiffness_Max - Const::GeneStiffness_Min);
-        gene.connectionDistance = Const::GeneConnectionDistance_Min
-            + data.primaryNumberGen.random() * (Const::GeneConnectionDistance_Max - Const::GeneConnectionDistance_Min);
-        atomicAdd_block(&accumulatedMutations, 3.0f);
+        // Genes are independent, so each thread mutates whole genes on its own.
+        for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+            if (data.primaryNumberGen.random() >= rate.nodeProbability) {
+                continue;
+            }
+            auto& gene = genome->genes[geneIndex];
+
+            auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
+                using ValueType = std::decay_t<decltype(value)>;
+                if (rate.valueChangeSigma <= 0) {
+                    return;
+                }
+                auto relDelta = generateGaussian(data) * rate.valueChangeSigma;
+                auto delta = relDelta * (maxValue - minValue);
+                value = max(static_cast<ValueType>(minValue), min(static_cast<ValueType>(maxValue), value + delta));
+                atomicAdd_block(&accumulatedMutations, std::abs(relDelta) * 4);
+            };
+
+            if (rate.enumChangeProbability > 0 && data.primaryNumberGen.random() < rate.enumChangeProbability) {
+                auto currentValue = gene.shape;
+                auto newValue = data.primaryNumberGen.random(ConstructorShape_Count - 2);
+                if (newValue >= currentValue) {
+                    ++newValue;
+                }
+                gene.shape = newValue;
+                atomicAdd_block(&accumulatedMutations, 1.0f);
+            }
+
+            mutateNumber(gene.stiffness, Const::GeneStiffness_Min, Const::GeneStiffness_Max);
+            mutateNumber(gene.connectionDistance, Const::GeneConnectionDistance_Min, Const::GeneConnectionDistance_Max);
+        }
     }
 }
 
@@ -1631,7 +1652,9 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         float geometrySigma = cudaSimulationParameters.geometryMetaMutationsSigma.value;
         if (geometrySigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * geometrySigma)); };
-            mutateFloat(genome->mutationRates.geometryMutation.geneProbability);
+            for (int i = 0; i < 2; ++i) {
+                mutateFloat(genome->mutationRates.geometryMutations[i].nodeProbability);
+            }
         }
 
         float cellTypeModeSigma = cudaSimulationParameters.cellTypeModeMetaMutationsSigma.value;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -525,7 +525,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_geometry(Simulation
                     ++newValue;
                 }
                 gene.shape = newValue;
-                atomicAdd_block(&accumulatedMutations, 1.0f);
+                atomicAdd_block(&accumulatedMutations, toFloat(gene.numNodes));
             }
 
             mutateNumber(gene.stiffness, Const::GeneStiffness_Min, Const::GeneStiffness_Max);

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -492,45 +492,24 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
 __inline__ __device__ void MutationProcessor::applyMutations_geometry(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
-    GeometryMutation rates[2] = {genome->mutationRates.geometryMutations[0], genome->mutationRates.geometryMutations[1]};
+    auto const& rate = genome->mutationRates.geometryMutation;
+    if (rate.nodeProbability <= 0) {
+        return;
+    }
 
-    for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
-        auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
+    // Genes are independent, so each thread mutates whole genes on its own.
+    for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
+        if (data.primaryNumberGen.random() >= rate.nodeProbability) {
             continue;
         }
+        auto& gene = genome->genes[geneIndex];
 
-        // Genes are independent, so each thread mutates whole genes on its own.
-        for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
-            if (data.primaryNumberGen.random() >= rate.nodeProbability) {
-                continue;
-            }
-            auto& gene = genome->genes[geneIndex];
-
-            auto mutateNumber = [&](auto& value, auto minValue, auto maxValue) {
-                using ValueType = std::decay_t<decltype(value)>;
-                if (rate.valueChangeSigma <= 0) {
-                    return;
-                }
-                auto relDelta = generateGaussian(data) * rate.valueChangeSigma;
-                auto delta = relDelta * (maxValue - minValue);
-                value = max(static_cast<ValueType>(minValue), min(static_cast<ValueType>(maxValue), value + delta));
-                atomicAdd_block(&accumulatedMutations, std::abs(relDelta) * 4);
-            };
-
-            if (rate.enumChangeProbability > 0 && data.primaryNumberGen.random() < rate.enumChangeProbability) {
-                auto currentValue = gene.shape;
-                auto newValue = data.primaryNumberGen.random(ConstructorShape_Count - 2);
-                if (newValue >= currentValue) {
-                    ++newValue;
-                }
-                gene.shape = newValue;
-                atomicAdd_block(&accumulatedMutations, 1.0f);
-            }
-
-            mutateNumber(gene.stiffness, Const::GeneStiffness_Min, Const::GeneStiffness_Max);
-            mutateNumber(gene.connectionDistance, Const::GeneConnectionDistance_Min, Const::GeneConnectionDistance_Max);
-        }
+        // Re-roll all 3 attributes uniformly within their valid range.
+        gene.shape = data.primaryNumberGen.random(ConstructorShape_Count - 1);
+        gene.stiffness = Const::GeneStiffness_Min + data.primaryNumberGen.random() * (Const::GeneStiffness_Max - Const::GeneStiffness_Min);
+        gene.connectionDistance = Const::GeneConnectionDistance_Min
+            + data.primaryNumberGen.random() * (Const::GeneConnectionDistance_Max - Const::GeneConnectionDistance_Min);
+        atomicAdd_block(&accumulatedMutations, 3.0f);
     }
 }
 
@@ -1652,9 +1631,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         float geometrySigma = cudaSimulationParameters.geometryMetaMutationsSigma.value;
         if (geometrySigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * geometrySigma)); };
-            for (int i = 0; i < 2; ++i) {
-                mutateFloat(genome->mutationRates.geometryMutations[i].nodeProbability);
-            }
+            mutateFloat(genome->mutationRates.geometryMutation.nodeProbability);
         }
 
         float cellTypeModeSigma = cudaSimulationParameters.cellTypeModeMetaMutationsSigma.value;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -496,13 +496,13 @@ __inline__ __device__ void MutationProcessor::applyMutations_geometry(Simulation
 
     for (int rateIndex = 0; rateIndex < 2; ++rateIndex) {
         auto const& rate = rates[rateIndex];
-        if (rate.nodeProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
+        if (rate.geneProbability <= 0 || (rate.valueChangeSigma <= 0 && rate.enumChangeProbability <= 0)) {
             continue;
         }
 
         // Genes are independent, so each thread mutates whole genes on its own.
         for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
-            if (data.primaryNumberGen.random() >= rate.nodeProbability) {
+            if (data.primaryNumberGen.random() >= rate.geneProbability) {
                 continue;
             }
             auto& gene = genome->genes[geneIndex];
@@ -1653,7 +1653,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
         if (geometrySigma > 0) {
             auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * geometrySigma)); };
             for (int i = 0; i < 2; ++i) {
-                mutateFloat(genome->mutationRates.geometryMutations[i].nodeProbability);
+                mutateFloat(genome->mutationRates.geometryMutations[i].geneProbability);
             }
         }
 

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -182,9 +182,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
                              CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
-                        .geometryMutations(
-                            {GeometryMutationDesc().nodeProbability(0.51f).valueChangeSigma(0.52f).enumChangeProbability(0.53f),
-                             GeometryMutationDesc().nodeProbability(0.56f).valueChangeSigma(0.57f).enumChangeProbability(0.58f)})
+                        .geometryMutation(GeometryMutationDesc().nodeProbability(0.51f))
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -182,6 +182,9 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
                              CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
+                        .geometryMutations(
+                            {GeometryMutationDesc().nodeProbability(0.51f).valueChangeSigma(0.52f).enumChangeProbability(0.53f),
+                             GeometryMutationDesc().nodeProbability(0.56f).valueChangeSigma(0.57f).enumChangeProbability(0.58f)})
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -182,7 +182,9 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
                              CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
-                        .geometryMutation(GeometryMutationDesc().geneProbability(0.51f))
+                        .geometryMutations(
+                            {GeometryMutationDesc().nodeProbability(0.51f).valueChangeSigma(0.52f).enumChangeProbability(0.53f),
+                             GeometryMutationDesc().nodeProbability(0.56f).valueChangeSigma(0.57f).enumChangeProbability(0.58f)})
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -183,8 +183,8 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                             {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
                              CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
                         .geometryMutations(
-                            {GeometryMutationDesc().nodeProbability(0.51f).valueChangeSigma(0.52f).enumChangeProbability(0.53f),
-                             GeometryMutationDesc().nodeProbability(0.56f).valueChangeSigma(0.57f).enumChangeProbability(0.58f)})
+                            {GeometryMutationDesc().geneProbability(0.51f).valueChangeSigma(0.52f).enumChangeProbability(0.53f),
+                             GeometryMutationDesc().geneProbability(0.56f).valueChangeSigma(0.57f).enumChangeProbability(0.58f)})
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -182,7 +182,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypePropertiesMutations(
                             {CellTypePropertiesMutationDesc().nodeProbability(0.45f).valueChangeSigma(0.55f).enumChangeProbability(0.65f),
                              CellTypePropertiesMutationDesc().nodeProbability(0.75f).valueChangeSigma(0.85f).enumChangeProbability(0.95f)})
-                        .geometryMutation(GeometryMutationDesc().nodeProbability(0.51f))
+                        .geometryMutation(GeometryMutationDesc().geneProbability(0.51f))
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -63,7 +63,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::Geometry:
-        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+        genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -63,7 +63,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::Geometry:
-        genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
+        genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -63,7 +63,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::Geometry:
-        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -63,7 +63,7 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::Geometry:
-        genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
+        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -116,6 +116,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.neuronsMetaMutationsSigma.value = 1.0f;
     _parameters.connectionsMetaMutationsSigma.value = 1.0f;
     _parameters.cellTypePropertiesMetaMutationsSigma.value = 1.0f;
+    _parameters.geometryMetaMutationsSigma.value = 1.0f;
     _parameters.cellTypeModeMetaMutationsSigma.value = 1.0f;
     _parameters.cellTypeMetaMutationsSigma.value = 1.0f;
     _parameters.voidMetaMutationsSigma.value = 1.0f;

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -14,6 +14,7 @@ enum class MutationType
     Neuron,
     Connection,
     CellTypeProperties,
+    Geometry,
     CellTypeMode,
     CellType,
     Void,
@@ -37,6 +38,7 @@ INSTANTIATE_TEST_SUITE_P(
         MutationType::Neuron,
         MutationType::Connection,
         MutationType::CellTypeProperties,
+        MutationType::Geometry,
         MutationType::CellTypeMode,
         MutationType::CellType,
         MutationType::Void,
@@ -59,6 +61,9 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         break;
     case MutationType::CellTypeProperties:
         genome._mutationRates._cellTypePropertiesMutations[0] = CellTypePropertiesMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+        break;
+    case MutationType::Geometry:
+        genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
         break;
     case MutationType::CellTypeMode:
         genome._mutationRates._cellTypeModeMutation = CellTypeModeMutationDesc().nodeProbability(1.0f);

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -31,6 +31,7 @@ PUBLIC
     HeadUpdateTests.cpp
     GarbageCollectorTests.cpp
     GeneratorTests.cpp
+    GeometryMutationTests.cpp
     GeometryTests.cpp
     InjectorTests.cpp
     IntegrationTestFramework.cpp

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -13,7 +13,7 @@ class GeometryMutationTests : public MutationTestsBase
 TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectionDistance)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -47,8 +47,8 @@ TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectio
 TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -72,8 +72,8 @@ TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -13,7 +13,7 @@ class GeometryMutationTests : public MutationTestsBase
 TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectionDistance)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -47,8 +47,7 @@ TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectio
 TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -72,8 +71,7 @@ TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/CellTypeConstants.h>
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class GeometryMutationTests : public MutationTestsBase
+{
+};
+
+TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectionDistance)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 20; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
+    bool shapeChanged = false;
+    bool stiffnessChanged = false;
+    bool connectionDistanceChanged = false;
+    for (size_t i = 0; i < genome._genes.size(); ++i) {
+        if (genome._genes[i]._shape != actualGenome._genes[i]._shape) {
+            shapeChanged = true;
+        }
+        if (genome._genes[i]._stiffness != actualGenome._genes[i]._stiffness) {
+            stiffnessChanged = true;
+        }
+        if (genome._genes[i]._connectionDistance != actualGenome._genes[i]._connectionDistance) {
+            connectionDistanceChanged = true;
+        }
+    }
+    EXPECT_TRUE(shapeChanged);
+    EXPECT_TRUE(stiffnessChanged);
+    EXPECT_TRUE(connectionDistanceChanged);
+}
+
+TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    for (auto const& gene : actualGenome._genes) {
+        EXPECT_GE(gene._stiffness, Const::GeneStiffness_Min);
+        EXPECT_LE(gene._stiffness, Const::GeneStiffness_Max);
+        EXPECT_GE(gene._connectionDistance, Const::GeneConnectionDistance_Min);
+        EXPECT_LE(gene._connectionDistance, Const::GeneConnectionDistance_Max);
+        EXPECT_GE(gene._shape, 0);
+        EXPECT_LT(gene._shape, ConstructorShape_Count);
+    }
+}
+
+TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
+    for (size_t i = 0; i < genome._genes.size(); ++i) {
+        EXPECT_EQ(genome._genes[i]._nodes, actualGenome._genes[i]._nodes);
+        EXPECT_EQ(genome._genes[i]._name, actualGenome._genes[i]._name);
+        EXPECT_EQ(genome._genes[i]._homogeneousCellType, actualGenome._genes[i]._homogeneousCellType);
+    }
+}

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -13,7 +13,7 @@ class GeometryMutationTests : public MutationTestsBase
 TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectionDistance)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -47,7 +47,7 @@ TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectio
 TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -71,7 +71,7 @@ TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(1.0f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -1,3 +1,5 @@
+#include <ranges>
+
 #include <gtest/gtest.h>
 
 #include <EngineInterface/CellTypeConstants.h>
@@ -18,37 +20,30 @@ TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectio
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    for (int i = 0; i < 20; ++i) {
-        _simulationFacade->testOnly_mutate(1);
-    }
+    _simulationFacade->testOnly_mutate(1);
 
     auto actualGenome = getMutatedGenome();
 
     ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
-    bool shapeChanged = false;
-    bool stiffnessChanged = false;
-    bool connectionDistanceChanged = false;
-    for (size_t i = 0; i < genome._genes.size(); ++i) {
-        if (genome._genes[i]._shape != actualGenome._genes[i]._shape) {
-            shapeChanged = true;
-        }
-        if (genome._genes[i]._stiffness != actualGenome._genes[i]._stiffness) {
-            stiffnessChanged = true;
-        }
-        if (genome._genes[i]._connectionDistance != actualGenome._genes[i]._connectionDistance) {
-            connectionDistanceChanged = true;
-        }
+    for (auto const& [expectedGene, actualGene] : std::views::zip(genome._genes, actualGenome._genes)) {
+        EXPECT_NE(expectedGene._shape, actualGene._shape);
+        EXPECT_NE(expectedGene._stiffness, actualGene._stiffness);
+        EXPECT_NE(expectedGene._connectionDistance, actualGene._connectionDistance);
+
+        EXPECT_GE(actualGene._stiffness, Const::GeneStiffness_Min);
+        EXPECT_LE(actualGene._stiffness, Const::GeneStiffness_Max);
+        EXPECT_GE(actualGene._connectionDistance, Const::GeneConnectionDistance_Min);
+        EXPECT_LE(actualGene._connectionDistance, Const::GeneConnectionDistance_Max);
+        EXPECT_GE(actualGene._shape, 0);
+        EXPECT_LT(actualGene._shape, ConstructorShape_Count);
     }
-    EXPECT_TRUE(shapeChanged);
-    EXPECT_TRUE(stiffnessChanged);
-    EXPECT_TRUE(connectionDistanceChanged);
 }
 
-TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
+TEST_F(GeometryMutationTests, geometryMutation_zeroProbabilityNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(0.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(0.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -59,13 +54,11 @@ TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 
     auto actualGenome = getMutatedGenome();
 
-    for (auto const& gene : actualGenome._genes) {
-        EXPECT_GE(gene._stiffness, Const::GeneStiffness_Min);
-        EXPECT_LE(gene._stiffness, Const::GeneStiffness_Max);
-        EXPECT_GE(gene._connectionDistance, Const::GeneConnectionDistance_Min);
-        EXPECT_LE(gene._connectionDistance, Const::GeneConnectionDistance_Max);
-        EXPECT_GE(gene._shape, 0);
-        EXPECT_LT(gene._shape, ConstructorShape_Count);
+    ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
+    for (auto const& [expectedGene, actualGene] : std::views::zip(genome._genes, actualGenome._genes)) {
+        EXPECT_EQ(expectedGene._shape, actualGene._shape);
+        EXPECT_EQ(expectedGene._stiffness, actualGene._stiffness);
+        EXPECT_EQ(expectedGene._connectionDistance, actualGene._connectionDistance);
     }
 }
 
@@ -85,9 +78,9 @@ TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
     auto actualGenome = getMutatedGenome();
 
     ASSERT_EQ(genome._genes.size(), actualGenome._genes.size());
-    for (size_t i = 0; i < genome._genes.size(); ++i) {
-        EXPECT_EQ(genome._genes[i]._nodes, actualGenome._genes[i]._nodes);
-        EXPECT_EQ(genome._genes[i]._name, actualGenome._genes[i]._name);
-        EXPECT_EQ(genome._genes[i]._homogeneousCellType, actualGenome._genes[i]._homogeneousCellType);
+    for (auto const& [expectedGene, actualGene] : std::views::zip(genome._genes, actualGenome._genes)) {
+        EXPECT_EQ(expectedGene._nodes, actualGene._nodes);
+        EXPECT_EQ(expectedGene._name, actualGene._name);
+        EXPECT_EQ(expectedGene._homogeneousCellType, actualGene._homogeneousCellType);
     }
 }

--- a/source/EngineTests/GeometryMutationTests.cpp
+++ b/source/EngineTests/GeometryMutationTests.cpp
@@ -13,7 +13,7 @@ class GeometryMutationTests : public MutationTestsBase
 TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectionDistance)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -47,7 +47,8 @@ TEST_F(GeometryMutationTests, geometryMutation_changesShapeStiffnessAndConnectio
 TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -71,7 +72,8 @@ TEST_F(GeometryMutationTests, geometryMutation_respectsBounds)
 TEST_F(GeometryMutationTests, geometryMutation_doesNotChangeNodes)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(1.0f).valueChangeSigma(1.0f).enumChangeProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -187,6 +187,60 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
     EXPECT_EQ(actualGenome._mutationRates._cellTypePropertiesMutations[1]._enumChangeProbability, 0.4f);
 }
 
+TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.geometryMetaMutationsSigma.value = 1.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+
+    bool nodeProbabilityChanged =
+        actualGenome._mutationRates._geometryMutations[0]._nodeProbability != 0.5f || actualGenome._mutationRates._geometryMutations[1]._nodeProbability != 0.4f;
+    EXPECT_TRUE(nodeProbabilityChanged);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.0f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
+}
+
+TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _parameters.geometryMetaMutationsSigma.value = 0.0f;
+    _simulationFacade->setSimulationParameters(_parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 100; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
+}
+
 TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)
 {
     auto genome = createTestGenome();

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -190,7 +190,8 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -203,15 +204,23 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_NE(actualGenome._mutationRates._geometryMutation._geneProbability, 0.5f);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutation._geneProbability, 0.0f);
-    EXPECT_LE(actualGenome._mutationRates._geometryMutation._geneProbability, 1.0f);
+
+    bool nodeProbabilityChanged =
+        actualGenome._mutationRates._geometryMutations[0]._nodeProbability != 0.5f || actualGenome._mutationRates._geometryMutations[1]._nodeProbability != 0.4f;
+    EXPECT_TRUE(nodeProbabilityChanged);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.0f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -224,7 +233,12 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutation._geneProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -190,7 +190,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(0.5f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -203,15 +203,15 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_NE(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.5f);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.0f);
-    EXPECT_LE(actualGenome._mutationRates._geometryMutation._nodeProbability, 1.0f);
+    EXPECT_NE(actualGenome._mutationRates._geometryMutation._geneProbability, 0.5f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._geometryMutation._geneProbability, 1.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(0.5f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -224,7 +224,7 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutation._geneProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -190,8 +190,7 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -204,23 +203,15 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
     }
 
     auto actualGenome = getMutatedGenome();
-
-    bool nodeProbabilityChanged =
-        actualGenome._mutationRates._geometryMutations[0]._nodeProbability != 0.5f || actualGenome._mutationRates._geometryMutations[1]._nodeProbability != 0.4f;
-    EXPECT_TRUE(nodeProbabilityChanged);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.0f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
+    EXPECT_NE(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.5f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._geometryMutation._nodeProbability, 1.0f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+    genome._mutationRates._geometryMutation = GeometryMutationDesc().nodeProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -233,12 +224,7 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutation._nodeProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_cellTypeModeRatesActuallyChange)

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -190,8 +190,8 @@ TEST_F(MetaMutationTests, metaMutation_cellTypePropertyRatesZeroSigmaNoChange)
 TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -206,10 +206,10 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
     auto actualGenome = getMutatedGenome();
 
     bool nodeProbabilityChanged =
-        actualGenome._mutationRates._geometryMutations[0]._nodeProbability != 0.5f || actualGenome._mutationRates._geometryMutations[1]._nodeProbability != 0.4f;
+        actualGenome._mutationRates._geometryMutations[0]._geneProbability != 0.5f || actualGenome._mutationRates._geometryMutations[1]._geneProbability != 0.4f;
     EXPECT_TRUE(nodeProbabilityChanged);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.0f);
-    EXPECT_GE(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[0]._geneProbability, 0.0f);
+    EXPECT_GE(actualGenome._mutationRates._geometryMutations[1]._geneProbability, 0.0f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
@@ -219,8 +219,8 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesActuallyChange)
 TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().nodeProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
-    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().nodeProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
+    genome._mutationRates._geometryMutations[0] = GeometryMutationDesc().geneProbability(0.5f).valueChangeSigma(0.5f).enumChangeProbability(0.5f);
+    genome._mutationRates._geometryMutations[1] = GeometryMutationDesc().geneProbability(0.4f).valueChangeSigma(0.4f).enumChangeProbability(0.4f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -233,10 +233,10 @@ TEST_F(MetaMutationTests, metaMutation_geometryRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._nodeProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._geneProbability, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._valueChangeSigma, 0.5f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[0]._enumChangeProbability, 0.5f);
-    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._nodeProbability, 0.4f);
+    EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._geneProbability, 0.4f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._valueChangeSigma, 0.4f);
     EXPECT_EQ(actualGenome._mutationRates._geometryMutations[1]._enumChangeProbability, 0.4f);
 }

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -109,19 +109,6 @@ namespace
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
                 &mutation._nodeProbability);
-            AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
-                &mutation._valueChangeSigma);
-            AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters()
-                    .name("Enum change probability")
-                    .id(id)
-                    .min(0.0f)
-                    .max(1.0f)
-                    .logarithmic(true)
-                    .format("%.5f")
-                    .textWidth(rightColumnWidth),
-                &mutation._enumChangeProbability);
         }
         AlienGui::EndTreeNode();
     }
@@ -288,16 +275,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
             settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    for (auto i = 0; i < 2; ++i) {
-        auto const indexSuffix = i == 0 ? "1" : "2";
-
-        mutationRates._geometryMutations[i]._nodeProbability = settings.getValue(
-            settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
-        mutationRates._geometryMutations[i]._valueChangeSigma =
-            settings.getValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
-        mutationRates._geometryMutations[i]._enumChangeProbability = settings.getValue(
-            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
-    }
+    mutationRates._geometryMutation._nodeProbability =
+        settings.getValue(settingsPrefix + "geometry mutation.node probability", mutationRates._geometryMutation._nodeProbability);
 
     mutationRates._cellTypeModeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
@@ -365,14 +344,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
             settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    for (auto i = 0; i < 2; ++i) {
-        auto const indexSuffix = i == 0 ? "1" : "2";
-
-        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
-        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
-        settings.setValue(
-            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
-    }
+    settings.setValue(settingsPrefix + "geometry mutation.node probability", mutationRates._geometryMutation._nodeProbability);
 
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
@@ -439,10 +411,8 @@ void MutationRatesDialog::processIntern()
             sectionTable.next();
 
             if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Geometry mutations").rank(AlienGui::TreeNodeRank::High))) {
-                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
-                    processGeometryMutationRate("Mutation rate 1", "GEOM1", _mutation._geometryMutations[0], RightColumnWidth);
-                    table.next();
-                    processGeometryMutationRate("Mutation rate 2", "GEOM2", _mutation._geometryMutations[1], RightColumnWidth);
+                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeometryMutationRate("Mutation rate", "GEOM", _mutation._geometryMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -96,23 +96,6 @@ namespace
         AlienGui::EndTreeNode();
     }
 
-    void processGeometryMutationRate(std::string const& name, std::string const& id, GeometryMutationDesc& mutation, float rightColumnWidth)
-    {
-        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
-            AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters()
-                    .name("Node probability")
-                    .id(id)
-                    .min(0.0f)
-                    .max(1.0f)
-                    .logarithmic(true)
-                    .format("%.5f")
-                    .textWidth(rightColumnWidth),
-                &mutation._nodeProbability);
-        }
-        AlienGui::EndTreeNode();
-    }
-
     void processCellTypeModeMutationRate(std::string const& name, std::string const& id, CellTypeModeMutationDesc& mutation, float rightColumnWidth)
     {
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
@@ -275,8 +258,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
             settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    mutationRates._geometryMutation._nodeProbability =
-        settings.getValue(settingsPrefix + "geometry mutation.node probability", mutationRates._geometryMutation._nodeProbability);
+    mutationRates._geometryMutation._geneProbability =
+        settings.getValue(settingsPrefix + "geometry mutation.gene probability", mutationRates._geometryMutation._geneProbability);
 
     mutationRates._cellTypeModeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
@@ -344,7 +327,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
             settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    settings.setValue(settingsPrefix + "geometry mutation.node probability", mutationRates._geometryMutation._nodeProbability);
+    settings.setValue(settingsPrefix + "geometry mutation.gene probability", mutationRates._geometryMutation._geneProbability);
 
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
@@ -412,7 +395,7 @@ void MutationRatesDialog::processIntern()
 
             if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Geometry mutations").rank(AlienGui::TreeNodeRank::High))) {
                 processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
-                    processGeometryMutationRate("Mutation rate", "GEOM", _mutation._geometryMutation, RightColumnWidth);
+                    processGeneProbabilityMutationRate("Mutation rate", "GEOM", _mutation._geometryMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -101,14 +101,14 @@ namespace
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters()
-                    .name("Node probability")
+                    .name("Gene probability")
                     .id(id)
                     .min(0.0f)
                     .max(1.0f)
                     .logarithmic(true)
                     .format("%.5f")
                     .textWidth(rightColumnWidth),
-                &mutation._nodeProbability);
+                &mutation._geneProbability);
             AlienGui::SliderFloat(
                 AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
                 &mutation._valueChangeSigma);
@@ -291,8 +291,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
 
-        mutationRates._geometryMutations[i]._nodeProbability = settings.getValue(
-            settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        mutationRates._geometryMutations[i]._geneProbability = settings.getValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".gene probability", mutationRates._geometryMutations[i]._geneProbability);
         mutationRates._geometryMutations[i]._valueChangeSigma =
             settings.getValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
         mutationRates._geometryMutations[i]._enumChangeProbability = settings.getValue(
@@ -368,7 +368,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     for (auto i = 0; i < 2; ++i) {
         auto const indexSuffix = i == 0 ? "1" : "2";
 
-        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".gene probability", mutationRates._geometryMutations[i]._geneProbability);
         settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
         settings.setValue(
             settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -96,6 +96,36 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    void processGeometryMutationRate(std::string const& name, std::string const& id, GeometryMutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Node probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._nodeProbability);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._valueChangeSigma);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Enum change probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._enumChangeProbability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     void processCellTypeModeMutationRate(std::string const& name, std::string const& id, CellTypeModeMutationDesc& mutation, float rightColumnWidth)
     {
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
@@ -258,8 +288,16 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
             settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    mutationRates._geometryMutation._geneProbability =
-        settings.getValue(settingsPrefix + "geometry mutation.gene probability", mutationRates._geometryMutation._geneProbability);
+    for (auto i = 0; i < 2; ++i) {
+        auto const indexSuffix = i == 0 ? "1" : "2";
+
+        mutationRates._geometryMutations[i]._nodeProbability = settings.getValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        mutationRates._geometryMutations[i]._valueChangeSigma =
+            settings.getValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
+        mutationRates._geometryMutations[i]._enumChangeProbability = settings.getValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
+    }
 
     mutationRates._cellTypeModeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
@@ -327,7 +365,14 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
             settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
-    settings.setValue(settingsPrefix + "geometry mutation.gene probability", mutationRates._geometryMutation._geneProbability);
+    for (auto i = 0; i < 2; ++i) {
+        auto const indexSuffix = i == 0 ? "1" : "2";
+
+        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
+        settings.setValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
+    }
 
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
@@ -394,8 +439,10 @@ void MutationRatesDialog::processIntern()
             sectionTable.next();
 
             if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Geometry mutations").rank(AlienGui::TreeNodeRank::High))) {
-                processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
-                    processGeneProbabilityMutationRate("Mutation rate", "GEOM", _mutation._geometryMutation, RightColumnWidth);
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeometryMutationRate("Mutation rate 1", "GEOM1", _mutation._geometryMutations[0], RightColumnWidth);
+                    table.next();
+                    processGeometryMutationRate("Mutation rate 2", "GEOM2", _mutation._geometryMutations[1], RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -96,6 +96,36 @@ namespace
         AlienGui::EndTreeNode();
     }
 
+    void processGeometryMutationRate(std::string const& name, std::string const& id, GeometryMutationDesc& mutation, float rightColumnWidth)
+    {
+        if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Node probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._nodeProbability);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters().name("Value change sigma").id(id).min(0.0f).max(1.0f).logarithmic(true).format("%.3f").textWidth(rightColumnWidth),
+                &mutation._valueChangeSigma);
+            AlienGui::SliderFloat(
+                AlienGui::SliderFloatParameters()
+                    .name("Enum change probability")
+                    .id(id)
+                    .min(0.0f)
+                    .max(1.0f)
+                    .logarithmic(true)
+                    .format("%.5f")
+                    .textWidth(rightColumnWidth),
+                &mutation._enumChangeProbability);
+        }
+        AlienGui::EndTreeNode();
+    }
+
     void processCellTypeModeMutationRate(std::string const& name, std::string const& id, CellTypeModeMutationDesc& mutation, float rightColumnWidth)
     {
         if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name(name).rank(AlienGui::TreeNodeRank::Default))) {
@@ -258,6 +288,17 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
             settingsPrefix + "cell type property mutation" + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
+    for (auto i = 0; i < 2; ++i) {
+        auto const indexSuffix = i == 0 ? "1" : "2";
+
+        mutationRates._geometryMutations[i]._nodeProbability = settings.getValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        mutationRates._geometryMutations[i]._valueChangeSigma =
+            settings.getValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
+        mutationRates._geometryMutations[i]._enumChangeProbability = settings.getValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
+    }
+
     mutationRates._cellTypeModeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     mutationRates._cellTypeMutation._nodeProbability =
@@ -324,6 +365,15 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
             settingsPrefix + "cell type property mutation " + indexSuffix + ".discrete change probability", mutationRates._cellTypePropertiesMutations[i]._enumChangeProbability);
     }
 
+    for (auto i = 0; i < 2; ++i) {
+        auto const indexSuffix = i == 0 ? "1" : "2";
+
+        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".node probability", mutationRates._geometryMutations[i]._nodeProbability);
+        settings.setValue(settingsPrefix + "geometry mutation " + indexSuffix + ".sigma", mutationRates._geometryMutations[i]._valueChangeSigma);
+        settings.setValue(
+            settingsPrefix + "geometry mutation " + indexSuffix + ".discrete change probability", mutationRates._geometryMutations[i]._enumChangeProbability);
+    }
+
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
@@ -382,6 +432,17 @@ void MutationRatesDialog::processIntern()
                     processCellTypePropertiesMutationRate("Mutation rate 1", "CTPM1", _mutation._cellTypePropertiesMutations[0], RightColumnWidth);
                     table.next();
                     processCellTypePropertiesMutationRate("Mutation rate 2", "CTPM2", _mutation._cellTypePropertiesMutations[1], RightColumnWidth);
+                    table.next();
+                });
+            }
+            AlienGui::EndTreeNode();
+            sectionTable.next();
+
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Geometry mutations").rank(AlienGui::TreeNodeRank::High))) {
+                processConcreteMutationRates(2, [&](AlienGui::DynamicTableLayout& table) {
+                    processGeometryMutationRate("Mutation rate 1", "GEOM1", _mutation._geometryMutations[0], RightColumnWidth);
+                    table.next();
+                    processGeometryMutationRate("Mutation rate 2", "GEOM2", _mutation._geometryMutations[1], RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -44,8 +44,7 @@ namespace
             activeMutations,
             "Cell type property mut.",
             {mutationRates._cellTypePropertiesMutations[0]._nodeProbability, mutationRates._cellTypePropertiesMutations[1]._nodeProbability});
-        addActiveMutationType(
-            activeMutations, "Geometry mutations", {mutationRates._geometryMutations[0]._nodeProbability, mutationRates._geometryMutations[1]._nodeProbability});
+        addActiveMutationType(activeMutations, "Geometry mutations", {mutationRates._geometryMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -44,7 +44,8 @@ namespace
             activeMutations,
             "Cell type property mut.",
             {mutationRates._cellTypePropertiesMutations[0]._nodeProbability, mutationRates._cellTypePropertiesMutations[1]._nodeProbability});
-        addActiveMutationType(activeMutations, "Geometry mutations", {mutationRates._geometryMutation._geneProbability});
+        addActiveMutationType(
+            activeMutations, "Geometry mutations", {mutationRates._geometryMutations[0]._nodeProbability, mutationRates._geometryMutations[1]._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -44,6 +44,8 @@ namespace
             activeMutations,
             "Cell type property mut.",
             {mutationRates._cellTypePropertiesMutations[0]._nodeProbability, mutationRates._cellTypePropertiesMutations[1]._nodeProbability});
+        addActiveMutationType(
+            activeMutations, "Geometry mutations", {mutationRates._geometryMutations[0]._nodeProbability, mutationRates._geometryMutations[1]._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -44,7 +44,7 @@ namespace
             activeMutations,
             "Cell type property mut.",
             {mutationRates._cellTypePropertiesMutations[0]._nodeProbability, mutationRates._cellTypePropertiesMutations[1]._nodeProbability});
-        addActiveMutationType(activeMutations, "Geometry mutations", {mutationRates._geometryMutation._nodeProbability});
+        addActiveMutationType(activeMutations, "Geometry mutations", {mutationRates._geometryMutation._geneProbability});
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -45,7 +45,7 @@ namespace
             "Cell type property mut.",
             {mutationRates._cellTypePropertiesMutations[0]._nodeProbability, mutationRates._cellTypePropertiesMutations[1]._nodeProbability});
         addActiveMutationType(
-            activeMutations, "Geometry mutations", {mutationRates._geometryMutations[0]._nodeProbability, mutationRates._geometryMutations[1]._nodeProbability});
+            activeMutations, "Geometry mutations", {mutationRates._geometryMutations[0]._geneProbability, mutationRates._geometryMutations[1]._geneProbability});
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -299,7 +299,9 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_ValueChangeSigma = 1;
     auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
-    auto constexpr Id_GeometryMutation_GeneProbability = 0;
+    auto constexpr Id_GeometryMutation_NodeProbability = 0;
+    auto constexpr Id_GeometryMutation_ValueChangeSigma = 1;
+    auto constexpr Id_GeometryMutation_EnumChangeProbability = 2;
 
     auto constexpr Id_CellTypeModeMutation_NodeProbability = 0;
 
@@ -463,7 +465,8 @@ namespace
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
     auto constexpr Id_MutationRates_CopyNodeSectionMutation = 18;
     auto constexpr Id_MutationRates_MoveNodeSectionMutation = 19;
-    auto constexpr Id_MutationRates_GeometryMutation = 20;
+    auto constexpr Id_MutationRates_GeometryMutation1 = 20;
+    auto constexpr Id_MutationRates_GeometryMutation2 = 21;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -942,7 +945,9 @@ namespace cereal
     {
         GeometryMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
-        scope.addMember(Id_GeometryMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+        scope.addMember(Id_GeometryMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
+        scope.addMember(Id_GeometryMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
+        scope.addMember(Id_GeometryMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
     }
     SPLIT_SERIALIZATION(GeometryMutationDesc)
 
@@ -1068,7 +1073,8 @@ namespace cereal
         scope.addDesc(Id_MutationRates_ConnectionMutation2, data._connectionMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation1, data._cellTypePropertiesMutations[0]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation2, data._cellTypePropertiesMutations[1]);
-        scope.addDesc(Id_MutationRates_GeometryMutation, data._geometryMutation);
+        scope.addDesc(Id_MutationRates_GeometryMutation1, data._geometryMutations[0]);
+        scope.addDesc(Id_MutationRates_GeometryMutation2, data._geometryMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -299,7 +299,7 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_ValueChangeSigma = 1;
     auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
-    auto constexpr Id_GeometryMutation_NodeProbability = 0;
+    auto constexpr Id_GeometryMutation_GeneProbability = 0;
 
     auto constexpr Id_CellTypeModeMutation_NodeProbability = 0;
 
@@ -942,7 +942,7 @@ namespace cereal
     {
         GeometryMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
-        scope.addMember(Id_GeometryMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
+        scope.addMember(Id_GeometryMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
     }
     SPLIT_SERIALIZATION(GeometryMutationDesc)
 

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -299,7 +299,7 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_ValueChangeSigma = 1;
     auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
-    auto constexpr Id_GeometryMutation_NodeProbability = 0;
+    auto constexpr Id_GeometryMutation_GeneProbability = 0;
     auto constexpr Id_GeometryMutation_ValueChangeSigma = 1;
     auto constexpr Id_GeometryMutation_EnumChangeProbability = 2;
 
@@ -945,7 +945,7 @@ namespace cereal
     {
         GeometryMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
-        scope.addMember(Id_GeometryMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
+        scope.addMember(Id_GeometryMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
         scope.addMember(Id_GeometryMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
         scope.addMember(Id_GeometryMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
     }

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -300,8 +300,6 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
     auto constexpr Id_GeometryMutation_NodeProbability = 0;
-    auto constexpr Id_GeometryMutation_ValueChangeSigma = 1;
-    auto constexpr Id_GeometryMutation_EnumChangeProbability = 2;
 
     auto constexpr Id_CellTypeModeMutation_NodeProbability = 0;
 
@@ -465,8 +463,7 @@ namespace
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
     auto constexpr Id_MutationRates_CopyNodeSectionMutation = 18;
     auto constexpr Id_MutationRates_MoveNodeSectionMutation = 19;
-    auto constexpr Id_MutationRates_GeometryMutation1 = 20;
-    auto constexpr Id_MutationRates_GeometryMutation2 = 21;
+    auto constexpr Id_MutationRates_GeometryMutation = 20;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -946,8 +943,6 @@ namespace cereal
         GeometryMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_GeometryMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
-        scope.addMember(Id_GeometryMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
-        scope.addMember(Id_GeometryMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
     }
     SPLIT_SERIALIZATION(GeometryMutationDesc)
 
@@ -1073,8 +1068,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_ConnectionMutation2, data._connectionMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation1, data._cellTypePropertiesMutations[0]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation2, data._cellTypePropertiesMutations[1]);
-        scope.addDesc(Id_MutationRates_GeometryMutation1, data._geometryMutations[0]);
-        scope.addDesc(Id_MutationRates_GeometryMutation2, data._geometryMutations[1]);
+        scope.addDesc(Id_MutationRates_GeometryMutation, data._geometryMutation);
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -299,6 +299,10 @@ namespace
     auto constexpr Id_CellTypePropertiesMutation_ValueChangeSigma = 1;
     auto constexpr Id_CellTypePropertiesMutation_EnumChangeProbability = 2;
 
+    auto constexpr Id_GeometryMutation_NodeProbability = 0;
+    auto constexpr Id_GeometryMutation_ValueChangeSigma = 1;
+    auto constexpr Id_GeometryMutation_EnumChangeProbability = 2;
+
     auto constexpr Id_CellTypeModeMutation_NodeProbability = 0;
 
     auto constexpr Id_CellTypeMutation_NodeProbability = 0;
@@ -461,6 +465,8 @@ namespace
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
     auto constexpr Id_MutationRates_CopyNodeSectionMutation = 18;
     auto constexpr Id_MutationRates_MoveNodeSectionMutation = 19;
+    auto constexpr Id_MutationRates_GeometryMutation1 = 20;
+    auto constexpr Id_MutationRates_GeometryMutation2 = 21;
 
     auto constexpr Id_Genome_Genes = 6;
     auto constexpr Id_Genome_MutationRates = 7;
@@ -935,6 +941,17 @@ namespace cereal
     SPLIT_SERIALIZATION(CellTypePropertiesMutationDesc)
 
     template <class Archive>
+    void loadSave(SerializationTask task, Archive& ar, GeometryMutationDesc& data)
+    {
+        GeometryMutationDesc defaultObject;
+        auto scope = getSerializationScope(task, ar);
+        scope.addMember(Id_GeometryMutation_NodeProbability, data._nodeProbability, defaultObject._nodeProbability);
+        scope.addMember(Id_GeometryMutation_ValueChangeSigma, data._valueChangeSigma, defaultObject._valueChangeSigma);
+        scope.addMember(Id_GeometryMutation_EnumChangeProbability, data._enumChangeProbability, defaultObject._enumChangeProbability);
+    }
+    SPLIT_SERIALIZATION(GeometryMutationDesc)
+
+    template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, CellTypeModeMutationDesc& data)
     {
         CellTypeModeMutationDesc defaultObject;
@@ -1056,6 +1073,8 @@ namespace cereal
         scope.addDesc(Id_MutationRates_ConnectionMutation2, data._connectionMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation1, data._cellTypePropertiesMutations[0]);
         scope.addDesc(Id_MutationRates_CellTypePropertiesMutation2, data._cellTypePropertiesMutations[1]);
+        scope.addDesc(Id_MutationRates_GeometryMutation1, data._geometryMutations[0]);
+        scope.addDesc(Id_MutationRates_GeometryMutation2, data._geometryMutations[1]);
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);


### PR DESCRIPTION
## Summary
- Add `GeometryMutation` type that mutates `Gene::shape`, `stiffness` and `connectionDistance`, mirroring `CellTypePropertiesMutation` (`nodeProbability`, `valueChangeSigma`, `enumChangeProbability`), with 2 rate-slot instances.
- Wire it through the kernel struct/TO layers (both GPU-side and host-side `DescConverterService`), validation, hash, genome-preview reset, serializer, GUI (`MutationRatesDialog`/`MutationRatesWidget`), and `DescTestDataFactory`.
- Add `GeometryMutationTests.cpp` and a parity case in `AccumulatedMutationTests.cpp`.

## Test plan
- [x] `EngineInterfaceTests.exe` — 159/159 passed
- [x] `PersisterTests.exe` — 64/64 passed
- [x] `NetworkTests.exe` — 4/4 passed
- [x] `EngineTests.exe` (GPU) — 3066/3066 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)