### PR TITLE
Rename AppendNodeMutation and TrimNodeMutation to gene-level naming

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -891,7 +891,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._mutationRates._cellTypeModeMutation._nodeProbability = genomeTO.mutationRates.cellTypeModeMutation.nodeProbability;
     result._mutationRates._cellTypeMutation._nodeProbability = genomeTO.mutationRates.cellTypeMutation.nodeProbability;
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
-    result._mutationRates._appendNodeMutation._geneProbability = genomeTO.mutationRates.appendNodeMutation.geneProbability;
+    result._mutationRates._extendGeneMutation._geneProbability = genomeTO.mutationRates.extendGeneMutation.geneProbability;
     result._mutationRates._addNodeMutation._nodeProbability = genomeTO.mutationRates.addNodeMutation.nodeProbability;
     result._mutationRates._trimNodeMutation._geneProbability = genomeTO.mutationRates.trimNodeMutation.geneProbability;
     result._mutationRates._deleteNodeMutation._nodeProbability = genomeTO.mutationRates.deleteNodeMutation.nodeProbability;
@@ -1001,7 +1001,7 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.mutationRates.cellTypeModeMutation = {genome._mutationRates._cellTypeModeMutation._nodeProbability};
     genomeTO.mutationRates.cellTypeMutation = {genome._mutationRates._cellTypeMutation._nodeProbability};
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};
-    genomeTO.mutationRates.appendNodeMutation = {genome._mutationRates._appendNodeMutation._geneProbability};
+    genomeTO.mutationRates.extendGeneMutation = {genome._mutationRates._extendGeneMutation._geneProbability};
     genomeTO.mutationRates.addNodeMutation = {genome._mutationRates._addNodeMutation._nodeProbability};
     genomeTO.mutationRates.trimNodeMutation = {genome._mutationRates._trimNodeMutation._geneProbability};
     genomeTO.mutationRates.deleteNodeMutation = {genome._mutationRates._deleteNodeMutation._nodeProbability};

