### PR TITLE
Add maximize button to MutationRatesDialog

### DIFF
--- a/source/Gui/AlienDialog.cpp
+++ b/source/Gui/AlienDialog.cpp
@@ -1,6 +1,6 @@
 #include "AlienDialog.h"
 
-#include <Fonts/IconsFontAwesome5.h>
+#include "AlienGui.h"
 
 AlienDialog::AlienDialog(std::string const& title, RealVector2D const& defaultSize, bool maximizable)
     : _title(title)
@@ -109,10 +109,8 @@ void AlienDialog::processMaximizeButton()
     auto windowSize = ImGui::GetWindowSize();
     auto iconSize = ImGui::GetFontSize();
     auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f), windowPos.y + (titlebarHeight - iconSize) * 0.5f);
-    auto iconCenter = ImVec2(iconPos.x + iconSize * 0.5f, iconPos.y + iconSize * 0.5f);
 
-    ImGui::SetCursorScreenPos(iconPos);
-    if (ImGui::InvisibleButton("MaximizeButton", ImVec2(iconSize, iconSize))) {
+    if (AlienGui::TitlebarMaximizeButton(iconPos, iconSize, _windowState == DialogWindowState::Maximized)) {
         if (_windowState == DialogWindowState::Maximized) {
             ImGui::SetWindowPos(_savedPos);
             ImGui::SetWindowSize(_savedSize);
@@ -123,23 +121,6 @@ void AlienDialog::processMaximizeButton()
             _windowState = DialogWindowState::Maximized;
         }
     }
-
-    auto pressed = ImGui::IsItemActive();
-    auto hovered = ImGui::IsItemHovered();
-    auto drawList = ImGui::GetWindowDrawList();
-    if (hovered || pressed) {
-        auto bgColor = hovered && pressed ? ImGui::GetColorU32(ImGuiCol_ButtonActive) : ImGui::GetColorU32(ImGuiCol_ButtonHovered);
-        auto radius = iconSize * 0.6f;
-        drawList->AddCircleFilled(iconCenter, radius, bgColor, 12);
-    }
-
-    auto icon = _windowState == DialogWindowState::Maximized ? ICON_FA_COMPRESS_ARROWS_ALT : ICON_FA_EXPAND_ARROWS_ALT;
-    drawList->AddText(
-        StyleRepository::get().getIconFont(),
-        iconSize * 0.7f,
-        ImVec2(iconCenter.x - iconSize * 0.31f, iconCenter.y - iconSize * 0.22f),
-        ImGui::GetColorU32(ImGuiCol_Text),
-        icon);
 }
 
 void AlienDialog::shutdown()

--- a/source/Gui/AlienDialog.cpp
+++ b/source/Gui/AlienDialog.cpp
@@ -1,9 +1,11 @@
 #include "AlienDialog.h"
 
+#include <Fonts/IconsFontAwesome5.h>
 
-AlienDialog::AlienDialog(std::string const& title, RealVector2D const& defaultSize)
+AlienDialog::AlienDialog(std::string const& title, RealVector2D const& defaultSize, bool maximizable)
     : _title(title)
     , _defaultSize(defaultSize)
+    , _isMaximizable(maximizable)
 {}
 
 void AlienDialog::init()
@@ -63,13 +65,22 @@ void AlienDialog::processDialog()
         ImGui::SetNextWindowSize({scale(_defaultSize.x), scale(_defaultSize.y)}, ImGuiCond_FirstUseEver);
         ImGui::OpenPopup(_title.c_str());
         _state = DialogState::Open;
+        _windowState = DialogWindowState::Normal;
     }
     auto& style = ImGui::GetStyle();
     auto origWindowMinSize = style.WindowMinSize;
     style.WindowMinSize.x = scale(350.0f);
     style.WindowMinSize.y = scale(150.0f);
 
