### PR TITLE
Assign new lineage id when creating seed

### DIFF
--- a/source/EngineInterface/DescEditService.cpp
+++ b/source/EngineInterface/DescEditService.cpp
@@ -516,7 +516,7 @@ void DescEditService::randomizeCountdowns(Desc& description, int minValue, int m
 void DescEditService::randomizeLineageIds(Desc& description) const
 {
     for (auto& creature : description._creatures) {
-        creature._lineageId = NumberGenerator::get().getRandomInt();
+        creature._lineageId = toInt(NumberGenerator::get().createLineageId());
     }
 }
 

--- a/source/Gui/GenomeEditorWindow.cpp
+++ b/source/Gui/GenomeEditorWindow.cpp
@@ -9,6 +9,7 @@
 #include <Base/GlobalSettings.h>
 #include <Base/StringHelper.h>
 
+#include <EngineInterface/DescEditService.h>
 #include <EngineInterface/GenomeDescInfoService.h>
 #include <EngineInterface/NumberGenerator.h>
 #include <EngineInterface/SimulationFacade.h>
@@ -320,6 +321,7 @@ void GenomeEditorWindow::onCreateSeed(bool provideEnergy)
                                                              .separation(true)))},
         CreatureDesc(),
         genome);
+    DescEditService::get().randomizeLineageIds(seed);
 
     _SimulationFacade::get()->addAndSelectSimulationData(std::move(seed));
     EditorModel::get().update();


### PR DESCRIPTION
## Summary
- `GenomeEditorWindow::onCreateSeed` now calls `DescEditService::randomizeLineageIds` so a freshly created seed gets its own lineage id instead of inheriting the genome tab's current one.

## Test plan
- [x] `build-windows-ninja.bat 16` — clean build, `alien.exe` links
- [x] `EngineInterfaceTests.exe` — 159 tests pass