--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -893,7 +893,7 @@ GenomeDesc DescConverterService::createGenomeDesc(TOs const& to, int genomeIndex
     result._mutationRates._voidMutation._nodeProbability = genomeTO.mutationRates.voidMutation.nodeProbability;
     result._mutationRates._extendGeneMutation._geneProbability = genomeTO.mutationRates.extendGeneMutation.geneProbability;
     result._mutationRates._addNodeMutation._nodeProbability = genomeTO.mutationRates.addNodeMutation.nodeProbability;
-    result._mutationRates._trimNodeMutation._geneProbability = genomeTO.mutationRates.trimNodeMutation.geneProbability;
+    result._mutationRates._trimGeneMutation._geneProbability = genomeTO.mutationRates.trimGeneMutation.geneProbability;
     result._mutationRates._deleteNodeMutation._nodeProbability = genomeTO.mutationRates.deleteNodeMutation.nodeProbability;
     result._mutationRates._duplicateGeneMutation._geneProbability = genomeTO.mutationRates.duplicateGeneMutation.geneProbability;
     result._mutationRates._deleteGeneMutation._geneProbability = genomeTO.mutationRates.deleteGeneMutation.geneProbability;
@@ -1003,7 +1003,7 @@ void DescConverterService::convertGenomeToTO(
     genomeTO.mutationRates.voidMutation = {genome._mutationRates._voidMutation._nodeProbability};
     genomeTO.mutationRates.extendGeneMutation = {genome._mutationRates._extendGeneMutation._geneProbability};
     genomeTO.mutationRates.addNodeMutation = {genome._mutationRates._addNodeMutation._nodeProbability};
-    genomeTO.mutationRates.trimNodeMutation = {genome._mutationRates._trimNodeMutation._geneProbability};
+    genomeTO.mutationRates.trimGeneMutation = {genome._mutationRates._trimGeneMutation._geneProbability};
     genomeTO.mutationRates.deleteNodeMutation = {genome._mutationRates._deleteNodeMutation._nodeProbability};
     genomeTO.mutationRates.duplicateGeneMutation = {genome._mutationRates._duplicateGeneMutation._geneProbability};
     genomeTO.mutationRates.deleteGeneMutation = {genome._mutationRates._deleteGeneMutation._geneProbability};

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -55,8 +55,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         std::clamp(genome._mutationRates._extendGeneMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._addNodeMutation._nodeProbability =
         std::clamp(genome._mutationRates._addNodeMutation._nodeProbability, 0.0f, 1.0f);
-    genome._mutationRates._trimNodeMutation._geneProbability =
-        std::clamp(genome._mutationRates._trimNodeMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._trimGeneMutation._geneProbability =
+        std::clamp(genome._mutationRates._trimGeneMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._deleteNodeMutation._nodeProbability =
         std::clamp(genome._mutationRates._deleteNodeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._duplicateGeneMutation._geneProbability =

--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -51,8 +51,8 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
         std::clamp(genome._mutationRates._cellTypeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._voidMutation._nodeProbability =
         std::clamp(genome._mutationRates._voidMutation._nodeProbability, 0.0f, 1.0f);
-    genome._mutationRates._appendNodeMutation._geneProbability =
-        std::clamp(genome._mutationRates._appendNodeMutation._geneProbability, 0.0f, 1.0f);
+    genome._mutationRates._extendGeneMutation._geneProbability =
+        std::clamp(genome._mutationRates._extendGeneMutation._geneProbability, 0.0f, 1.0f);
     genome._mutationRates._addNodeMutation._nodeProbability =
         std::clamp(genome._mutationRates._addNodeMutation._nodeProbability, 0.0f, 1.0f);
     genome._mutationRates._trimNodeMutation._geneProbability =

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -469,11 +469,11 @@ struct VoidMutationDesc
     MEMBER(VoidMutationDesc, float, nodeProbability, 0.0f);
 };
 
-struct AppendNodeMutationDesc
+struct ExtendGeneMutationDesc
 {
-    auto operator<=>(AppendNodeMutationDesc const&) const = default;
+    auto operator<=>(ExtendGeneMutationDesc const&) const = default;
 
-    MEMBER(AppendNodeMutationDesc, float, geneProbability, 0.0f);
+    MEMBER(ExtendGeneMutationDesc, float, geneProbability, 0.0f);
 };
 
 struct AddNodeMutationDesc
@@ -574,7 +574,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, CellTypeModeMutationDesc, cellTypeModeMutation, CellTypeModeMutationDesc());
     MEMBER(MutationRatesDesc, CellTypeMutationDesc, cellTypeMutation, CellTypeMutationDesc());
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
-    MEMBER(MutationRatesDesc, AppendNodeMutationDesc, appendNodeMutation, AppendNodeMutationDesc());
+    MEMBER(MutationRatesDesc, ExtendGeneMutationDesc, extendGeneMutation, ExtendGeneMutationDesc());
     MEMBER(MutationRatesDesc, AddNodeMutationDesc, addNodeMutation, AddNodeMutationDesc());
     MEMBER(MutationRatesDesc, TrimNodeMutationDesc, trimNodeMutation, TrimNodeMutationDesc());
     MEMBER(MutationRatesDesc, DeleteNodeMutationDesc, deleteNodeMutation, DeleteNodeMutationDesc());

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -483,11 +483,11 @@ struct AddNodeMutationDesc
     MEMBER(AddNodeMutationDesc, float, nodeProbability, 0.0f);
 };
 
-struct TrimNodeMutationDesc
+struct TrimGeneMutationDesc
 {
-    auto operator<=>(TrimNodeMutationDesc const&) const = default;
+    auto operator<=>(TrimGeneMutationDesc const&) const = default;
 
-    MEMBER(TrimNodeMutationDesc, float, geneProbability, 0.0f);
+    MEMBER(TrimGeneMutationDesc, float, geneProbability, 0.0f);
 };
 
 struct DeleteNodeMutationDesc
@@ -576,7 +576,7 @@ struct MutationRatesDesc
     MEMBER(MutationRatesDesc, VoidMutationDesc, voidMutation, VoidMutationDesc());
     MEMBER(MutationRatesDesc, ExtendGeneMutationDesc, extendGeneMutation, ExtendGeneMutationDesc());
     MEMBER(MutationRatesDesc, AddNodeMutationDesc, addNodeMutation, AddNodeMutationDesc());
-    MEMBER(MutationRatesDesc, TrimNodeMutationDesc, trimNodeMutation, TrimNodeMutationDesc());
+    MEMBER(MutationRatesDesc, TrimGeneMutationDesc, trimGeneMutation, TrimGeneMutationDesc());
     MEMBER(MutationRatesDesc, DeleteNodeMutationDesc, deleteNodeMutation, DeleteNodeMutationDesc());
     MEMBER(MutationRatesDesc, CopyNodeSectionMutationDesc, copyNodeSectionMutation, CopyNodeSectionMutationDesc());
     MEMBER(MutationRatesDesc, MoveNodeSectionMutationDesc, moveNodeSectionMutation, MoveNodeSectionMutationDesc());

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -565,7 +565,7 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._extendGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._addNodeMutation._nodeProbability);
-        hash_combine(seed, desc._mutationRates._trimNodeMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._trimGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._deleteNodeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._duplicateGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._deleteGeneMutation._geneProbability);

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -563,7 +563,7 @@ struct std::hash<GenomeDesc>
         hash_combine(seed, desc._mutationRates._cellTypeModeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._cellTypeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._voidMutation._nodeProbability);
-        hash_combine(seed, desc._mutationRates._appendNodeMutation._geneProbability);
+        hash_combine(seed, desc._mutationRates._extendGeneMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._addNodeMutation._nodeProbability);
         hash_combine(seed, desc._mutationRates._trimNodeMutation._geneProbability);
         hash_combine(seed, desc._mutationRates._deleteNodeMutation._nodeProbability);

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -499,9 +499,9 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::voidMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
-                        .name("Append node mutation sigma")
+                        .name("Extend gene mutation sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::appendNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::extendGeneMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Add node mutation sigma")
                         .reference(

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -507,9 +507,9 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .reference(
                             FloatSpec().member(&SimulationParameters::addNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
-                        .name("Trim node mutation sigma")
+                        .name("Trim gene mutation sigma")
                         .reference(
-                            FloatSpec().member(&SimulationParameters::trimNodeMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
+                            FloatSpec().member(&SimulationParameters::trimGeneMetaMutationsSigma).min(0.0f).max(1.0f).logarithmic(true).format("%.5f")),
                     ParameterSpec()
                         .name("Delete node mutation sigma")
                         .reference(

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -118,7 +118,7 @@ struct SimulationParameters
     BaseParameter<float> voidMetaMutationsSigma = {0};
     BaseParameter<float> extendGeneMetaMutationsSigma = {0};
     BaseParameter<float> addNodeMetaMutationsSigma = {0};
-    BaseParameter<float> trimNodeMetaMutationsSigma = {0};
+    BaseParameter<float> trimGeneMetaMutationsSigma = {0};
     BaseParameter<float> deleteNodeMetaMutationsSigma = {0};
     BaseParameter<float> duplicateGeneMetaMutationsSigma = {0};
     BaseParameter<float> deleteGeneMetaMutationsSigma = {0};

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -116,7 +116,7 @@ struct SimulationParameters
     BaseParameter<float> cellTypeModeMetaMutationsSigma = {0};
     BaseParameter<float> cellTypeMetaMutationsSigma = {0};
     BaseParameter<float> voidMetaMutationsSigma = {0};
-    BaseParameter<float> appendNodeMetaMutationsSigma = {0};
+    BaseParameter<float> extendGeneMetaMutationsSigma = {0};
     BaseParameter<float> addNodeMetaMutationsSigma = {0};
     BaseParameter<float> trimNodeMetaMutationsSigma = {0};
     BaseParameter<float> deleteNodeMetaMutationsSigma = {0};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -61,7 +61,7 @@ namespace
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};
             genomeTO.mutationRates.extendGeneMutation = {genome->mutationRates.extendGeneMutation.geneProbability};
             genomeTO.mutationRates.addNodeMutation = {genome->mutationRates.addNodeMutation.nodeProbability};
-            genomeTO.mutationRates.trimNodeMutation = {genome->mutationRates.trimNodeMutation.geneProbability};
+            genomeTO.mutationRates.trimGeneMutation = {genome->mutationRates.trimGeneMutation.geneProbability};
             genomeTO.mutationRates.deleteNodeMutation = {genome->mutationRates.deleteNodeMutation.nodeProbability};
             genomeTO.mutationRates.duplicateGeneMutation = {genome->mutationRates.duplicateGeneMutation.geneProbability};
             genomeTO.mutationRates.deleteGeneMutation = {genome->mutationRates.deleteGeneMutation.geneProbability};

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -59,7 +59,7 @@ namespace
             genomeTO.mutationRates.cellTypeModeMutation = {genome->mutationRates.cellTypeModeMutation.nodeProbability};
             genomeTO.mutationRates.cellTypeMutation = {genome->mutationRates.cellTypeMutation.nodeProbability};
             genomeTO.mutationRates.voidMutation = {genome->mutationRates.voidMutation.nodeProbability};
-            genomeTO.mutationRates.appendNodeMutation = {genome->mutationRates.appendNodeMutation.geneProbability};
+            genomeTO.mutationRates.extendGeneMutation = {genome->mutationRates.extendGeneMutation.geneProbability};
             genomeTO.mutationRates.addNodeMutation = {genome->mutationRates.addNodeMutation.nodeProbability};
             genomeTO.mutationRates.trimNodeMutation = {genome->mutationRates.trimNodeMutation.geneProbability};
             genomeTO.mutationRates.deleteNodeMutation = {genome->mutationRates.deleteNodeMutation.nodeProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -117,7 +117,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};
     genome->mutationRates.extendGeneMutation = {genomeTO.mutationRates.extendGeneMutation.geneProbability};
     genome->mutationRates.addNodeMutation = {genomeTO.mutationRates.addNodeMutation.nodeProbability};
-    genome->mutationRates.trimNodeMutation = {genomeTO.mutationRates.trimNodeMutation.geneProbability};
+    genome->mutationRates.trimGeneMutation = {genomeTO.mutationRates.trimGeneMutation.geneProbability};
     genome->mutationRates.deleteNodeMutation = {genomeTO.mutationRates.deleteNodeMutation.nodeProbability};
     genome->mutationRates.duplicateGeneMutation = {genomeTO.mutationRates.duplicateGeneMutation.geneProbability};
     genome->mutationRates.deleteGeneMutation = {genomeTO.mutationRates.deleteGeneMutation.geneProbability};

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -115,7 +115,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
     genome->mutationRates.cellTypeModeMutation = {genomeTO.mutationRates.cellTypeModeMutation.nodeProbability};
     genome->mutationRates.cellTypeMutation = {genomeTO.mutationRates.cellTypeMutation.nodeProbability};
     genome->mutationRates.voidMutation = {genomeTO.mutationRates.voidMutation.nodeProbability};
-    genome->mutationRates.appendNodeMutation = {genomeTO.mutationRates.appendNodeMutation.geneProbability};
+    genome->mutationRates.extendGeneMutation = {genomeTO.mutationRates.extendGeneMutation.geneProbability};
     genome->mutationRates.addNodeMutation = {genomeTO.mutationRates.addNodeMutation.nodeProbability};
     genome->mutationRates.trimNodeMutation = {genomeTO.mutationRates.trimNodeMutation.geneProbability};
     genome->mutationRates.deleteNodeMutation = {genomeTO.mutationRates.deleteNodeMutation.nodeProbability};

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -393,7 +393,7 @@ struct AddNodeMutation
     float nodeProbability;
 };
 
-struct TrimNodeMutation
+struct TrimGeneMutation
 {
     float geneProbability;
 };
@@ -442,7 +442,7 @@ struct MutationRates
     VoidMutation voidMutation;
     ExtendGeneMutation extendGeneMutation;
     AddNodeMutation addNodeMutation;
-    TrimNodeMutation trimNodeMutation;
+    TrimGeneMutation trimGeneMutation;
     DeleteNodeMutation deleteNodeMutation;
     CopyNodeSectionMutation copyNodeSectionMutation;
     MoveNodeSectionMutation moveNodeSectionMutation;

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -383,7 +383,7 @@ struct VoidMutation
     float nodeProbability;
 };
 
-struct AppendNodeMutation
+struct ExtendGeneMutation
 {
     float geneProbability;
 };
@@ -440,7 +440,7 @@ struct MutationRates
     CellTypeModeMutation cellTypeModeMutation;
     CellTypeMutation cellTypeMutation;
     VoidMutation voidMutation;
-    AppendNodeMutation appendNodeMutation;
+    ExtendGeneMutation extendGeneMutation;
     AddNodeMutation addNodeMutation;
     TrimNodeMutation trimNodeMutation;
     DeleteNodeMutation deleteNodeMutation;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -388,7 +388,7 @@ struct VoidMutationTO
     float nodeProbability;
 };
 
-struct AppendNodeMutationTO
+struct ExtendGeneMutationTO
 {
     float geneProbability;
 };
@@ -445,7 +445,7 @@ struct MutationRatesTO
     CellTypeModeMutationTO cellTypeModeMutation;
     CellTypeMutationTO cellTypeMutation;
     VoidMutationTO voidMutation;
-    AppendNodeMutationTO appendNodeMutation;
+    ExtendGeneMutationTO extendGeneMutation;
     AddNodeMutationTO addNodeMutation;
     TrimNodeMutationTO trimNodeMutation;
     DeleteNodeMutationTO deleteNodeMutation;

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -398,7 +398,7 @@ struct AddNodeMutationTO
     float nodeProbability;
 };
 
-struct TrimNodeMutationTO
+struct TrimGeneMutationTO
 {
     float geneProbability;
 };
@@ -447,7 +447,7 @@ struct MutationRatesTO
     VoidMutationTO voidMutation;
     ExtendGeneMutationTO extendGeneMutation;
     AddNodeMutationTO addNodeMutation;
-    TrimNodeMutationTO trimNodeMutation;
+    TrimGeneMutationTO trimGeneMutation;
     DeleteNodeMutationTO deleteNodeMutation;
     CopyNodeSectionMutationTO copyNodeSectionMutation;
     MoveNodeSectionMutationTO moveNodeSectionMutation;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -34,7 +34,7 @@ private:
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_extendGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_addNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
-    __inline__ __device__ static void applyMutations_trimNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_trimGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_deleteNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_duplicateGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_deleteGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -92,11 +92,11 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     block.sync();
     auto const& nodeRates = genome->mutationRates;
     bool anyNodeMutation = nodeRates.extendGeneMutation.geneProbability > 0 || nodeRates.addNodeMutation.nodeProbability > 0
-        || nodeRates.trimNodeMutation.geneProbability > 0 || nodeRates.deleteNodeMutation.nodeProbability > 0;
+        || nodeRates.trimGeneMutation.geneProbability > 0 || nodeRates.deleteNodeMutation.nodeProbability > 0;
     if (anyNodeMutation) {
         applyMutations_extendGene(data, genome, accumulatedMutations);
         applyMutations_addNode(data, genome, accumulatedMutations);
-        applyMutations_trimNode(data, genome, accumulatedMutations);
+        applyMutations_trimGene(data, genome, accumulatedMutations);
         applyMutations_deleteNode(data, genome, accumulatedMutations);
         block.sync();
         correctGenome(data, genome);
@@ -996,10 +996,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_addNode(SimulationD
     }
 }
 
-__inline__ __device__ void MutationProcessor::applyMutations_trimNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+__inline__ __device__ void MutationProcessor::applyMutations_trimGene(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
-    auto const& rate = genome->mutationRates.trimNodeMutation;
+    auto const& rate = genome->mutationRates.trimGeneMutation;
     if (rate.geneProbability <= 0) {
         return;
     }
@@ -1699,10 +1699,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             mutateFloat(genome->mutationRates.addNodeMutation.nodeProbability);
         }
 
-        float trimNodeSigma = cudaSimulationParameters.trimNodeMetaMutationsSigma.value;
-        if (trimNodeSigma > 0) {
-            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * trimNodeSigma)); };
-            mutateFloat(genome->mutationRates.trimNodeMutation.geneProbability);
+        float trimGeneSigma = cudaSimulationParameters.trimGeneMetaMutationsSigma.value;
+        if (trimGeneSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * trimGeneSigma)); };
+            mutateFloat(genome->mutationRates.trimGeneMutation.geneProbability);
         }
 
         float deleteNodeSigma = cudaSimulationParameters.deleteNodeMetaMutationsSigma.value;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -32,7 +32,7 @@ private:
     __inline__ __device__ static void applyMutations_cellTypeMode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_cellType(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_void(SimulationData& data, Genome* genome, float& accumulatedMutations);
-    __inline__ __device__ static void applyMutations_appendNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void applyMutations_extendGene(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_addNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_trimNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
     __inline__ __device__ static void applyMutations_deleteNode(SimulationData& data, Genome* genome, float& accumulatedMutations);
@@ -91,10 +91,10 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     // sync since following mutations may change entire genes
     block.sync();
     auto const& nodeRates = genome->mutationRates;
-    bool anyNodeMutation = nodeRates.appendNodeMutation.geneProbability > 0 || nodeRates.addNodeMutation.nodeProbability > 0
+    bool anyNodeMutation = nodeRates.extendGeneMutation.geneProbability > 0 || nodeRates.addNodeMutation.nodeProbability > 0
         || nodeRates.trimNodeMutation.geneProbability > 0 || nodeRates.deleteNodeMutation.nodeProbability > 0;
     if (anyNodeMutation) {
-        applyMutations_appendNode(data, genome, accumulatedMutations);
+        applyMutations_extendGene(data, genome, accumulatedMutations);
         applyMutations_addNode(data, genome, accumulatedMutations);
         applyMutations_trimNode(data, genome, accumulatedMutations);
         applyMutations_deleteNode(data, genome, accumulatedMutations);
@@ -951,10 +951,10 @@ __inline__ __device__ void MutationProcessor::removeNode(SimulationData& data, G
     gene.numNodes = newNumNodes;
 }
 
-__inline__ __device__ void MutationProcessor::applyMutations_appendNode(SimulationData& data, Genome* genome, float& accumulatedMutations)
+__inline__ __device__ void MutationProcessor::applyMutations_extendGene(SimulationData& data, Genome* genome, float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
-    auto const& rate = genome->mutationRates.appendNodeMutation;
+    auto const& rate = genome->mutationRates.extendGeneMutation;
     if (rate.geneProbability <= 0) {
         return;
     }
@@ -1687,10 +1687,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
             mutateFloat(genome->mutationRates.voidMutation.nodeProbability);
         }
 
-        float appendNodeSigma = cudaSimulationParameters.appendNodeMetaMutationsSigma.value;
-        if (appendNodeSigma > 0) {
-            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * appendNodeSigma)); };
-            mutateFloat(genome->mutationRates.appendNodeMutation.geneProbability);
+        float extendGeneSigma = cudaSimulationParameters.extendGeneMetaMutationsSigma.value;
+        if (extendGeneSigma > 0) {
+            auto mutateFloat = [&](float& val) { val = min(1.0f, max(0.0f, val + generateGaussian(data) * extendGeneSigma)); };
+            mutateFloat(genome->mutationRates.extendGeneMutation.geneProbability);
         }
 
         float addNodeSigma = cudaSimulationParameters.addNodeMetaMutationsSigma.value;

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -188,7 +188,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .cellTypeModeMutation(CellTypeModeMutationDesc().nodeProbability(0.33f))
                         .cellTypeMutation(CellTypeMutationDesc().nodeProbability(0.22f))
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))
-                        .appendNodeMutation(AppendNodeMutationDesc().geneProbability(0.41f))
+                        .extendGeneMutation(ExtendGeneMutationDesc().geneProbability(0.41f))
                         .addNodeMutation(AddNodeMutationDesc().nodeProbability(0.42f))
                         .trimNodeMutation(TrimNodeMutationDesc().geneProbability(0.43f))
                         .deleteNodeMutation(DeleteNodeMutationDesc().nodeProbability(0.44f))

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -190,7 +190,7 @@ std::pair<CreatureDesc, GenomeDesc> DescTestDataFactory::createNonDefaultCreatur
                         .voidMutation(VoidMutationDesc().nodeProbability(0.11f))
                         .extendGeneMutation(ExtendGeneMutationDesc().geneProbability(0.41f))
                         .addNodeMutation(AddNodeMutationDesc().nodeProbability(0.42f))