-    if (ImGui::BeginPopupModal(_title.c_str(), NULL, 0)) {
+    ImGuiWindowFlags flags = ImGuiWindowFlags_None;
+    if (_isMaximizable && _windowState == DialogWindowState::Maximized) {
+        auto viewport = ImGui::GetMainViewport();
+        ImGui::SetNextWindowPos(viewport->Pos, ImGuiCond_Always);
+        ImGui::SetNextWindowSize(viewport->Size, ImGuiCond_Always);
+        flags |= ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
+    }
+
+    if (ImGui::BeginPopupModal(_title.c_str(), NULL, flags)) {
         if (!_sizeInitialized) {
             auto size = ImGui::GetWindowSize();
             auto factor = WindowController::get().getContentScaleFactor() / WindowController::get().getLastContentScaleFactor();
@@ -77,6 +88,9 @@ void AlienDialog::processDialog()
             _sizeInitialized = true;
         }
 
+        if (_isMaximizable) {
+            processMaximizeButton();
+        }
 
         ImGui::PushID(_title.c_str());
         processIntern();
@@ -86,6 +100,46 @@ void AlienDialog::processDialog()
     }
 
     style.WindowMinSize = origWindowMinSize;
+}
+
+void AlienDialog::processMaximizeButton()
+{
+    auto titlebarHeight = ImGui::GetFrameHeight();
+    auto windowPos = ImGui::GetWindowPos();
+    auto windowSize = ImGui::GetWindowSize();
+    auto iconSize = ImGui::GetFontSize();
+    auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f), windowPos.y + (titlebarHeight - iconSize) * 0.5f);
+    auto iconCenter = ImVec2(iconPos.x + iconSize * 0.5f, iconPos.y + iconSize * 0.5f);
+
+    ImGui::SetCursorScreenPos(iconPos);
+    if (ImGui::InvisibleButton("MaximizeButton", ImVec2(iconSize, iconSize))) {
+        if (_windowState == DialogWindowState::Maximized) {
+            ImGui::SetWindowPos(_savedPos);
+            ImGui::SetWindowSize(_savedSize);
+            _windowState = DialogWindowState::Normal;
+        } else {
+            _savedPos = windowPos;
+            _savedSize = windowSize;
+            _windowState = DialogWindowState::Maximized;
+        }
+    }
+
+    auto pressed = ImGui::IsItemActive();
+    auto hovered = ImGui::IsItemHovered();
+    auto drawList = ImGui::GetWindowDrawList();
+    if (hovered || pressed) {
+        auto bgColor = hovered && pressed ? ImGui::GetColorU32(ImGuiCol_ButtonActive) : ImGui::GetColorU32(ImGuiCol_ButtonHovered);
+        auto radius = iconSize * 0.6f;
+        drawList->AddCircleFilled(iconCenter, radius, bgColor, 12);
+    }
+
+    auto icon = _windowState == DialogWindowState::Maximized ? ICON_FA_COMPRESS_ARROWS_ALT : ICON_FA_EXPAND_ARROWS_ALT;
+    drawList->AddText(
+        StyleRepository::get().getIconFont(),
+        iconSize * 0.7f,
+        ImVec2(iconCenter.x - iconSize * 0.31f, iconCenter.y - iconSize * 0.22f),
+        ImGui::GetColorU32(ImGuiCol_Text),
+        icon);
 }
 
 void AlienDialog::shutdown()

--- a/source/Gui/AlienDialog.cpp
+++ b/source/Gui/AlienDialog.cpp
@@ -110,7 +110,13 @@ void AlienDialog::processMaximizeButton()
     auto iconSize = ImGui::GetFontSize();
     auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f), windowPos.y + (titlebarHeight - iconSize) * 0.5f);
 
