### PR TITLE
Auto-focus parameter filter on typing

### DIFF
--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -258,6 +258,9 @@ void SimulationParametersMainWindow::processDetailWidget()
             //AlienGui::ResetFilterText();
 
             ImGui::Spacing();
+            if (shouldStartFilterTyping()) {
+                ImGui::SetKeyboardFocusHere();
+            }
             AlienGui::InputFilter(AlienGui::InputFilterParameters().width(250.0f), _filter);
         }
         AlienGui::EndTreeNode();
@@ -269,6 +272,19 @@ void SimulationParametersMainWindow::processDetailWidget()
         AlienGui::MovableHorizontalSeparator(AlienGui::MovableHorizontalSeparatorParameters().additive(false), _expertWidgetHeight);
         ImGui::PopID();
     }
+}
+
+bool SimulationParametersMainWindow::shouldStartFilterTyping() const
+{
+    if (ImGui::IsAnyItemActive() || !ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows)) {
+        return false;
+    }
+    for (auto const& c : ImGui::GetIO().InputQueueCharacters) {
+        if (c >= 32 && c != 127) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void SimulationParametersMainWindow::processExpertWidget()

--- a/source/Gui/SimulationParametersMainWindow.h
+++ b/source/Gui/SimulationParametersMainWindow.h
@@ -26,6 +26,8 @@ private:
     void processExpertWidget();
     void processStatusBar();
 
+    bool shouldStartFilterTyping() const;
+
     struct Location
     {
         std::string name;


### PR DESCRIPTION
## Summary
In the simulation parameters window the filter field now grabs keyboard focus the moment the user starts typing — no need to click into the filter widget first.

## Details
- `SimulationParametersMainWindow::shouldStartFilterTyping()` returns true when the window (incl. child windows) is focused, no other item is active, and a printable character was entered this frame.
- When true, `ImGui::SetKeyboardFocusHere()` is called right before the filter `InputText`, so the first typed character already lands in the filter.
- Focus is only forced on the initial frame; once the input is active `IsAnyItemActive()` is true, so there is no focus-fighting.

## Test
- Release build (`build-windows-ninja.bat 16`) succeeds, `alien.exe` links.
- GUI-only change; no engine/network/persistence tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)