-                        .trimNodeMutation(TrimNodeMutationDesc().geneProbability(0.43f))
+                        .trimGeneMutation(TrimGeneMutationDesc().geneProbability(0.43f))
                         .deleteNodeMutation(DeleteNodeMutationDesc().nodeProbability(0.44f))
                         .duplicateGeneMutation(DuplicateGeneMutationDesc().geneProbability(0.45f))
                         .deleteGeneMutation(DeleteGeneMutationDesc().geneProbability(0.46f))

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -20,7 +20,7 @@ enum class MutationType
     Void,
     ExtendGene,
     AddNode,
-    TrimNode,
+    TrimGene,
     DeleteNode,
     Constructor
 };
@@ -44,7 +44,7 @@ INSTANTIATE_TEST_SUITE_P(
         MutationType::Void,
         MutationType::ExtendGene,
         MutationType::AddNode,
-        MutationType::TrimNode,
+        MutationType::TrimGene,
         MutationType::DeleteNode,
         MutationType::Constructor));
 
@@ -82,8 +82,8 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
         // exhaust the genome heap over the 100 passes below. A small probability still accumulates mutations reliably.
         genome._mutationRates._addNodeMutation = AddNodeMutationDesc().nodeProbability(0.02f);
         break;
-    case MutationType::TrimNode:
-        genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+    case MutationType::TrimGene:
+        genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(1.0f);
         break;
     case MutationType::DeleteNode:
         genome._mutationRates._deleteNodeMutation = DeleteNodeMutationDesc().nodeProbability(1.0f);
