### PR TITLE
Save global settings instantly on Linux

### DIFF
--- a/source/Base/GlobalSettings.cpp
+++ b/source/Base/GlobalSettings.cpp
@@ -180,6 +180,26 @@ namespace
             std::filesystem::create_directories(configPath);
         }
     }
+
+    void saveLinuxSettings(boost::property_tree::ptree const& tree)
+    {
+        try {
+            ensureLinuxConfigDirectoryExists();
+
+            std::stringstream ss;
+            boost::property_tree::json_parser::write_json(ss, tree);
+            auto data = ss.str();
+
+            auto settingsPath = getLinuxSettingsFilePath();
+            std::ofstream stream(settingsPath, std::ios::binary);
+            if (stream) {
+                stream << data;
+                stream.close();
+            }
+        } catch (...) {
+            //do nothing
+        }
+    }
 }
 #endif
 
@@ -234,6 +254,7 @@ void GlobalSettings::setValue(std::string const& key, bool value)
     setBoolToWinReg(key, value);
 #else
     JsonParser::encodeDecode(_impl->_tree, value, false, key, ParserTask::Encode);
+    saveLinuxSettings(_impl->_tree);
 #endif
 }
 
@@ -254,6 +275,7 @@ void GlobalSettings::setValue(std::string const& key, int value)
     setIntToWinReg(key, value);
 #else
     JsonParser::encodeDecode(_impl->_tree, value, 0, key, ParserTask::Encode);
+    saveLinuxSettings(_impl->_tree);
 #endif
 }
 
@@ -274,6 +296,7 @@ void GlobalSettings::setValue(std::string const& key, float value)
     setFloatToWinReg(key, value);
 #else
     JsonParser::encodeDecode(_impl->_tree, value, 0.0f, key, ParserTask::Encode);
+    saveLinuxSettings(_impl->_tree);
 #endif
 }
 
@@ -294,6 +317,7 @@ void GlobalSettings::setValue(std::string const& key, std::string value)
     setStringToWinReg(key, value);
 #else
     JsonParser::encodeDecode(_impl->_tree, value, std::string(), key, ParserTask::Encode);
+    saveLinuxSettings(_impl->_tree);
 #endif
 }
 
@@ -335,21 +359,6 @@ GlobalSettings::GlobalSettings()
 GlobalSettings::~GlobalSettings()
 {
 #ifndef _WIN32
-    try {
-        ensureLinuxConfigDirectoryExists();
-
-        std::stringstream ss;
-        boost::property_tree::json_parser::write_json(ss, _impl->_tree);
-        auto data = ss.str();
-
-        auto settingsPath = getLinuxSettingsFilePath();
-        std::ofstream stream(settingsPath, std::ios::binary);
-        if (stream) {
-            stream << data;
-            stream.close();
-        }
-    } catch (...) {
-        //do nothing
-    }
+    saveLinuxSettings(_impl->_tree);
 #endif
 }


### PR DESCRIPTION
## Summary
- Windows already writes each GlobalSettings::setValue to the registry immediately.
- Linux was buffering all writes in an in-memory ptree and only flushing to settings.json in the destructor (process exit), so settings were lost on crash and not visible until exit.
- Extracted the write logic into saveLinuxSettings() and call it after every setValue on Linux, so settings are persisted instantly like on Windows.

## Test plan
- Built via build-windows-ninja.bat 16 (Release) — all 265 targets linked successfully, alien.exe produced.
- clang-format --dry-run --Werror clean on the modified file.