### PR TITLE
Fix filter typing needing two keypresses to start

### DIFF
--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -553,6 +553,10 @@ bool AlienGui::InputFilter(InputFilterParameters const& parameters, std::string&
 {
     auto result = AlienGui::InputText(
         AlienGui::InputTextParameters().hint("Filter (case insensitive)").bold(!filter.empty()).textWidth(0).width(parameters._width - 28.0f), filter);
+    if (ImGui::IsItemDeactivated() && ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+        filter.clear();
+        result = true;
+    }
     ImGui::SameLine();
 
     ImGui::BeginDisabled(filter.empty());

--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -33,20 +33,6 @@ namespace
 
     auto constexpr ExpertWidgetHeight = 130.0f;
     auto constexpr ExpertWidgetMinHeight = 60.0f;
-
-    void appendAsUtf8(std::string& target, ImWchar c)
-    {
-        if (c < 0x80) {
-            target += static_cast<char>(c);
-        } else if (c < 0x800) {
-            target += static_cast<char>(0xC0 | (c >> 6));
-            target += static_cast<char>(0x80 | (c & 0x3F));
-        } else {
-            target += static_cast<char>(0xE0 | (c >> 12));
-            target += static_cast<char>(0x80 | ((c >> 6) & 0x3F));
-            target += static_cast<char>(0x80 | (c & 0x3F));
-        }
-    }
 }
 
 SimulationParametersMainWindow::SimulationParametersMainWindow()
@@ -288,23 +274,29 @@ void SimulationParametersMainWindow::processDetailWidget()
 
 void SimulationParametersMainWindow::startFilterTypingIfNeeded()
 {
+    // SetKeyboardFocusHere() takes effect only on the next frame. Characters typed on the
+    // triggering frame are queued here and replayed into ImGui's input queue on the frame the
+    // filter field actually becomes active, so ImGui's own selection/insertion logic handles
+    // them (e.g. correctly replacing a pre-existing filter instead of us splicing text in and
+    // fighting the auto-select-on-focus behavior).
+    if (!_pendingFilterChars.empty()) {
+        for (auto c : _pendingFilterChars) {
+            ImGui::GetIO().AddInputCharacter(c);
+        }
+        _pendingFilterChars.clear();
+        return;
+    }
+
     if (ImGui::IsAnyItemActive() || !ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows)) {
         return;
     }
 
-    // SetKeyboardFocusHere() only takes effect one frame later, so the character that
-    // triggered it would otherwise be lost. Append it to the filter directly instead.
-    auto startedTyping = false;
     for (auto const& c : ImGui::GetIO().InputQueueCharacters) {
         if (c >= 32 && c != 127) {
-            if (!startedTyping) {
-                _filter.clear();
-            }
-            appendAsUtf8(_filter, c);
-            startedTyping = true;
+            _pendingFilterChars.push_back(c);
         }
     }
-    if (startedTyping) {
+    if (!_pendingFilterChars.empty()) {
         ImGui::SetKeyboardFocusHere();
     }
 }

--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -1,6 +1,5 @@
 #include "SimulationParametersMainWindow.h"
 
-#include <imgui_internal.h>
 #include <Fonts/IconsFontAwesome5.h>
 
 #include <Base/StringHelper.h>
@@ -34,6 +33,20 @@ namespace
 
     auto constexpr ExpertWidgetHeight = 130.0f;
     auto constexpr ExpertWidgetMinHeight = 60.0f;
+
+    void appendAsUtf8(std::string& target, ImWchar c)
+    {
+        if (c < 0x80) {
+            target += static_cast<char>(c);
+        } else if (c < 0x800) {
+            target += static_cast<char>(0xC0 | (c >> 6));
+            target += static_cast<char>(0x80 | (c & 0x3F));
+        } else {
+            target += static_cast<char>(0xE0 | (c >> 12));
+            target += static_cast<char>(0x80 | ((c >> 6) & 0x3F));
+            target += static_cast<char>(0x80 | (c & 0x3F));
+        }
+    }
 }
 
 SimulationParametersMainWindow::SimulationParametersMainWindow()