@@ -124,7 +124,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.voidMetaMutationsSigma.value = 1.0f;
     _parameters.extendGeneMetaMutationsSigma.value = 1.0f;
     _parameters.addNodeMetaMutationsSigma.value = 1.0f;
-    _parameters.trimNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.trimGeneMetaMutationsSigma.value = 1.0f;
     _parameters.deleteNodeMetaMutationsSigma.value = 1.0f;
     _parameters.constructorMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);

--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -18,7 +18,7 @@ enum class MutationType
     CellTypeMode,
     CellType,
     Void,
-    AppendNode,
+    ExtendGene,
     AddNode,
     TrimNode,
     DeleteNode,
@@ -42,7 +42,7 @@ INSTANTIATE_TEST_SUITE_P(
         MutationType::CellTypeMode,
         MutationType::CellType,
         MutationType::Void,
-        MutationType::AppendNode,
+        MutationType::ExtendGene,
         MutationType::AddNode,
         MutationType::TrimNode,
         MutationType::DeleteNode,
@@ -74,8 +74,8 @@ TEST_P(AccumulatedMutationTests_AllTypes, accumulatedMutations_increases)
     case MutationType::Void:
         genome._mutationRates._voidMutation = VoidMutationDesc().nodeProbability(1.0f);
         break;
-    case MutationType::AppendNode:
-        genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+    case MutationType::ExtendGene:
+        genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(1.0f);
         break;
     case MutationType::AddNode:
         // Per-node probability: inserting before every node compounds the genome each pass, so a full probability would
@@ -122,7 +122,7 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
     _parameters.cellTypeModeMetaMutationsSigma.value = 1.0f;
     _parameters.cellTypeMetaMutationsSigma.value = 1.0f;
     _parameters.voidMetaMutationsSigma.value = 1.0f;
-    _parameters.appendNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.extendGeneMetaMutationsSigma.value = 1.0f;
     _parameters.addNodeMetaMutationsSigma.value = 1.0f;
     _parameters.trimNodeMetaMutationsSigma.value = 1.0f;
     _parameters.deleteNodeMetaMutationsSigma.value = 1.0f;

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -52,7 +52,7 @@ PUBLIC
     SimulationControlTests.cpp
     StatisticsTests.cpp
     Testsuite.cpp
-    TrimNodeMutationTests.cpp
+    TrimGeneMutationTests.cpp
     VoidMutationTests.cpp
     VoidTests.cpp)
 

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(EngineTests
 PUBLIC
     AccumulatedMutationTests.cpp
     AddNodeMutationTests.cpp
-    AppendNodeMutationTests.cpp
+    ExtendGeneMutationTests.cpp
     AttackerTests.cpp
     BalanceTests.cpp
     CellStateTransitionTests.cpp

--- a/source/EngineTests/ExtendGeneMutationTests.cpp
+++ b/source/EngineTests/ExtendGeneMutationTests.cpp
@@ -6,13 +6,13 @@
 
 #include "MutationTestsBase.h"
 
-class AppendNodeMutationTests : public MutationTestsBase
+class ExtendGeneMutationTests : public MutationTestsBase
 {};
 
-TEST_F(AppendNodeMutationTests, appendNodeMutation_addsExactlyOneNodePerPass)
+TEST_F(ExtendGeneMutationTests, extendGeneMutation_addsExactlyOneNodePerPass)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -30,10 +30,10 @@ TEST_F(AppendNodeMutationTests, appendNodeMutation_addsExactlyOneNodePerPass)
     }
 }
 
