### PR TITLE
Do not count injector references in removeUnreachableGenesFromRoot

### DIFF
--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -1338,9 +1338,6 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
                 if (node.constructorAvailable && newGeneIndices[node.constructor.geneIndex] == -1) {
                     newGeneIndices[node.constructor.geneIndex] = 1;
                 }
-                if (node.cellType == CellType_Injector && newGeneIndices[node.cellTypeData.injector.geneIndex] == -1) {
-                    newGeneIndices[node.cellTypeData.injector.geneIndex] = 1;
-                }
             }
         }
         block.sync();
@@ -1357,8 +1354,9 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
     block.sync();
 
     if (newNumGenes != numGenes) {
-        // Remap the references of the surviving genes in parallel; the reachable set is closed under references, so every
-        // reference of a survivor maps to a survivor.
+        // Remap the references of the surviving genes in parallel; the reachable set is closed under constructor references, so
+        // every constructor reference of a survivor maps to a survivor. Injector references are not part of the reachability
+        // closure, so an injector may point at a removed gene; fall back to gene 0 in that case.
         for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
             if (newGeneIndices[geneIndex] < 0) {
                 continue;
@@ -1370,7 +1368,8 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
                     node.constructor.geneIndex = newGeneIndices[node.constructor.geneIndex];
                 }
                 if (node.cellType == CellType_Injector) {
-                    node.cellTypeData.injector.geneIndex = newGeneIndices[node.cellTypeData.injector.geneIndex];
+                    int mapped = newGeneIndices[node.cellTypeData.injector.geneIndex];
+                    node.cellTypeData.injector.geneIndex = mapped < 0 ? 0 : mapped;
                 }
             }
         }

--- a/source/EngineTests/UnusedGeneRemovalTests.cpp
+++ b/source/EngineTests/UnusedGeneRemovalTests.cpp
@@ -72,10 +72,32 @@ TEST_F(UnusedGeneRemovalTests, removeUnreachableGenesFromRoot_allGenesReachable_
     EXPECT_EQ(genome, actualGenome);
 }
 
-TEST_F(UnusedGeneRemovalTests, removeUnreachableGenesFromRoot_keepsGeneReferencedByInjector)
+TEST_F(UnusedGeneRemovalTests, removeUnreachableGenesFromRoot_removesGeneOnlyReferencedByInjector)
 {
+    // An injector's gene reference is a payload for a foreign creature, not part of this creature's own construction
+    // graph, so it must not keep the referenced gene alive.
     auto genome = GenomeDesc().genes({
         GeneDesc().name("gene0").nodes({NodeDesc().cellType(InjectorGenomeDesc().geneIndex(2))}),
+        GeneDesc().name("gene1").nodes({NodeDesc()}),
+        GeneDesc().name("gene2").nodes({NodeDesc()}),
+    });
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeUnusedGenes(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(1, actualGenome._genes.size());
+    EXPECT_EQ("gene0", actualGenome._genes.at(0)._name);
+    EXPECT_EQ(0, std::get<InjectorGenomeDesc>(actualGenome._genes.at(0)._nodes.at(0)._cellType)._geneIndex);
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(UnusedGeneRemovalTests, removeUnreachableGenesFromRoot_keepsGeneReferencedByInjectorAndConstructor)
+{
+    // gene2 is targeted by both an injector and a constructor reference; the constructor reference alone must keep it alive.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().name("gene0").nodes({NodeDesc().cellType(InjectorGenomeDesc().geneIndex(2)).constructor(ConstructorGenomeDesc().geneIndex(2))}),
         GeneDesc().name("gene1").nodes({NodeDesc()}),
         GeneDesc().name("gene2").nodes({NodeDesc()}),
     });
@@ -88,7 +110,6 @@ TEST_F(UnusedGeneRemovalTests, removeUnreachableGenesFromRoot_keepsGeneReference
     ASSERT_EQ(2, actualGenome._genes.size());
     EXPECT_EQ("gene0", actualGenome._genes.at(0)._name);
     EXPECT_EQ("gene2", actualGenome._genes.at(1)._name);
-    EXPECT_EQ(1, std::get<InjectorGenomeDesc>(actualGenome._genes.at(0)._nodes.at(0)._cellType)._geneIndex);
     EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
 }
 


### PR DESCRIPTION
## Summary
- `removeUnreachableGenesFromRoot` used to treat an Injector node's `geneIndex` as a reachability edge, so any gene it targeted (and everything reachable from that gene via constructor chains) was kept alive even if unrelated to the creature's own body.
- An injector's referenced gene is a payload for a foreign creature; it should not protect genes from pruning in the host's own genome.
- Repro: `D:/dev/claude/examples/UnusedGenes.genome` has 5 genes only bridged in via an injector reference; before this change, `removeUnreachableGenesFromRoot` kept all 13 genes instead of pruning the 5 unreachable ones.

## Changes
- `MutationProcessor.cuh`: reachability marking (`removeUnreachableGenesFromRoot`) now only follows constructor references, not injector references. The remap step now falls back to gene 0 if an injector ends up pointing at a removed gene.
- `UnusedGeneRemovalTests.cpp`: inverted `keepsGeneReferencedByInjector` into `removesGeneOnlyReferencedByInjector`, and added `keepsGeneReferencedByInjectorAndConstructor` to confirm a constructor reference still keeps a gene alive independent of any injector reference to it.

## Test plan
- [x] `EngineTests.exe --gtest_filter=UnusedGeneRemovalTests.*` (7/7 pass)
- [x] Full `EngineTests.exe` suite (3074 passed, 3 pre-existing unrelated skips)
- [x] `clang-format --dry-run --Werror` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)