### PR TITLE
Fix AccumulatedMutationTests.accumulatedMutations_createsNewLineageId

### DIFF
--- a/source/EngineTests/AccumulatedMutationTests.cpp
+++ b/source/EngineTests/AccumulatedMutationTests.cpp
@@ -142,6 +142,8 @@ TEST_F(AccumulatedMutationTests, accumulatedMutations_metaMutationDoesNotAccount
 TEST_F(AccumulatedMutationTests, accumulatedMutations_createsNewLineageId)
 {
     auto genome = createTestGenome();
+    genome._mutationRates._neuronMutations[0] =
+        NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f).biasChangeSigma(1.0f).actfnChangeProbability(1.0f);
 
     auto data =
         Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42).accumulatedMutations(11.0f).accumulatedMutationsInLineage(11.0f), genome);


### PR DESCRIPTION
## Summary
- `accumulatedMutations_createsNewLineageId` asserted `accumulatedMutations > 11.0f` after one mutate call, but the genome had no active mutation rate (all default `nodeProbability` values are `0.0f`), so no mutation actually happened and the value stayed exactly `11.0f`.
- Set an active neuron mutation rate on the genome so a real mutation occurs, matching the pattern used in the other tests in this file.

## Test plan
- [x] `EngineTests.exe`: 3080 tests ran, 3077 passed, 3 skipped (pre-existing), 0 failed