-TEST_F(AppendNodeMutationTests, appendNodeMutation_newNodeInheritsNeighborColor)
+TEST_F(ExtendGeneMutationTests, extendGeneMutation_newNodeInheritsNeighborColor)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().color(3), NodeDesc().color(3)})});
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -48,10 +48,10 @@ TEST_F(AppendNodeMutationTests, appendNodeMutation_newNodeInheritsNeighborColor)
     }
 }
 
-TEST_F(AppendNodeMutationTests, appendNodeMutation_zeroProbabilityNoChange)
+TEST_F(ExtendGeneMutationTests, extendGeneMutation_zeroProbabilityNoChange)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.0f);
+    genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -443,14 +443,14 @@ TEST_F(MetaMutationTests, metaMutation_addNodeRatesZeroSigmaNoChange)
     EXPECT_EQ(actualGenome._mutationRates._addNodeMutation._nodeProbability, 0.5f);
 }
 
-TEST_F(MetaMutationTests, metaMutation_trimNodeRatesActuallyChange)
+TEST_F(MetaMutationTests, metaMutation_trimGeneRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.trimNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.trimGeneMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -459,19 +459,19 @@ TEST_F(MetaMutationTests, metaMutation_trimNodeRatesActuallyChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.5f));
-    EXPECT_GE(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.0f);
-    EXPECT_LE(actualGenome._mutationRates._trimNodeMutation._geneProbability, 1.0f);
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._trimGeneMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._trimGeneMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._trimGeneMutation._geneProbability, 1.0f);
 }
 
