### PR TITLE
Add oneway flag to Sender

### DIFF
--- a/source/EngineImpl/DescConverterService.cpp
+++ b/source/EngineImpl/DescConverterService.cpp
@@ -570,6 +570,7 @@ ObjectDesc DescConverterService::createObjectDesc(TOs const& to, int objectIndex
             if (communicatorTO.mode == CommunicatorMode_Sender) {
                 SenderDesc sender;
                 sender._range = communicatorTO.modeData.sender.range;
+                sender._oneway = communicatorTO.modeData.sender.oneway;
                 communicator._mode = sender;
             } else if (communicatorTO.mode == CommunicatorMode_Receiver) {
                 ReceiverDesc receiver;
@@ -821,6 +822,7 @@ NodeDesc DescConverterService::createNodeDesc(TOs const& to, NodeTO const* nodeT
         if (communicatorTO.mode == CommunicatorMode_Sender) {
             SenderGenomeDesc sender;
             sender._range = communicatorTO.modeData.sender.range;
+            sender._oneway = communicatorTO.modeData.sender.oneway;
             communicatorDesc._mode = sender;
         } else if (communicatorTO.mode == CommunicatorMode_Receiver) {
             ReceiverGenomeDesc receiver;
@@ -1207,6 +1209,7 @@ void DescConverterService::convertGenomeToTO(
                 if (communicatorTO.mode == CommunicatorMode_Sender) {
                     auto const& senderDesc = std::get<SenderGenomeDesc>(communicatorDesc._mode);
                     communicatorTO.modeData.sender.range = static_cast<uint8_t>(senderDesc._range);
+                    communicatorTO.modeData.sender.oneway = senderDesc._oneway;
                 } else if (communicatorTO.mode == CommunicatorMode_Receiver) {
                     auto const& receiverDesc = std::get<ReceiverGenomeDesc>(communicatorDesc._mode);
                     communicatorTO.modeData.receiver.restrictToColors = static_cast<uint16_t>(receiverDesc._restrictToColors);
@@ -1533,6 +1536,7 @@ void DescConverterService::convertObjectToTO(
             if (communicatorTO.mode == CommunicatorMode_Sender) {
                 auto const& senderDesc = std::get<SenderDesc>(communicatorDesc._mode);
                 communicatorTO.modeData.sender.range = static_cast<uint8_t>(senderDesc._range);
+                communicatorTO.modeData.sender.oneway = senderDesc._oneway;
             } else if (communicatorTO.mode == CommunicatorMode_Receiver) {
                 auto const& receiverDesc = std::get<ReceiverDesc>(communicatorDesc._mode);
                 communicatorTO.modeData.receiver.restrictToColors = static_cast<uint16_t>(receiverDesc._restrictToColors);

--- a/source/EngineInterface/CellTypeConstants.h
+++ b/source/EngineInterface/CellTypeConstants.h
@@ -482,6 +482,7 @@ namespace Const
     auto constexpr CommunicatorRange_Min = 0;
     auto constexpr CommunicatorRange_Max = 20;
     auto constexpr CommunicatorRange_Default = 15;
+    auto constexpr CommunicatorOneway_Default = true;
 }
 
 using CommunicatorMode = int;

--- a/source/EngineInterface/Desc.h
+++ b/source/EngineInterface/Desc.h
@@ -409,6 +409,7 @@ struct SenderDesc
     auto operator<=>(SenderDesc const&) const = default;
 
     MEMBER(SenderDesc, int, range, Const::CommunicatorRange_Default);
+    MEMBER(SenderDesc, bool, oneway, Const::CommunicatorOneway_Default);
 };
 
 struct ReceiverDesc

--- a/source/EngineInterface/GenomeDesc.h
+++ b/source/EngineInterface/GenomeDesc.h
@@ -343,6 +343,7 @@ struct SenderGenomeDesc
     auto operator<=>(SenderGenomeDesc const&) const = default;
 
     MEMBER(SenderGenomeDesc, int, range, Const::CommunicatorRange_Default);
+    MEMBER(SenderGenomeDesc, bool, oneway, Const::CommunicatorOneway_Default);
 };
 
 struct ReceiverGenomeDesc

--- a/source/EngineInterface/GenomeDescHash.h
+++ b/source/EngineInterface/GenomeDescHash.h
@@ -436,6 +436,7 @@ struct std::hash<SenderGenomeDesc>
     {
         std::size_t seed = 0;
         hash_combine(seed, desc._range);
+        hash_combine(seed, desc._oneway);
         return seed;
     }
 };

--- a/source/EngineKernels/CommunicatorProcessor.cuh
+++ b/source/EngineKernels/CommunicatorProcessor.cuh
@@ -138,11 +138,7 @@ __device__ __inline__ void CommunicatorProcessor::processSender(SimulationData& 
             auto const& otherRecord = records[otherIndex];
             auto otherObject = otherRecord.self;
             if (isMatch(otherObject)) {
-                // Direction gating: only send if the receiver lies in the half-plane opposite to the encoded facing direction
-                auto toReceiver = data.objectMap.getCorrectedDirection(otherObject->pos - senderPos);
-                if (Math::dot(toReceiver, senderFacing) <= 0) {
-                    tryTransmitSignal(data, object, otherObject, senderFacing);
-                }
+                tryTransmitSignal(data, object, otherObject, senderFacing);
             }
             otherIndex = otherRecord.nextObjectIndex;
         }
@@ -152,6 +148,15 @@ __device__ __inline__ void CommunicatorProcessor::processSender(SimulationData& 
 __inline__ __device__ bool
 CommunicatorProcessor::tryTransmitSignal(SimulationData& data, Object* senderObject, Object* receiverObject, float2 const& senderFacing)
 {
+    auto const& sender = senderObject->typeData.cell.cellTypeData.communicator.modeData.sender;
+    if (sender.oneway) {
+        // Direction gating: only send if the receiver lies in the half-plane opposite to the encoded facing direction
+        auto toReceiver = data.objectMap.getCorrectedDirection(receiverObject->pos - senderObject->pos);
+        if (Math::dot(toReceiver, senderFacing) > 0) {
+            return false;
+        }
+    }
+
     // The receiver must have an initialized front direction
     if (receiverObject->typeData.cell.frontAngle == VALUE_NOT_SET_FLOAT) {
         return false;

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -245,6 +245,7 @@ namespace
                         nodeTO.cellTypeData.communicator.mode = node.cellTypeData.communicator.mode;
                         if (node.cellTypeData.communicator.mode == CommunicatorMode_Sender) {
                             nodeTO.cellTypeData.communicator.modeData.sender.range = node.cellTypeData.communicator.modeData.sender.range;
+                            nodeTO.cellTypeData.communicator.modeData.sender.oneway = node.cellTypeData.communicator.modeData.sender.oneway;
                         } else if (node.cellTypeData.communicator.mode == CommunicatorMode_Receiver) {
                             nodeTO.cellTypeData.communicator.modeData.receiver.restrictToColors =
                                 node.cellTypeData.communicator.modeData.receiver.restrictToColors;
@@ -543,6 +544,7 @@ namespace
                 cellTO.cellTypeData.communicator.mode = cell.cellTypeData.communicator.mode;
                 if (cell.cellTypeData.communicator.mode == CommunicatorMode_Sender) {
                     cellTO.cellTypeData.communicator.modeData.sender.range = cell.cellTypeData.communicator.modeData.sender.range;
+                    cellTO.cellTypeData.communicator.modeData.sender.oneway = cell.cellTypeData.communicator.modeData.sender.oneway;
                 } else if (cell.cellTypeData.communicator.mode == CommunicatorMode_Receiver) {
                     cellTO.cellTypeData.communicator.modeData.receiver.restrictToColors = cell.cellTypeData.communicator.modeData.receiver.restrictToColors;
                     cellTO.cellTypeData.communicator.modeData.receiver.restrictToLineage = cell.cellTypeData.communicator.modeData.receiver.restrictToLineage;

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -382,6 +382,7 @@ struct Memory
 struct Sender
 {
     uint8_t range;
+    bool oneway;
 };
 
 struct Receiver

--- a/source/EngineKernels/EntityFactory.cuh
+++ b/source/EngineKernels/EntityFactory.cuh
@@ -298,6 +298,7 @@ __inline__ __device__ Genome* EntityFactory::createGenomeFromTO(TOs const& to, i
                 node.cellTypeData.communicator.mode = nodeTO.cellTypeData.communicator.mode;
                 if (nodeTO.cellTypeData.communicator.mode == CommunicatorMode_Sender) {
                     node.cellTypeData.communicator.modeData.sender.range = nodeTO.cellTypeData.communicator.modeData.sender.range;
+                    node.cellTypeData.communicator.modeData.sender.oneway = nodeTO.cellTypeData.communicator.modeData.sender.oneway;
                 } else if (nodeTO.cellTypeData.communicator.mode == CommunicatorMode_Receiver) {
                     node.cellTypeData.communicator.modeData.receiver.restrictToColors = nodeTO.cellTypeData.communicator.modeData.receiver.restrictToColors;
                     node.cellTypeData.communicator.modeData.receiver.restrictToLineage = nodeTO.cellTypeData.communicator.modeData.receiver.restrictToLineage;
@@ -580,6 +581,7 @@ __inline__ __device__ void EntityFactory::changeObjectFromTO(TOs const& to, Obje
             cell->cellTypeData.communicator.mode = cellTO.cellTypeData.communicator.mode;
             if (cellTO.cellTypeData.communicator.mode == CommunicatorMode_Sender) {
                 cell->cellTypeData.communicator.modeData.sender.range = cellTO.cellTypeData.communicator.modeData.sender.range;
+                cell->cellTypeData.communicator.modeData.sender.oneway = cellTO.cellTypeData.communicator.modeData.sender.oneway;
             } else if (cellTO.cellTypeData.communicator.mode == CommunicatorMode_Receiver) {
                 cell->cellTypeData.communicator.modeData.receiver.restrictToColors = cellTO.cellTypeData.communicator.modeData.receiver.restrictToColors;
                 cell->cellTypeData.communicator.modeData.receiver.restrictToLineage = cellTO.cellTypeData.communicator.modeData.receiver.restrictToLineage;
@@ -964,6 +966,7 @@ __inline__ __device__ Object* EntityFactory::createCellFromNode(
         communicator.mode = nodeCommunicator.mode;
         if (nodeCommunicator.mode == CommunicatorMode_Sender) {
             communicator.modeData.sender.range = nodeCommunicator.modeData.sender.range;
+            communicator.modeData.sender.oneway = nodeCommunicator.modeData.sender.oneway;
         } else if (nodeCommunicator.mode == CommunicatorMode_Receiver) {
             communicator.modeData.receiver.restrictToColors = nodeCommunicator.modeData.receiver.restrictToColors;
             communicator.modeData.receiver.restrictToLineage = nodeCommunicator.modeData.receiver.restrictToLineage;

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -277,6 +277,7 @@ struct MemoryGenome
 struct SenderGenome
 {
     uint8_t range;
+    bool oneway;
 };
 
 struct ReceiverGenome

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -282,6 +282,7 @@ struct MemoryGenomeTO
 struct SenderGenomeTO
 {
     uint8_t range;
+    bool oneway;
 };
 
 struct ReceiverGenomeTO

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -474,6 +474,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_cellTypeProperties(
                     switch (node.cellTypeData.communicator.mode) {
                     case CommunicatorMode_Sender:
                         mutateNumber(node.cellTypeData.communicator.modeData.sender.range, Const::CommunicatorRange_Min, Const::CommunicatorRange_Max);
+                        mutateBoolField(node.cellTypeData.communicator.modeData.sender.oneway);
                         break;
                     case CommunicatorMode_Receiver:
                         mutateBitset(node.cellTypeData.communicator.modeData.receiver.restrictToColors, Const::RestrictToColors_Max);
@@ -640,7 +641,7 @@ __inline__ __device__ void MutationProcessor::resetCellTypeModeToDefault(Node& n
         auto& communicator = node.cellTypeData.communicator;
         switch (communicator.mode) {
         case CommunicatorMode_Sender:
-            communicator.modeData.sender = {Const::CommunicatorRange_Default};
+            communicator.modeData.sender = {Const::CommunicatorRange_Default, Const::CommunicatorOneway_Default};
             break;
         case CommunicatorMode_Receiver:
             communicator.modeData.receiver = {Const::RestrictToColors_Default, LineageRestriction_No};

--- a/source/EngineKernels/TOs.cuh
+++ b/source/EngineKernels/TOs.cuh
@@ -353,6 +353,7 @@ struct MemoryTO
 struct SenderTO
 {
     uint8_t range;
+    bool oneway;
 };
 
 struct ReceiverTO

--- a/source/EngineTestData/DescTestDataFactory.cpp
+++ b/source/EngineTestData/DescTestDataFactory.cpp
@@ -625,6 +625,9 @@ bool DescTestDataFactory::compare(ObjectDesc const& object, NodeDesc const& node
             if (sender._range != nodeSender._range) {
                 return false;
             }
+            if (sender._oneway != nodeSender._oneway) {
+                return false;
+            }
         } break;
         case CommunicatorMode_Receiver: {
             auto const& receiver = std::get<ReceiverDesc>(communicator._mode);
@@ -827,7 +830,7 @@ CellTypeDesc DescTestDataFactory::createNonDefaultCellTypeDesc(ObjectParameter o
         CommunicatorModeDesc communicatorModeDesc;
         switch (communicatorMode) {
         case CommunicatorMode_Sender:
-            communicatorModeDesc = SenderDesc().range(150);
+            communicatorModeDesc = SenderDesc().range(150).oneway(false);
             break;
         case CommunicatorMode_Receiver:
             communicatorModeDesc = ReceiverDesc().restrictToColors(1 << 2).restrictToLineage(LineageRestriction_UnrelatedLineage);
@@ -993,7 +996,7 @@ CellTypeGenomeDesc DescTestDataFactory::createNonDefaultCellTypeGenomeDesc(NodeP
         CommunicatorModeGenomeDesc communicatorModeDesc;
         switch (communicatorMode) {
         case CommunicatorMode_Sender:
-            communicatorModeDesc = SenderGenomeDesc().range(200);
+            communicatorModeDesc = SenderGenomeDesc().range(200).oneway(false);
             break;
         case CommunicatorMode_Receiver:
             communicatorModeDesc = ReceiverGenomeDesc().restrictToColors(1 << 5).restrictToLineage(LineageRestriction_RelatedLineage);

--- a/source/EngineTests/CellTypeMutationCoverageGuard.cpp
+++ b/source/EngineTests/CellTypeMutationCoverageGuard.cpp
@@ -79,7 +79,7 @@ ALIEN_MUTATION_FIELD_COUNT(SignalStorageGenomeDesc, 1);
 ALIEN_MUTATION_FIELD_COUNT(SignalIntegratorGenomeDesc, 1);
 
 // --- Communicator modes (switch (node.cellTypeData.communicator.mode)) ---
-ALIEN_MUTATION_FIELD_COUNT(SenderGenomeDesc, 1);
+ALIEN_MUTATION_FIELD_COUNT(SenderGenomeDesc, 2);
 ALIEN_MUTATION_FIELD_COUNT(ReceiverGenomeDesc, 2);
 
 // --- Number of modes per cell type ---

--- a/source/Gui/InspectionWindow.cpp
+++ b/source/Gui/InspectionWindow.cpp
@@ -859,6 +859,7 @@ void _InspectionWindow::processCellTypeNode(CellDesc& cell)
             if (mode == CommunicatorMode_Sender) {
                 auto& m = std::get<SenderDesc>(communicator._mode);
                 AlienGui::SliderInt(AlienGui::SliderIntParameters().name("Range").min(0).max(20).textWidth(TextWidth), &m._range);
+                AlienGui::Checkbox(AlienGui::CheckboxParameters().name("One-way").textWidth(TextWidth), m._oneway);
             } else if (mode == CommunicatorMode_Receiver) {
                 auto& m = std::get<ReceiverDesc>(communicator._mode);
                 AlienGui::ColorCheckboxes(

--- a/source/Gui/NodeEditorWidget.cpp
+++ b/source/Gui/NodeEditorWidget.cpp
@@ -672,6 +672,7 @@ void _NodeEditorWidget::processNodeAttributes()
                     AlienGui::BeginIndent();
                     auto& sender = std::get<SenderGenomeDesc>(communicator._mode);
                     AlienGui::SliderInt(AlienGui::SliderIntParameters().name("Range").min(0).max(20).textWidth(rightColumnWidth), &sender._range);
+                    AlienGui::Checkbox(AlienGui::CheckboxParameters().name("One-way").textWidth(rightColumnWidth), sender._oneway);
                     AlienGui::EndIndent();
                 } else if (mode == CommunicatorMode_Receiver) {
                     AlienGui::BeginIndent();

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -434,6 +434,7 @@ namespace
     auto constexpr Id_MemoryGenome_ChannelBitMask = 0;
 
     auto constexpr Id_SenderGenome_Range = 0;
+    auto constexpr Id_SenderGenome_Oneway = 1;
 
     auto constexpr Id_ReceiverGenome_RestrictToColor = 1;
     auto constexpr Id_ReceiverGenome_RestrictToLineage = 2;
@@ -849,6 +850,7 @@ namespace cereal
         SenderGenomeDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_SenderGenome_Range, data._range, defaultObject._range);
+        scope.addMember(Id_SenderGenome_Oneway, data._oneway, defaultObject._oneway);
     }
     SPLIT_SERIALIZATION(SenderGenomeDesc)
 
@@ -1281,6 +1283,7 @@ namespace
     auto constexpr Id_Memory_ChannelBitMask = 0;
 
     auto constexpr Id_Sender_Range = 0;
+    auto constexpr Id_Sender_Oneway = 1;
 
     auto constexpr Id_Receiver_RestrictToColor = 1;
     auto constexpr Id_Receiver_RestrictToLineage = 2;
@@ -1732,6 +1735,7 @@ namespace cereal
         SenderDesc defaultObject;
         auto scope = getSerializationScope(task, ar);
         scope.addMember(Id_Sender_Range, data._range, defaultObject._range);
+        scope.addMember(Id_Sender_Oneway, data._oneway, defaultObject._oneway);
     }
     SPLIT_SERIALIZATION(SenderDesc)
 


### PR DESCRIPTION
## Summary
- Add `oneway` flag (default `true`) to `SenderDesc`/`SenderTO`/`SenderGenomeDesc`/`SenderGenomeTO` (and the underlying runtime `Sender`/`SenderGenome` structs), wired through conversion, persistence, mutation, and the GPU-side runtime/genome copy paths.
- Refactor: move the `Math::dot(toReceiver, senderFacing) <= 0` facing-direction gate out of `processSender`'s scan loop and into `tryTransmitSignal`, where it is now guarded by `sender.oneway`. When `oneway` is false, a sender transmits to matching receivers regardless of facing direction.
- Wire the new flag into `DescTestDataFactory`, GUI editors (`NodeEditorWidget` genome editor, `InspectionWindow` live object editor).

## Test plan
- [x] `build-windows-ninja.bat` Release build succeeds
- [x] `EngineInterfaceTests.exe` — 159/159 passed
- [x] `NetworkTests.exe` — 4/4 passed
- [x] `PersisterTests.exe` — 64/64 passed
- [x] `EngineTests.exe` (GPU) — 3077/3077 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)