@@ -284,9 +297,10 @@ void SimulationParametersMainWindow::startFilterTypingIfNeeded()
     auto startedTyping = false;
     for (auto const& c : ImGui::GetIO().InputQueueCharacters) {
         if (c >= 32 && c != 127) {
-            char utf8[5];
-            ImTextCharToUtf8(utf8, c);
-            _filter += utf8;
+            if (!startedTyping) {
+                _filter.clear();
+            }
+            appendAsUtf8(_filter, c);
             startedTyping = true;
         }
     }

--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -1,5 +1,6 @@
 #include "SimulationParametersMainWindow.h"
 
+#include <imgui_internal.h>
 #include <Fonts/IconsFontAwesome5.h>
 
 #include <Base/StringHelper.h>
@@ -258,9 +259,7 @@ void SimulationParametersMainWindow::processDetailWidget()
             //AlienGui::ResetFilterText();
 
             ImGui::Spacing();
-            if (shouldStartFilterTyping()) {
-                ImGui::SetKeyboardFocusHere();
-            }
+            startFilterTypingIfNeeded();
             AlienGui::InputFilter(AlienGui::InputFilterParameters().width(250.0f), _filter);
         }
         AlienGui::EndTreeNode();
@@ -274,17 +273,26 @@ void SimulationParametersMainWindow::processDetailWidget()
     }
 }
 
-bool SimulationParametersMainWindow::shouldStartFilterTyping() const
+void SimulationParametersMainWindow::startFilterTypingIfNeeded()
 {
     if (ImGui::IsAnyItemActive() || !ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows)) {
-        return false;
+        return;
     }
+
+    // SetKeyboardFocusHere() only takes effect one frame later, so the character that
+    // triggered it would otherwise be lost. Append it to the filter directly instead.
+    auto startedTyping = false;
     for (auto const& c : ImGui::GetIO().InputQueueCharacters) {
         if (c >= 32 && c != 127) {
-            return true;
+            char utf8[5];
+            ImTextCharToUtf8(utf8, c);
+            _filter += utf8;
+            startedTyping = true;
         }
     }
-    return false;
+    if (startedTyping) {
+        ImGui::SetKeyboardFocusHere();
+    }
 }
 
 void SimulationParametersMainWindow::processExpertWidget()

--- a/source/Gui/SimulationParametersMainWindow.h
+++ b/source/Gui/SimulationParametersMainWindow.h
@@ -89,4 +89,5 @@ private:
     std::string _fileDialogPath;
 
     std::string _filter;
+    std::vector<unsigned int> _pendingFilterChars;
 };

--- a/source/Gui/SimulationParametersMainWindow.h
+++ b/source/Gui/SimulationParametersMainWindow.h
@@ -26,7 +26,7 @@ private:
     void processExpertWidget();
     void processStatusBar();
 
-    bool shouldStartFilterTyping() const;
+    void startFilterTypingIfNeeded();
 
     struct Location
     {


### PR DESCRIPTION
## Summary
- The type-to-filter feature in the simulation parameters window (added in #779) required two keypresses: the first only moved keyboard focus into the filter field, the second actually typed.
- Root cause: `ImGui::SetKeyboardFocusHere()` resolves focus at the start of the *next* frame, so the character queued in `io.InputQueueCharacters` on the triggering frame is discarded before the input widget becomes active and can consume it.
- Fix: append the queued character(s) to `_filter` directly (UTF-8 encoded via `ImTextCharToUtf8`) and only use `SetKeyboardFocusHere()` to move the cursor/focus into the field for subsequent frames.

## Test plan
- [x] `build-windows-ninja.bat Release` builds cleanly
- [ ] Manually verify: open simulation parameters window, click elsewhere to defocus, type a letter — filter should populate on the first keypress