-TEST_F(MetaMutationTests, metaMutation_trimNodeRatesZeroSigmaNoChange)
+TEST_F(MetaMutationTests, metaMutation_trimGeneRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.trimNodeMetaMutationsSigma.value = 0.0f;
+    _parameters.trimGeneMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -480,7 +480,7 @@ TEST_F(MetaMutationTests, metaMutation_trimNodeRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._trimNodeMutation._geneProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._trimGeneMutation._geneProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_deleteNodeRatesActuallyChange)

--- a/source/EngineTests/MetaMutationTests.cpp
+++ b/source/EngineTests/MetaMutationTests.cpp
@@ -359,14 +359,14 @@ TEST_F(MetaMutationTests, metaMutation_voidRatesZeroSigmaNoChange)
     EXPECT_EQ(actualGenome._mutationRates._voidMutation._nodeProbability, 0.5f);
 }
 
-TEST_F(MetaMutationTests, metaMutation_appendNodeRatesActuallyChange)
+TEST_F(MetaMutationTests, metaMutation_extendGeneRatesActuallyChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.appendNodeMetaMutationsSigma.value = 1.0f;
+    _parameters.extendGeneMetaMutationsSigma.value = 1.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -375,19 +375,19 @@ TEST_F(MetaMutationTests, metaMutation_appendNodeRatesActuallyChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.5f));
-    EXPECT_GE(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.0f);
-    EXPECT_LE(actualGenome._mutationRates._appendNodeMutation._geneProbability, 1.0f);
+    EXPECT_FALSE(approxCompare(actualGenome._mutationRates._extendGeneMutation._geneProbability, 0.5f));
+    EXPECT_GE(actualGenome._mutationRates._extendGeneMutation._geneProbability, 0.0f);
+    EXPECT_LE(actualGenome._mutationRates._extendGeneMutation._geneProbability, 1.0f);
 }
 
-TEST_F(MetaMutationTests, metaMutation_appendNodeRatesZeroSigmaNoChange)
+TEST_F(MetaMutationTests, metaMutation_extendGeneRatesZeroSigmaNoChange)
 {
     auto genome = createTestGenome();
-    genome._mutationRates._appendNodeMutation = AppendNodeMutationDesc().geneProbability(0.5f);
+    genome._mutationRates._extendGeneMutation = ExtendGeneMutationDesc().geneProbability(0.5f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
-    _parameters.appendNodeMetaMutationsSigma.value = 0.0f;
+    _parameters.extendGeneMetaMutationsSigma.value = 0.0f;
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -396,7 +396,7 @@ TEST_F(MetaMutationTests, metaMutation_appendNodeRatesZeroSigmaNoChange)
     }
 
     auto actualGenome = getMutatedGenome();
-    EXPECT_EQ(actualGenome._mutationRates._appendNodeMutation._geneProbability, 0.5f);
+    EXPECT_EQ(actualGenome._mutationRates._extendGeneMutation._geneProbability, 0.5f);
 }
 
 TEST_F(MetaMutationTests, metaMutation_addNodeRatesActuallyChange)

--- a/source/EngineTests/TrimGeneMutationTests.cpp
+++ b/source/EngineTests/TrimGeneMutationTests.cpp
@@ -6,13 +6,13 @@
 
 #include "MutationTestsBase.h"
 
-class TrimNodeMutationTests : public MutationTestsBase
+class TrimGeneMutationTests : public MutationTestsBase
 {};
 
-TEST_F(TrimNodeMutationTests, trimNodeMutation_removesExactlyOneNodePerPass)
+TEST_F(TrimGeneMutationTests, trimGeneMutation_removesExactlyOneNodePerPass)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -23,10 +23,10 @@ TEST_F(TrimNodeMutationTests, trimNodeMutation_removesExactlyOneNodePerPass)
     EXPECT_EQ(2, actualGenome._genes.at(0)._nodes.size());
 }
 
-TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsAtLeastOneNode)
+TEST_F(TrimGeneMutationTests, trimGeneMutation_keepsAtLeastOneNode)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc()})});
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -39,11 +39,11 @@ TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsAtLeastOneNode)
     EXPECT_EQ(1, actualGenome._genes.at(0)._nodes.size());
 }
 
-TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsFirstAndLastNonVoid)
+TEST_F(TrimGeneMutationTests, trimGeneMutation_keepsFirstAndLastNonVoid)
 {
     // Trimming a boundary node exposes the interior void node; it must be corrected to a non-void cell type.
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc().cellType(VoidGenomeDesc()), NodeDesc()})});
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(1.0f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
@@ -56,10 +56,10 @@ TEST_F(TrimNodeMutationTests, trimNodeMutation_keepsFirstAndLastNonVoid)
     EXPECT_NE(CellType_Void, nodes.back().getCellType());
 }
 
