### PR TITLE
Mutate first offspring genome instead of host genome

### DIFF
--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -172,21 +172,22 @@ __inline__ __device__ void ConstructorProcessor::processCell(SimulationData& dat
         if (readyToConstruct) {
             readyToConstruct = checkHostEnergyAndRequestExternalEnergyIfNeeded(data, object);
         }
+        if (readyToConstruct) {
+            constructor.offspring = findOrCreateNewCreature(data, object);
+        }
     }
     __syncthreads();
     if (!readyToConstruct) {
         return;
     }
 
-    // Important: mutate the host genome before it is cloned for the offspring.
+    // Mutate the freshly cloned genome of the first offspring, leaving the host genome untouched.
     mutateGenome(data, object);
 
     // The actual construction runs on a single thread.
     if (threadIdx.x != 0) {
         return;
     }
-
-    constructor.offspring = findOrCreateNewCreature(data, object);
 
     // Check again after cloning the creature, because the offspring genome may diverge from the host genome.
     if (ConstructorHelper::isFinished(object, *constructor.offspring->genome)) {
@@ -219,29 +220,24 @@ __inline__ __device__ void ConstructorProcessor::processCell(SimulationData& dat
 
 __inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& data, Object* object)
 {
-    auto& cell = object->typeData.cell;
-    auto& constructor = cell.constructor;
+    auto& constructor = object->typeData.cell.constructor;
+    auto offspring = constructor.offspring;
 
-    __shared__ Genome* clonedGenome;
+    __shared__ Genome* genomeToMutate;
     if (threadIdx.x == 0) {
-        clonedGenome = nullptr;
-        if (ConstructorHelper::createsNewCreature(constructor)) {
-            auto& creature = cell.creature;
-            int origMutationState = atomicExch(&creature->mutationState, MutationState_Mutated);
+        genomeToMutate = nullptr;
+        // Only the first offspring is mutated; its genome was cloned for it in findOrCreateNewCreature.
+        if (constructor.currentOffspring == 0 && ConstructorHelper::createsNewCreature(constructor)) {
+            int origMutationState = atomicExch(&offspring->mutationState, MutationState_Mutated);
             if (origMutationState == MutationState_NotMutated) {
-                EntityFactory factory;
-                factory.init(&data);
-                clonedGenome = factory.cloneGenome(creature->genome);
+                genomeToMutate = offspring->genome;
             }
         }
     }
     __syncthreads();
 
-    if (clonedGenome != nullptr) {
-        MutationProcessor::applyMutations(data, cell.creature, clonedGenome);
-        if (threadIdx.x == 0) {
-            cell.creature->genome = clonedGenome;
-        }
+    if (genomeToMutate != nullptr) {
+        MutationProcessor::applyMutations(data, offspring, genomeToMutate);
     }
     __syncthreads();
 }
@@ -273,6 +269,11 @@ __inline__ __device__ Creature* ConstructorProcessor::findOrCreateNewCreature(Si
     factory.init(&data);
     auto result = factory.cloneCreature(object->typeData.cell.creature);
     result->numCells = 0;
+
+    // Give the first offspring its own genome copy so it can be mutated without affecting the host
+    if (constructor.currentOffspring == 0) {
+        result->genome = factory.cloneGenome(object->typeData.cell.creature->genome);
+    }
 
     return result;
 }


### PR DESCRIPTION
## Summary
Move genome mutation so it applies to the **first offspring's own cloned genome** instead of the host genome.

Previously `mutateGenome` cloned and mutated the host creature's genome in place (before it was cloned for the offspring). Now:

- `processCell`: the offspring creature is created (`findOrCreateNewCreature`) **before** `mutateGenome`, so the mutation targets the offspring.
- `mutateGenome`: mutates `offspring->genome`, guarded by `currentOffspring == 0 && createsNewCreature(...)`; the host genome is left untouched. Once-guard via `atomicExch(offspring->mutationState)`.
- `findOrCreateNewCreature`: the first offspring (`currentOffspring == 0`) gets its own genome copy (`cloneGenome`) so the mutation does not affect the host.

Result: only the **first** offspring is mutated, on its **own** genome copy; the parent keeps its original genome.

## Testing
Not built/run here — the vcpkg submodule is not provisioned in this environment. Tests intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)