### PR TITLE
fix: CUDA 13.3 compatibility and CJK font rendering support

### DIFF
--- a/external/cuda/helper_cuda.h
+++ b/external/cuda/helper_cuda.h
@@ -1100,7 +1100,9 @@ inline int gpuDeviceInit(int devID)
     cudaDeviceProp deviceProp;
     checkCudaErrors(cudaGetDeviceProperties(&deviceProp, devID));
 
-    if (deviceProp.computeMode == cudaComputeModeProhibited)
+    int computeMode = 0;
+    checkCudaErrors(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, devID));
+    if (computeMode == cudaComputeModeProhibited)
     {
         fprintf(stderr, "Error: device is running in <Compute Mode Prohibited>, no threads can use ::cudaSetDevice().\n");
         return -1;
@@ -1144,7 +1146,9 @@ inline int gpuGetMaxGflopsDeviceId()
         cudaGetDeviceProperties(&deviceProp, current_device);
 
         // If this GPU is not running on Compute Mode prohibited, then we can add it to the list
-        if (deviceProp.computeMode != cudaComputeModeProhibited)
+        int computeMode = 0;
+        checkCudaErrors(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, current_device));
+        if (computeMode != cudaComputeModeProhibited)
         {
             if (deviceProp.major > 0 && deviceProp.major < 9999)
             {
@@ -1172,8 +1176,10 @@ inline int gpuGetMaxGflopsDeviceId()
     {
         cudaGetDeviceProperties(&deviceProp, current_device);
 
+        int computeMode = 0;
+        checkCudaErrors(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, current_device));
         // If this GPU is not running on Compute Mode prohibited, then we can add it to the list
-        if (deviceProp.computeMode != cudaComputeModeProhibited)
+        if (computeMode != cudaComputeModeProhibited)
         {
             if (deviceProp.major == 9999 && deviceProp.minor == 9999)
             {
@@ -1184,7 +1190,9 @@ inline int gpuGetMaxGflopsDeviceId()
                 sm_per_multiproc = _ConvertSMVer2Cores(deviceProp.major, deviceProp.minor);
             }
 
-            unsigned long long compute_perf  = (unsigned long long) deviceProp.multiProcessorCount * sm_per_multiproc * deviceProp.clockRate;
+            int clockRate = 0;
+            checkCudaErrors(cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate, current_device));
+            unsigned long long compute_perf  = (unsigned long long) deviceProp.multiProcessorCount * sm_per_multiproc * clockRate;
 
             if (compute_perf  > max_compute_perf)
             {

--- a/source/EngineGpuKernels/ConstantMemory.cu
+++ b/source/EngineGpuKernels/ConstantMemory.cu
@@ -1,4 +1,4 @@
 ﻿#include "ConstantMemory.cuh"
 
 __constant__ GpuSettings cudaThreadSettings;
-__constant__ SimulationParameters cudaSimulationParameters;
+__device__ char cudaSimulationParametersData[sizeof(SimulationParameters)];

--- a/source/EngineGpuKernels/ConstantMemory.cuh
+++ b/source/EngineGpuKernels/ConstantMemory.cuh
@@ -4,4 +4,5 @@
 #include "EngineInterface/GpuSettings.h"
 
 __constant__ extern GpuSettings cudaThreadSettings;
-__constant__ extern SimulationParameters cudaSimulationParameters;
+__device__ extern char cudaSimulationParametersData[sizeof(SimulationParameters)];
+#define cudaSimulationParameters (*reinterpret_cast<SimulationParameters*>(cudaSimulationParametersData))

--- a/source/EngineGpuKernels/SimulationCudaFacade.cu
+++ b/source/EngineGpuKernels/SimulationCudaFacade.cu
@@ -145,7 +145,7 @@ void _SimulationCudaFacade::calcTimestep(uint64_t timesteps, bool forceUpdateSta
             std::lock_guard lock(_mutexForSimulationParameters);
             if (SimulationParametersUpdateService::get().updateSimulationParametersAfterTimestep(_settings, _maxAgeBalancer, simulationData, statistics)) {
                 CHECK_FOR_CUDA_ERROR(
-                    cudaMemcpyToSymbol(cudaSimulationParameters, &_settings.simulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
+                    cudaMemcpyToSymbol(cudaSimulationParametersData, &_settings.simulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
             }
         }
         auto now = std::chrono::steady_clock::now();
@@ -489,7 +489,7 @@ void _SimulationCudaFacade::testOnly_mutate(uint64_t cellId, MutationType mutati
         if (_newSimulationParameters) {
             _settings.simulationParameters = *_newSimulationParameters;
             CHECK_FOR_CUDA_ERROR(
-                cudaMemcpyToSymbol(cudaSimulationParameters, &*_newSimulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
+                cudaMemcpyToSymbol(cudaSimulationParametersData, &*_newSimulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
             _newSimulationParameters.reset();
         }
     }
@@ -506,7 +506,7 @@ void _SimulationCudaFacade::testOnly_mutationCheck(uint64_t cellId)
         if (_newSimulationParameters) {
             _settings.simulationParameters = *_newSimulationParameters;
             CHECK_FOR_CUDA_ERROR(
-                cudaMemcpyToSymbol(cudaSimulationParameters, &*_newSimulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
+                cudaMemcpyToSymbol(cudaSimulationParametersData, &*_newSimulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
             _newSimulationParameters.reset();
         }
     }
@@ -661,7 +661,7 @@ void _SimulationCudaFacade::checkAndProcessSimulationParameterChanges()
         _settings.simulationParameters =
             SimulationParametersUpdateService::get().integrateChanges(_settings.simulationParameters, *_newSimulationParameters, _simulationParametersUpdateConfig);
         CHECK_FOR_CUDA_ERROR(
-            cudaMemcpyToSymbol(cudaSimulationParameters, &_settings.simulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
+            cudaMemcpyToSymbol(cudaSimulationParametersData, &_settings.simulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
         _newSimulationParameters.reset();
 
         if (_cudaSimulationData) {

--- a/source/Gui/StyleRepository.cpp
+++ b/source/Gui/StyleRepository.cpp
@@ -1,6 +1,7 @@
 #include "StyleRepository.h"
 
 #include <stdexcept>
+#include <unistd.h>
 
 #include <ImFileDialog.h>
 #include <GLFW/glfw3.h> // Will drag system OpenGL headers
@@ -31,6 +32,13 @@ void StyleRepository::setup()
     configMerge.MergeMode = true;
     configMerge.FontBuilderFlags = ImGuiFreeTypeBuilderFlags_LightHinting;
 
+    ImFontConfig configCJK;
+    configCJK.MergeMode = true;
+    configCJK.FontBuilderFlags = ImGuiFreeTypeBuilderFlags_LightHinting;
+    configCJK.FontNo = 0;
+    auto const* cjkFontPath = "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc";
+    auto cjkFontAvailable = (access(cjkFontPath, R_OK) == 0);
+
     ImGuiIO& io = ImGui::GetIO();
 
     //default font (small with icons)
@@ -40,18 +48,33 @@ void StyleRepository::setup()
         io.Fonts->AddFontFromMemoryCompressedTTF(
             FontAwesomeSolid_compressed_data, FontAwesomeSolid_compressed_size, 16.0f * scaleFactor, &configMerge, rangesIcons);
     }
+    if (cjkFontAvailable) {
+        io.Fonts->AddFontFromFileTTF(cjkFontPath, 16.0f * scaleFactor, &configCJK, io.Fonts->GetGlyphRangesChineseFull());
+    }
 
     //small bold font
     _smallBoldFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSansBold_compressed_data, DroidSansBold_compressed_size, 16.0f * scaleFactor);
+    if (cjkFontAvailable) {
+        io.Fonts->AddFontFromFileTTF(cjkFontPath, 16.0f * scaleFactor, &configCJK, io.Fonts->GetGlyphRangesChineseFull());
+    }
 
     //medium bold font
     _mediumBoldFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSansBold_compressed_data, DroidSansBold_compressed_size, 24.0f * scaleFactor);
+    if (cjkFontAvailable) {
+        io.Fonts->AddFontFromFileTTF(cjkFontPath, 24.0f * scaleFactor, &configCJK, io.Fonts->GetGlyphRangesChineseFull());
+    }
 
     //medium font
     _mediumFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSans_compressed_data, DroidSans_compressed_size, 24.0f * scaleFactor);
+    if (cjkFontAvailable) {
+        io.Fonts->AddFontFromFileTTF(cjkFontPath, 24.0f * scaleFactor, &configCJK, io.Fonts->GetGlyphRangesChineseFull());
+    }
 
     //large font
     _largeFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSans_compressed_data, DroidSans_compressed_size, 48.0f * scaleFactor);
+    if (cjkFontAvailable) {
+        io.Fonts->AddFontFromFileTTF(cjkFontPath, 48.0f * scaleFactor, &configCJK, io.Fonts->GetGlyphRangesChineseFull());
+    }
 
     //icon font
     _iconFont = io.Fonts->AddFontFromMemoryCompressedTTF(AlienIconFont_compressed_data, AlienIconFont_compressed_size, 24.0f * scaleFactor);


### PR DESCRIPTION
## Changes

### CUDA 13.3+ Compatibility
- **helper_cuda.h**: Replace deprecated computeMode/clockRate with cudaDeviceGetAttribute() calls
- **ConstantMemory.cuh/.cu**: Replace __constant__ with __device__ char[] + macro
- **SimulationCudaFacade.cu**: Update cudaMemcpyToSymbol target variable name

### CJK Font Support
- **StyleRepository.cpp**: Merge system NotoSansCJK into DroidSans fonts with GetGlyphRangesChineseFull

---

> **AI Generated Notice**: This PR was fully AI-generated using [opencode](https://opencode.ai) with the **DeepSeek-v4-Flash** model. I have reviewed the code and confirmed it functions correctly. If this PR is not appropriate, feel free to close it.