-TEST_F(TrimNodeMutationTests, trimNodeMutation_zeroProbabilityNoChange)
+TEST_F(TrimGeneMutationTests, trimGeneMutation_zeroProbabilityNoChange)
 {
     auto genome = GenomeDesc().genes({GeneDesc().nodes({NodeDesc(), NodeDesc(), NodeDesc()})});
-    genome._mutationRates._trimNodeMutation = TrimNodeMutationDesc().geneProbability(0.0f);
+    genome._mutationRates._trimGeneMutation = TrimGeneMutationDesc().geneProbability(0.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -323,8 +323,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
         settings.getValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
     mutationRates._voidMutation._nodeProbability =
         settings.getValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
-    mutationRates._appendNodeMutation._geneProbability =
-        settings.getValue(settingsPrefix + "append node mutation.gene probability", mutationRates._appendNodeMutation._geneProbability);
+    mutationRates._extendGeneMutation._geneProbability =
+        settings.getValue(settingsPrefix + "extend gene mutation.gene probability", mutationRates._extendGeneMutation._geneProbability);
     mutationRates._addNodeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "add node mutation.node probability", mutationRates._addNodeMutation._nodeProbability);
     mutationRates._trimNodeMutation._geneProbability =
@@ -395,7 +395,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     settings.setValue(settingsPrefix + "cell type mode mutation.node probability", mutationRates._cellTypeModeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "cell type mutation.node probability", mutationRates._cellTypeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
-    settings.setValue(settingsPrefix + "append node mutation.gene probability", mutationRates._appendNodeMutation._geneProbability);
+    settings.setValue(settingsPrefix + "extend gene mutation.gene probability", mutationRates._extendGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "add node mutation.node probability", mutationRates._addNodeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "trim node mutation.gene probability", mutationRates._trimNodeMutation._geneProbability);
     settings.setValue(settingsPrefix + "delete node mutation.node probability", mutationRates._deleteNodeMutation._nodeProbability);
@@ -494,9 +494,9 @@ void MutationRatesDialog::processIntern()
             AlienGui::EndTreeNode();
             sectionTable.next();
 
-            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Append node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Extend gene mutations").rank(AlienGui::TreeNodeRank::High))) {
                 processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
-                    processGeneProbabilityMutationRate("Mutation rate", "APNM", _mutation._appendNodeMutation, RightColumnWidth);
+                    processGeneProbabilityMutationRate("Mutation rate", "EXGM", _mutation._extendGeneMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -327,8 +327,8 @@ void MutationRatesDialog::loadSettings(MutationRatesDesc& mutationRates, std::st
         settings.getValue(settingsPrefix + "extend gene mutation.gene probability", mutationRates._extendGeneMutation._geneProbability);
     mutationRates._addNodeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "add node mutation.node probability", mutationRates._addNodeMutation._nodeProbability);
-    mutationRates._trimNodeMutation._geneProbability =
-        settings.getValue(settingsPrefix + "trim node mutation.gene probability", mutationRates._trimNodeMutation._geneProbability);
+    mutationRates._trimGeneMutation._geneProbability =
+        settings.getValue(settingsPrefix + "trim gene mutation.gene probability", mutationRates._trimGeneMutation._geneProbability);
     mutationRates._deleteNodeMutation._nodeProbability =
         settings.getValue(settingsPrefix + "delete node mutation.node probability", mutationRates._deleteNodeMutation._nodeProbability);
     mutationRates._duplicateGeneMutation._geneProbability =
@@ -397,7 +397,7 @@ void MutationRatesDialog::saveSettings(MutationRatesDesc const& mutationRates, s
     settings.setValue(settingsPrefix + "void mutation.node probability", mutationRates._voidMutation._nodeProbability);
     settings.setValue(settingsPrefix + "extend gene mutation.gene probability", mutationRates._extendGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "add node mutation.node probability", mutationRates._addNodeMutation._nodeProbability);
-    settings.setValue(settingsPrefix + "trim node mutation.gene probability", mutationRates._trimNodeMutation._geneProbability);
+    settings.setValue(settingsPrefix + "trim gene mutation.gene probability", mutationRates._trimGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "delete node mutation.node probability", mutationRates._deleteNodeMutation._nodeProbability);
     settings.setValue(settingsPrefix + "duplicate gene mutation.gene probability", mutationRates._duplicateGeneMutation._geneProbability);
     settings.setValue(settingsPrefix + "delete gene mutation.gene probability", mutationRates._deleteGeneMutation._geneProbability);
@@ -512,9 +512,9 @@ void MutationRatesDialog::processIntern()
             AlienGui::EndTreeNode();
             sectionTable.next();
 
-            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Trim node mutations").rank(AlienGui::TreeNodeRank::High))) {
+            if (AlienGui::BeginTreeNode(AlienGui::TreeNodeParameters().name("Trim gene mutations").rank(AlienGui::TreeNodeRank::High))) {
                 processConcreteMutationRates(1, [&](AlienGui::DynamicTableLayout& table) {
-                    processGeneProbabilityMutationRate("Mutation rate", "TRNM", _mutation._trimNodeMutation, RightColumnWidth);
+                    processGeneProbabilityMutationRate("Mutation rate", "TRGM", _mutation._trimGeneMutation, RightColumnWidth);
                     table.next();
                 });
             }

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -51,7 +51,7 @@ namespace
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Extend gene mutations", {mutationRates._extendGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Add node mutations", {mutationRates._addNodeMutation._nodeProbability});
-        addActiveMutationType(activeMutations, "Trim node mutations", {mutationRates._trimNodeMutation._geneProbability});
+        addActiveMutationType(activeMutations, "Trim gene mutations", {mutationRates._trimGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Delete node mutations", {mutationRates._deleteNodeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Duplicate gene mutations", {mutationRates._duplicateGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Delete gene mutations", {mutationRates._deleteGeneMutation._geneProbability});

--- a/source/Gui/MutationRatesWidget.cpp
+++ b/source/Gui/MutationRatesWidget.cpp
@@ -49,7 +49,7 @@ namespace
         addActiveMutationType(activeMutations, "Cell type mode mut.", {mutationRates._cellTypeModeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Cell type mutations", {mutationRates._cellTypeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Void mutations", {mutationRates._voidMutation._nodeProbability});
-        addActiveMutationType(activeMutations, "Append node mutations", {mutationRates._appendNodeMutation._geneProbability});
+        addActiveMutationType(activeMutations, "Extend gene mutations", {mutationRates._extendGeneMutation._geneProbability});
         addActiveMutationType(activeMutations, "Add node mutations", {mutationRates._addNodeMutation._nodeProbability});
         addActiveMutationType(activeMutations, "Trim node mutations", {mutationRates._trimNodeMutation._geneProbability});
         addActiveMutationType(activeMutations, "Delete node mutations", {mutationRates._deleteNodeMutation._nodeProbability});

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -313,7 +313,7 @@ namespace
 
     auto constexpr Id_AddNodeMutation_NodeProbability = 0;
 
-    auto constexpr Id_TrimNodeMutation_GeneProbability = 0;
+    auto constexpr Id_TrimGeneMutation_GeneProbability = 0;
 
     auto constexpr Id_DeleteNodeMutation_NodeProbability = 0;
 
@@ -459,7 +459,7 @@ namespace
     auto constexpr Id_MutationRates_ConstructorMutation2 = 11;
     auto constexpr Id_MutationRates_ExtendGeneMutation = 12;
     auto constexpr Id_MutationRates_AddNodeMutation = 13;
-    auto constexpr Id_MutationRates_TrimNodeMutation = 14;
+    auto constexpr Id_MutationRates_TrimGeneMutation = 14;
     auto constexpr Id_MutationRates_DeleteNodeMutation = 15;
     auto constexpr Id_MutationRates_DuplicateGeneMutation = 16;
     auto constexpr Id_MutationRates_DeleteGeneMutation = 17;
@@ -997,13 +997,13 @@ namespace cereal
     SPLIT_SERIALIZATION(AddNodeMutationDesc)
 
     template <class Archive>
-    void loadSave(SerializationTask task, Archive& ar, TrimNodeMutationDesc& data)
+    void loadSave(SerializationTask task, Archive& ar, TrimGeneMutationDesc& data)
     {
-        TrimNodeMutationDesc defaultObject;
+        TrimGeneMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
-        scope.addMember(Id_TrimNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+        scope.addMember(Id_TrimGeneMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
     }
-    SPLIT_SERIALIZATION(TrimNodeMutationDesc)
+    SPLIT_SERIALIZATION(TrimGeneMutationDesc)
 
     template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, DeleteNodeMutationDesc& data)
@@ -1080,7 +1080,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);
         scope.addDesc(Id_MutationRates_ExtendGeneMutation, data._extendGeneMutation);
         scope.addDesc(Id_MutationRates_AddNodeMutation, data._addNodeMutation);
-        scope.addDesc(Id_MutationRates_TrimNodeMutation, data._trimNodeMutation);
+        scope.addDesc(Id_MutationRates_TrimGeneMutation, data._trimGeneMutation);
         scope.addDesc(Id_MutationRates_DeleteNodeMutation, data._deleteNodeMutation);
         scope.addDesc(Id_MutationRates_DuplicateGeneMutation, data._duplicateGeneMutation);
         scope.addDesc(Id_MutationRates_DeleteGeneMutation, data._deleteGeneMutation);

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -309,7 +309,7 @@ namespace
 
     auto constexpr Id_VoidMutation_NodeProbability = 0;
 
-    auto constexpr Id_AppendNodeMutation_GeneProbability = 0;
+    auto constexpr Id_ExtendGeneMutation_GeneProbability = 0;
 
     auto constexpr Id_AddNodeMutation_NodeProbability = 0;
 
@@ -457,7 +457,7 @@ namespace
     auto constexpr Id_MutationRates_VoidMutation = 9;
     auto constexpr Id_MutationRates_ConstructorMutation1 = 10;
     auto constexpr Id_MutationRates_ConstructorMutation2 = 11;
-    auto constexpr Id_MutationRates_AppendNodeMutation = 12;
+    auto constexpr Id_MutationRates_ExtendGeneMutation = 12;
     auto constexpr Id_MutationRates_AddNodeMutation = 13;
     auto constexpr Id_MutationRates_TrimNodeMutation = 14;
     auto constexpr Id_MutationRates_DeleteNodeMutation = 15;
@@ -979,13 +979,13 @@ namespace cereal
     SPLIT_SERIALIZATION(VoidMutationDesc)
 
     template <class Archive>
-    void loadSave(SerializationTask task, Archive& ar, AppendNodeMutationDesc& data)
+    void loadSave(SerializationTask task, Archive& ar, ExtendGeneMutationDesc& data)
     {
-        AppendNodeMutationDesc defaultObject;
+        ExtendGeneMutationDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
-        scope.addMember(Id_AppendNodeMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
+        scope.addMember(Id_ExtendGeneMutation_GeneProbability, data._geneProbability, defaultObject._geneProbability);
     }
-    SPLIT_SERIALIZATION(AppendNodeMutationDesc)
+    SPLIT_SERIALIZATION(ExtendGeneMutationDesc)
 
     template <class Archive>
     void loadSave(SerializationTask task, Archive& ar, AddNodeMutationDesc& data)
@@ -1078,7 +1078,7 @@ namespace cereal
         scope.addDesc(Id_MutationRates_CellTypeModeMutation, data._cellTypeModeMutation);
         scope.addDesc(Id_MutationRates_CellTypeMutation, data._cellTypeMutation);
         scope.addDesc(Id_MutationRates_VoidMutation, data._voidMutation);
-        scope.addDesc(Id_MutationRates_AppendNodeMutation, data._appendNodeMutation);
+        scope.addDesc(Id_MutationRates_ExtendGeneMutation, data._extendGeneMutation);
         scope.addDesc(Id_MutationRates_AddNodeMutation, data._addNodeMutation);
         scope.addDesc(Id_MutationRates_TrimNodeMutation, data._trimNodeMutation);
         scope.addDesc(Id_MutationRates_DeleteNodeMutation, data._deleteNodeMutation);


### PR DESCRIPTION
## Summary
- Renames `AppendNodeMutation` to `ExtendGeneMutation` and `TrimNodeMutation` to `TrimGeneMutation`, matching the gene-level mutation naming convention already used for `DuplicateGeneMutation`/`DeleteGeneMutation` (both mutations act per-gene, keyed by `geneProbability`, not per-node).
- Covers descriptor structs, TO structs, GPU kernel structs, serialization ids, the `applyMutations_appendNode`/`applyMutations_trimNode` kernel functions, the meta-mutation sigma parameters, GUI labels/settings keys, and test class/case names for both.
- Leaves the unrelated `trimNodes(...)` helper in `GenomeDescEditService.cpp` (genome-preview cell-count trimming) untouched — different feature, coincidental name overlap.

## Test plan
- [ ] Build (blocked locally: `external/vcpkg` submodule not initialized in this environment)
- [ ] `EngineInterfaceTests.exe`, `NetworkTests.exe`, `PersisterTests.exe`
- [ ] `EngineTests.exe --gtest_filter=ExtendGeneMutationTests.*:TrimGeneMutationTests.*:MetaMutationTests.*extendGene*:MetaMutationTests.*trimGene*:AccumulatedMutationTests*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)