-    if (AlienGui::MaximizeButton(iconPos, iconSize, _windowState == DialogWindowState::Maximized)) {
+    // BeginPopupModal() clips widgets to the area below its native titlebar, so widen the clip rect
+    // to make the button visible and clickable inside that titlebar strip.
+    ImGui::PushClipRect(windowPos, ImVec2(windowPos.x + windowSize.x, windowPos.y + titlebarHeight), false);
+    auto clicked = AlienGui::MaximizeButton(iconPos, iconSize, _windowState == DialogWindowState::Maximized);
+    ImGui::PopClipRect();
+
+    if (clicked) {
         if (_windowState == DialogWindowState::Maximized) {
             ImGui::SetWindowPos(_savedPos);
             ImGui::SetWindowSize(_savedSize);

--- a/source/Gui/AlienDialog.cpp
+++ b/source/Gui/AlienDialog.cpp
@@ -110,7 +110,7 @@ void AlienDialog::processMaximizeButton()
     auto iconSize = ImGui::GetFontSize();
     auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f), windowPos.y + (titlebarHeight - iconSize) * 0.5f);
 
-    if (AlienGui::TitlebarMaximizeButton(iconPos, iconSize, _windowState == DialogWindowState::Maximized)) {
+    if (AlienGui::MaximizeButton(iconPos, iconSize, _windowState == DialogWindowState::Maximized)) {
         if (_windowState == DialogWindowState::Maximized) {
             ImGui::SetWindowPos(_savedPos);
             ImGui::SetWindowSize(_savedSize);

--- a/source/Gui/AlienDialog.h
+++ b/source/Gui/AlienDialog.h
@@ -12,7 +12,7 @@
 class AlienDialog : public MainLoopEntity
 {
 public:
-    AlienDialog(std::string const& title, RealVector2D const& defaultSize = RealVector2D(450.0f, 150.0f));
+    AlienDialog(std::string const& title, RealVector2D const& defaultSize = RealVector2D(450.0f, 150.0f), bool maximizable = false);
 
     virtual void open();
     void processNested();
@@ -32,6 +32,7 @@ private:
     void init() override;
     void process() override;
     void processDialog();
+    void processMaximizeButton();
     void shutdown() override;
 
     bool _sizeInitialized = false;
@@ -45,4 +46,14 @@ private:
     DialogState _state = DialogState::Closed;
     std::string _title;
     RealVector2D _defaultSize;
+
+    bool _isMaximizable = false;
+    enum class DialogWindowState
+    {
+        Normal,
+        Maximized
+    };
+    DialogWindowState _windowState = DialogWindowState::Normal;
+    ImVec2 _savedPos;
+    ImVec2 _savedSize;
 };

--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -1921,6 +1921,33 @@ bool AlienGui::CollapseButton(bool collapsed)
     return result;
 }
 
+bool AlienGui::TitlebarMaximizeButton(ImVec2 const& pos, float iconSize, bool maximized)
+{
+    auto iconCenter = ImVec2(pos.x + iconSize * 0.5f, pos.y + iconSize * 0.5f);
+
+    ImGui::SetCursorScreenPos(pos);
+    auto clicked = ImGui::InvisibleButton("MaximizeButton", ImVec2(iconSize, iconSize));
+
+    auto pressed = ImGui::IsItemActive();
+    auto hovered = ImGui::IsItemHovered();
+    auto drawList = ImGui::GetWindowDrawList();
+    if (hovered || pressed) {
+        auto bgColor = hovered && pressed ? ImGui::GetColorU32(ImGuiCol_ButtonActive) : ImGui::GetColorU32(ImGuiCol_ButtonHovered);
+        auto radius = iconSize * 0.6f;
+        drawList->AddCircleFilled(iconCenter, radius, bgColor, 12);
+    }
+
+    auto icon = maximized ? ICON_FA_COMPRESS_ARROWS_ALT : ICON_FA_EXPAND_ARROWS_ALT;
+    drawList->AddText(
+        StyleRepository::get().getIconFont(),
+        iconSize * 0.7f,
+        ImVec2(iconCenter.x - iconSize * 0.31f, iconCenter.y - iconSize * 0.22f),
+        ImGui::GetColorU32(ImGuiCol_Text),
+        icon);
+
+    return clicked;
+}
+
 bool AlienGui::BeginTreeNode(TreeNodeParameters const& parameters)
 {
     auto id = ImGui::GetID(parameters._name.c_str());

--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -1921,7 +1921,7 @@ bool AlienGui::CollapseButton(bool collapsed)
     return result;
 }
 
-bool AlienGui::TitlebarMaximizeButton(ImVec2 const& pos, float iconSize, bool maximized)
+bool AlienGui::MaximizeButton(ImVec2 const& pos, float iconSize, bool maximized)
 {
     auto iconCenter = ImVec2(pos.x + iconSize * 0.5f, pos.y + iconSize * 0.5f);
 

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -440,6 +440,7 @@ public:
     static void ToolbarSeparator();
     static bool Button(std::string const& text, float size = 0);
     static bool CollapseButton(bool collapsed);
+    static bool TitlebarMaximizeButton(ImVec2 const& pos, float iconSize, bool maximized);
 
     enum class TreeNodeRank
     {

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -440,7 +440,7 @@ public:
     static void ToolbarSeparator();
     static bool Button(std::string const& text, float size = 0);
     static bool CollapseButton(bool collapsed);
-    static bool TitlebarMaximizeButton(ImVec2 const& pos, float iconSize, bool maximized);
+    static bool MaximizeButton(ImVec2 const& pos, float iconSize, bool maximized);
 
     enum class TreeNodeRank
     {

--- a/source/Gui/AlienWindow.cpp
+++ b/source/Gui/AlienWindow.cpp
@@ -1,5 +1,7 @@
 #include "AlienWindow.h"
 
+#include "AlienGui.h"
+
 AlienWindow::AlienWindow(std::string const& title, std::string const& settingsNode, bool defaultOn, bool maximizable, RealVector2D const& minSize)
     : _title(title)
     , _settingsNode(settingsNode)
@@ -220,47 +222,14 @@ void AlienWindow::processMaximizeButton()
     auto windowSize = ImGui::GetWindowSize();
     auto iconSize = ImGui::GetFontSize();
     auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f) * 2, windowPos.y + (titlebarHeight - iconSize) * 0.5f);
-    auto iconCenter = ImVec2(iconPos.x + iconSize * 0.5f, iconPos.y + iconSize * 0.5f);
 
-    // Process interaction field
-    ImGui::SetCursorScreenPos(iconPos);
-    if (ImGui::InvisibleButton("MaximizeButton", ImVec2(iconSize, iconSize))) {
+    if (AlienGui::TitlebarMaximizeButton(iconPos, iconSize, _state == WindowState::Maximized)) {
         if (_state == WindowState::Maximized) {
             ImGui::SetWindowPos(_savedPos);
             ImGui::SetWindowSize(_savedSize);
             _state = WindowState::Normal;
         } else {
             _state = WindowState::Maximized;
-        }
-    }
-
-    // Draw background circle
-    auto pressed = ImGui::IsItemActive();
-    bool hovered = ImGui::IsItemHovered();
-    auto drawList = ImGui::GetWindowDrawList();
-    auto center = ImVec2(iconPos.x + iconSize * 0.5f, iconPos.y + iconSize * 0.5f);
-    if (hovered || pressed) {
-        auto bgColor = hovered && pressed ? ImGui::GetColorU32(ImGuiCol_ButtonActive) : ImGui::GetColorU32(ImGuiCol_ButtonHovered);
-        auto radius = iconSize * 0.6f;
-        drawList->AddCircleFilled(iconCenter, radius, bgColor, 12);
-    }
-
-    // Draw icon
-    {
-        if (_state == WindowState::Maximized) {
-            drawList->AddText(
-                StyleRepository::get().getIconFont(),
-                iconSize * 0.7f,
-                ImVec2(center.x - iconSize * 0.31f, center.y - iconSize * 0.22f),
-                ImGui::GetColorU32(ImGuiCol_Text),
-                ICON_FA_COMPRESS_ARROWS_ALT);
-        } else {
-            drawList->AddText(
-                StyleRepository::get().getIconFont(),
-                iconSize * 0.7f,
-                ImVec2(center.x - iconSize * 0.31f, center.y - iconSize * 0.22f),
-                ImGui::GetColorU32(ImGuiCol_Text),
-                ICON_FA_EXPAND_ARROWS_ALT);
         }
     }
 }

--- a/source/Gui/AlienWindow.cpp
+++ b/source/Gui/AlienWindow.cpp
@@ -223,7 +223,7 @@ void AlienWindow::processMaximizeButton()
     auto iconSize = ImGui::GetFontSize();
     auto iconPos = ImVec2(windowPos.x + windowSize.x - scale(24.0f) * 2, windowPos.y + (titlebarHeight - iconSize) * 0.5f);
 
-    if (AlienGui::TitlebarMaximizeButton(iconPos, iconSize, _state == WindowState::Maximized)) {
+    if (AlienGui::MaximizeButton(iconPos, iconSize, _state == WindowState::Maximized)) {
         if (_state == WindowState::Maximized) {
             ImGui::SetWindowPos(_savedPos);
             ImGui::SetWindowSize(_savedSize);

--- a/source/Gui/AlienWindow.h
+++ b/source/Gui/AlienWindow.h
@@ -2,8 +2,6 @@
 
 #include <imgui.h>
 
-#include <Fonts/IconsFontAwesome5.h>
-
 #include <Base/GlobalSettings.h>
 
 #include "Definitions.h"

--- a/source/Gui/MutationRatesDialog.cpp
+++ b/source/Gui/MutationRatesDialog.cpp
@@ -265,7 +265,7 @@ namespace
 }
 
 MutationRatesDialog::MutationRatesDialog()
-    : AlienDialog("Mutation rates", {800.0f, 400.0f})
+    : AlienDialog("Mutation rates", {800.0f, 400.0f}, true)
 {}
 
 void MutationRatesDialog::initIntern() {}


### PR DESCRIPTION
## Summary
- Port `AlienWindow`'s maximize icon/behavior into `AlienDialog` (modal popups) as an opt-in `maximizable` constructor flag.
- Enable it for `MutationRatesDialog`, adding a maximize/restore icon to its titlebar so it can fill the viewport.

## Test plan
- [x] `build-windows-ninja.bat 16` builds clean
- [x] `EngineInterfaceTests.exe` passes (159 tests)
- [ ] Manual click-through of the maximize button in the running app (not done in this session)