### PR TITLE
Evolution Dashboard: real data supply (Phases 1-3)

### DIFF
--- a/source/EngineImpl/EngineWorker.cpp
+++ b/source/EngineImpl/EngineWorker.cpp
@@ -114,6 +114,16 @@ void EngineWorker::setStatisticsHistory(StatisticsHistoryData const& data)
     _simulationCudaFacade->setStatisticsHistory(data);
 }
 
+RawLineageStatistics EngineWorker::getRawLineageStatistics() const
+{
+    return _simulationCudaFacade->getRawLineageStatistics();
+}
+
+LineageHistory const& EngineWorker::getLineageHistory() const
+{
+    return _simulationCudaFacade->getLineageHistory();
+}
+
 void EngineWorker::addAndSelectSimulationData(Desc&& dataToUpdate)
 {
     EngineWorkerGuard access(this);

--- a/source/EngineImpl/EngineWorker.h
+++ b/source/EngineImpl/EngineWorker.h
@@ -14,6 +14,8 @@
 #include <EngineInterface/CudaSettings.h>
 #include <EngineInterface/Definitions.h>
 #include <EngineInterface/GeometryBuffers.h>
+#include <EngineInterface/LineageHistory.h>
+#include <EngineInterface/LineageStatistics.h>
 #include <EngineInterface/PreviewDesc.h>
 #include <EngineInterface/SelectionShallowData.h>
 #include <EngineInterface/SettingsForSimulation.h>
@@ -58,6 +60,8 @@ public:
     StatisticsRawData getStatisticsRawData() const;
     StatisticsHistory const& getStatisticsHistory() const;
     void setStatisticsHistory(StatisticsHistoryData const& data);
+    RawLineageStatistics getRawLineageStatistics() const;
+    LineageHistory const& getLineageHistory() const;
 
     void addAndSelectSimulationData(Desc&& dataToUpdate);
     void setSimulationData(Desc const& dataToUpdate);

--- a/source/EngineImpl/SimulationCudaFacade.cu
+++ b/source/EngineImpl/SimulationCudaFacade.cu
@@ -51,6 +51,11 @@
 namespace
 {
     std::chrono::milliseconds const StatisticsUpdate(30);
+
+    // The evolution statistics kernels are heavy; running them at wall-clock-throttled (i.e. run-to-run varying)
+    // timesteps perturbs the simulation's GPU execution timing and makes simulation runs non-reproducible.
+    // They are therefore scheduled at deterministic timestep intervals instead.
+    auto constexpr EvolutionStatisticsUpdateInterval = 10;
     auto constexpr PreviewLineageMapCapacity = 1 << 12;
     ArraySizesForGpuEntities const PreviewCapacityGpu{10000, 10000, 10000000};
     ArraySizesForTOs const PreviewCapacityTO{1000, 1000, 1000, 10000, 10000, 10000, 10000000};
@@ -444,16 +449,32 @@ StatisticsRawData _SimulationCudaFacade::getStatisticsRawData()
 
 void _SimulationCudaFacade::updateStatistics()
 {
+    updateEvolutionStatistics();
+    updateTimestepStatistics();
+}
+
+void _SimulationCudaFacade::updateTimestepStatistics()
+{
     StatisticsKernelsService::get().updateStatistics(_settings.cudaSettings, getSimulationDataPtrCopy(), *_cudaSimulationStatistics);
+    syncAndCheck();
+
+    {
+        std::lock_guard lock(_mutexForStatistics);
+        _statisticsData = _cudaSimulationStatistics->getStatistics();
+    }
+    StatisticsService::get().addDataPoint(_statisticsHistory, _statisticsData->timeline, getCurrentTimestep());
+}
+
+void _SimulationCudaFacade::updateEvolutionStatistics()
+{
+    StatisticsKernelsService::get().updateEvolutionStatistics(_settings.cudaSettings, getSimulationDataPtrCopy(), *_cudaSimulationStatistics);
     syncAndCheck();
 
     auto lineageStatistics = _cudaSimulationStatistics->getLineageStatistics();
     {
         std::lock_guard lock(_mutexForStatistics);
-        _statisticsData = _cudaSimulationStatistics->getStatistics();
         _lineageStatisticsData = lineageStatistics;
     }
-    StatisticsService::get().addDataPoint(_statisticsHistory, _statisticsData->timeline, getCurrentTimestep());
     _lineageHistoryService.addSample(_lineageHistory, lineageStatistics, getCurrentTimestep());
 }
 
@@ -840,10 +861,14 @@ void _SimulationCudaFacade::calcTimestepsInternal(uint64_t timesteps, bool force
                     cudaMemcpyToSymbol(cudaSimulationParameters, &_settings.simulationParameters, sizeof(SimulationParameters), 0, cudaMemcpyHostToDevice));
             }
         }
+        if (getCurrentTimestep() % EvolutionStatisticsUpdateInterval == 0) {
+            updateEvolutionStatistics();
+        }
+
         auto now = std::chrono::steady_clock::now();
         if (!_lastStatisticsUpdateTime || now - *_lastStatisticsUpdateTime > StatisticsUpdate) {
             _lastStatisticsUpdateTime = now;
-            updateStatistics();
+            updateTimestepStatistics();
         }
     }
     if (forceUpdateStatistics) {

--- a/source/EngineImpl/SimulationCudaFacade.cu
+++ b/source/EngineImpl/SimulationCudaFacade.cu
@@ -51,6 +51,7 @@
 namespace
 {
     std::chrono::milliseconds const StatisticsUpdate(30);
+    auto constexpr PreviewLineageMapCapacity = 1 << 12;
     ArraySizesForGpuEntities const PreviewCapacityGpu{10000, 10000, 10000000};
     ArraySizesForTOs const PreviewCapacityTO{1000, 1000, 1000, 10000, 10000, 10000, 10000000};
 }
@@ -82,7 +83,7 @@ _SimulationCudaFacade::_SimulationCudaFacade(uint64_t timestep, SettingsForSimul
     _cudaSimulationData->init({_settings.worldSizeX, _settings.worldSizeY}, timestep);
     _cudaPreviewData->init({_settingsForPreview.worldSizeX, _settingsForPreview.worldSizeY}, 0);
     _cudaSimulationStatistics->init();
-    _cudaPreviewStatistics->init();
+    _cudaPreviewStatistics->init(PreviewLineageMapCapacity);
     _cudaSelectionResult->init();
 
     GarbageCollectorKernelsService::get().init();
@@ -112,6 +113,7 @@ _SimulationCudaFacade::~_SimulationCudaFacade() noexcept
             _cudaSimulationData->free();
             _cudaPreviewData->free();
             _cudaSimulationStatistics->free();
+            _cudaPreviewStatistics->free();
             _cudaSelectionResult->free();
 
             SimulationKernelsService::get().shutdown();
@@ -445,16 +447,34 @@ void _SimulationCudaFacade::updateStatistics()
     StatisticsKernelsService::get().updateStatistics(_settings.cudaSettings, getSimulationDataPtrCopy(), *_cudaSimulationStatistics);
     syncAndCheck();
 
+    auto lineageStatistics = _cudaSimulationStatistics->getLineageStatistics();
     {
         std::lock_guard lock(_mutexForStatistics);
         _statisticsData = _cudaSimulationStatistics->getStatistics();
+        _lineageStatisticsData = lineageStatistics;
     }
     StatisticsService::get().addDataPoint(_statisticsHistory, _statisticsData->timeline, getCurrentTimestep());
+    _lineageHistoryService.addSample(_lineageHistory, lineageStatistics, getCurrentTimestep());
 }
 
 StatisticsHistory const& _SimulationCudaFacade::getStatisticsHistory() const
 {
     return _statisticsHistory;
+}
+
+RawLineageStatistics _SimulationCudaFacade::getRawLineageStatistics()
+{
+    std::lock_guard lock(_mutexForStatistics);
+    if (_lineageStatisticsData) {
+        return *_lineageStatisticsData;
+    } else {
+        return RawLineageStatistics();
+    }
+}
+
+LineageHistory const& _SimulationCudaFacade::getLineageHistory() const
+{
+    return _lineageHistory;
 }
 
 void _SimulationCudaFacade::setStatisticsHistory(StatisticsHistoryData const& data)
@@ -582,7 +602,7 @@ TOs _SimulationCudaFacade::getPreviewData()
 void _SimulationCudaFacade::testOnly_mutate(uint64_t objectId)
 {
     checkAndProcessSimulationParameterChanges();
-    TestKernelsService::get().testOnly_mutate(_settings.cudaSettings, getSimulationDataPtrCopy(), objectId);
+    TestKernelsService::get().testOnly_mutate(_settings.cudaSettings, getSimulationDataPtrCopy(), *_cudaSimulationStatistics, objectId);
     syncAndCheck();
 
     resizeArraysIfNecessary();

--- a/source/EngineImpl/SimulationCudaFacade.cuh
+++ b/source/EngineImpl/SimulationCudaFacade.cuh
@@ -126,6 +126,9 @@ public:
 private:
     void initCuda();
 
+    void updateTimestepStatistics();
+    void updateEvolutionStatistics();
+
     void syncAndCheck();
     void copyDataTOtoGpu(TOs const& cudaTO, TOs const& to);
     void copyDataTOtoHost(TOs const& to, TOs const& cudaTO);

--- a/source/EngineImpl/SimulationCudaFacade.cuh
+++ b/source/EngineImpl/SimulationCudaFacade.cuh
@@ -13,6 +13,9 @@
 #include <EngineInterface/ArraySizesForTOs.h>
 #include <EngineInterface/Definitions.h>
 #include <EngineInterface/GeometryBuffers.h>
+#include <EngineInterface/LineageHistory.h>
+#include <EngineInterface/LineageHistoryService.h>
+#include <EngineInterface/LineageStatistics.h>
 #include <EngineInterface/SelectionShallowData.h>
 #include <EngineInterface/SettingsForSimulation.h>
 #include <EngineInterface/ShallowUpdateSelectionData.h>
@@ -87,6 +90,8 @@ public:
     void updateStatistics();
     StatisticsHistory const& getStatisticsHistory() const;
     void setStatisticsHistory(StatisticsHistoryData const& data);
+    RawLineageStatistics getRawLineageStatistics();
+    LineageHistory const& getLineageHistory() const;
 
     void resetTimeIntervalStatistics();
     uint64_t getCurrentTimestep() const;
@@ -156,6 +161,9 @@ private:
     std::optional<std::chrono::steady_clock::time_point> _lastStatisticsUpdateTime;
     std::optional<StatisticsRawData> _statisticsData;
     StatisticsHistory _statisticsHistory;
+    std::optional<RawLineageStatistics> _lineageStatisticsData;
+    LineageHistory _lineageHistory;
+    LineageHistoryService _lineageHistoryService;
     std::shared_ptr<SimulationStatistics> _cudaSimulationStatistics;
     std::shared_ptr<SimulationStatistics> _cudaPreviewStatistics;
     MaxAgeBalancer _maxAgeBalancer;

--- a/source/EngineImpl/SimulationFacadeImpl.cpp
+++ b/source/EngineImpl/SimulationFacadeImpl.cpp
@@ -335,6 +335,16 @@ void _SimulationFacadeImpl::setStatisticsHistory(StatisticsHistoryData const& da
     _worker.setStatisticsHistory(data);
 }
 
+RawLineageStatistics _SimulationFacadeImpl::getRawLineageStatistics() const
+{
+    return _worker.getRawLineageStatistics();
+}
+
+LineageHistory const& _SimulationFacadeImpl::getLineageHistory() const
+{
+    return _worker.getLineageHistory();
+}
+
 std::optional<int> _SimulationFacadeImpl::getTpsRestriction() const
 {
     auto result = _worker.getTpsRestriction();

--- a/source/EngineImpl/SimulationFacadeImpl.h
+++ b/source/EngineImpl/SimulationFacadeImpl.h
@@ -91,6 +91,8 @@ public:
     StatisticsRawData getStatisticsRawData() const override;
     StatisticsHistory const& getStatisticsHistory() const override;
     void setStatisticsHistory(StatisticsHistoryData const& data) override;
+    RawLineageStatistics getRawLineageStatistics() const override;
+    LineageHistory const& getLineageHistory() const override;
 
     std::optional<int> getTpsRestriction() const override;
     void setTpsRestriction(std::optional<int> const& value) override;

--- a/source/EngineImpl/StatisticsKernelsService.cu
+++ b/source/EngineImpl/StatisticsKernelsService.cu
@@ -11,6 +11,16 @@ void StatisticsKernelsService::updateStatistics(CudaSettings const& gpuSettings,
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep1, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep2, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep3, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateEvolutionStatistics_substep1, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateEvolutionStatistics_substep2, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateEvolutionStatistics_substep3, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateEvolutionStatistics_substep4, data, simulationStatistics);
+    KERNEL_CALL_1_1(cudaUpdateEvolutionStatistics_substep5, data, simulationStatistics);
+    if (simulationStatistics.isLineageAccumulatorGCNeeded()) {
+        KERNEL_CALL(cudaPrepareLineageAccumulatorGC, simulationStatistics);
+        KERNEL_CALL(cudaLineageAccumulatorGC, simulationStatistics);
+        KERNEL_CALL_1_1(cudaFinishLineageAccumulatorGC, simulationStatistics);
+    }
     KERNEL_CALL_1_1(cudaUpdateHistogramData_substep1, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateHistogramData_substep2, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateHistogramData_substep3, data, simulationStatistics);

--- a/source/EngineImpl/StatisticsKernelsService.cu
+++ b/source/EngineImpl/StatisticsKernelsService.cu
@@ -11,6 +11,16 @@ void StatisticsKernelsService::updateStatistics(CudaSettings const& gpuSettings,
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep1, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep2, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateTimestepStatistics_substep3, data, simulationStatistics);
+    KERNEL_CALL_1_1(cudaUpdateHistogramData_substep1, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateHistogramData_substep2, data, simulationStatistics);
+    KERNEL_CALL(cudaUpdateHistogramData_substep3, data, simulationStatistics);
+}
+
+void StatisticsKernelsService::updateEvolutionStatistics(
+    CudaSettings const& gpuSettings,
+    SimulationData const& data,
+    SimulationStatistics const& simulationStatistics)
+{
     KERNEL_CALL(cudaUpdateEvolutionStatistics_substep1, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateEvolutionStatistics_substep2, data, simulationStatistics);
     KERNEL_CALL(cudaUpdateEvolutionStatistics_substep3, data, simulationStatistics);
@@ -21,7 +31,4 @@ void StatisticsKernelsService::updateStatistics(CudaSettings const& gpuSettings,
         KERNEL_CALL(cudaLineageAccumulatorGC, simulationStatistics);
         KERNEL_CALL_1_1(cudaFinishLineageAccumulatorGC, simulationStatistics);
     }
-    KERNEL_CALL_1_1(cudaUpdateHistogramData_substep1, data, simulationStatistics);
-    KERNEL_CALL(cudaUpdateHistogramData_substep2, data, simulationStatistics);
-    KERNEL_CALL(cudaUpdateHistogramData_substep3, data, simulationStatistics);
 }

--- a/source/EngineImpl/StatisticsKernelsService.cuh
+++ b/source/EngineImpl/StatisticsKernelsService.cuh
@@ -18,6 +18,10 @@ public:
 
     void updateStatistics(CudaSettings const& gpuSettings, SimulationData const& data, SimulationStatistics const& simulationStatistics);
 
+    // Runs at deterministic timesteps (not wall-clock throttled): heavy kernels here would otherwise
+    // perturb the simulation's execution timing at run-to-run varying timesteps.
+    void updateEvolutionStatistics(CudaSettings const& gpuSettings, SimulationData const& data, SimulationStatistics const& simulationStatistics);
+
 private:
     StatisticsKernelsService() = default;
 };

--- a/source/EngineImpl/TestKernelsService.cu
+++ b/source/EngineImpl/TestKernelsService.cu
@@ -15,9 +15,9 @@ void TestKernelsService::shutdown()
     CudaMemoryManager::getInstance().freeMemory(_cudaBoolResult);
 }
 
-void TestKernelsService::testOnly_mutate(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId)
+void TestKernelsService::testOnly_mutate(CudaSettings const& gpuSettings, SimulationData const& data, SimulationStatistics const& statistics, uint64_t objectId)
 {
-    KERNEL_CALL_MOD(cudaTestMutate, NEURONS_PER_CELL, data, objectId);
+    KERNEL_CALL_MOD(cudaTestMutate, NEURONS_PER_CELL, data, statistics, objectId);
 }
 
 void TestKernelsService::testOnly_removeUnusedGenes(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId)

--- a/source/EngineImpl/TestKernelsService.cuh
+++ b/source/EngineImpl/TestKernelsService.cuh
@@ -14,7 +14,7 @@ public:
     void init();
     void shutdown();
 
-    void testOnly_mutate(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId);
+    void testOnly_mutate(CudaSettings const& gpuSettings, SimulationData const& data, SimulationStatistics const& statistics, uint64_t objectId);
     void testOnly_removeUnusedGenes(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId);
     void testOnly_createConnection(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId1, uint64_t objectId2);
     void testOnly_createConnectionWithAbsAngle(

--- a/source/EngineInterface/CMakeLists.txt
+++ b/source/EngineInterface/CMakeLists.txt
@@ -26,6 +26,11 @@ add_library(EngineInterface
     GeometryBuffers.h
     Ids.h
     InspectedEntityIds.h
+    LineageHistory.cpp
+    LineageHistory.h
+    LineageHistoryService.cpp
+    LineageHistoryService.h
+    LineageStatistics.h
     LocationHelper.cpp
     LocationHelper.h
     NeuralNetWeight.h

--- a/source/EngineInterface/DataPointCollection.cpp
+++ b/source/EngineInterface/DataPointCollection.cpp
@@ -50,6 +50,18 @@ DataPointCollection DataPointCollection::operator+(DataPointCollection const& ot
     result.numReconnectorCreated = numReconnectorCreated + other.numReconnectorCreated;
     result.numReconnectorRemoved = numReconnectorRemoved + other.numReconnectorRemoved;
     result.numDetonations = numDetonations + other.numDetonations;
+    result.numCreatures = numCreatures + other.numCreatures;
+    result.averageCreatureCells = averageCreatureCells + other.averageCreatureCells;
+    result.averageGenomeNodes = averageGenomeNodes + other.averageGenomeNodes;
+    result.creatureEnergy = creatureEnergy + other.creatureEnergy;
+    result.averageMutationRate = averageMutationRate + other.averageMutationRate;
+    result.averageGeneration = averageGeneration + other.averageGeneration;
+    result.numLineages = numLineages + other.numLineages;
+    result.numSolidObjects = numSolidObjects + other.numSolidObjects;
+    result.numFluidObjects = numFluidObjects + other.numFluidObjects;
+    result.numCellObjects = numCellObjects + other.numCellObjects;
+    result.accumCreatedCreatures = accumCreatedCreatures + other.accumCreatedCreatures;
+    result.accumMutations = accumMutations + other.accumMutations;
     return result;
 }
 
@@ -83,5 +95,17 @@ DataPointCollection DataPointCollection::operator/(double divisor) const
     result.numReconnectorCreated = numReconnectorCreated / divisor;
     result.numReconnectorRemoved = numReconnectorRemoved / divisor;
     result.numDetonations = numDetonations / divisor;
+    result.numCreatures = numCreatures / divisor;
+    result.averageCreatureCells = averageCreatureCells / divisor;
+    result.averageGenomeNodes = averageGenomeNodes / divisor;
+    result.creatureEnergy = creatureEnergy / divisor;
+    result.averageMutationRate = averageMutationRate / divisor;
+    result.averageGeneration = averageGeneration / divisor;
+    result.numLineages = numLineages / divisor;
+    result.numSolidObjects = numSolidObjects / divisor;
+    result.numFluidObjects = numFluidObjects / divisor;
+    result.numCellObjects = numCellObjects / divisor;
+    result.accumCreatedCreatures = accumCreatedCreatures / divisor;
+    result.accumMutations = accumMutations / divisor;
     return result;
 }

--- a/source/EngineInterface/DataPointCollection.h
+++ b/source/EngineInterface/DataPointCollection.h
@@ -43,6 +43,20 @@ struct DataPointCollection
     DataPoint numReconnectorRemoved;
     DataPoint numDetonations;
 
+    // Evolution dashboard values (not color-resolved)
+    double numCreatures = 0;
+    double averageCreatureCells = 0;
+    double averageGenomeNodes = 0;
+    double creatureEnergy = 0;
+    double averageMutationRate = 0;
+    double averageGeneration = 0;
+    double numLineages = 0;
+    double numSolidObjects = 0;
+    double numFluidObjects = 0;
+    double numCellObjects = 0;
+    double accumCreatedCreatures = 0;  // Raw accumulated value; rates are derived GUI-side
+    double accumMutations = 0;         // Raw accumulated value; rates are derived GUI-side
+
     DataPointCollection operator+(DataPointCollection const& other) const;
     DataPointCollection operator/(double divisor) const;
 };

--- a/source/EngineInterface/LineageHistory.cpp
+++ b/source/EngineInterface/LineageHistory.cpp
@@ -1,0 +1,23 @@
+#include "LineageHistory.h"
+
+LineageHistoryData LineageHistory::getCopiedData() const
+{
+    std::lock_guard lock(_mutex);
+    auto copy = _data;
+    return copy;
+}
+
+std::mutex& LineageHistory::getMutex() const
+{
+    return _mutex;
+}
+
+LineageHistoryData& LineageHistory::getDataRef()
+{
+    return _data;
+}
+
+LineageHistoryData const& LineageHistory::getDataRef() const
+{
+    return _data;
+}

--- a/source/EngineInterface/LineageHistory.h
+++ b/source/EngineInterface/LineageHistory.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <mutex>
+#include <vector>
+
+#include "LineageStatistics.h"
+
+struct LineageSample
+{
+    double time = 0;  // Could be a time step or real-time
+    double systemClock = 0;
+    std::vector<LineageStatisticsEntry> entries;  // Sorted by lineageId
+};
+
+using LineageHistoryData = std::vector<LineageSample>;
+
+class LineageHistory
+{
+public:
+    LineageHistoryData getCopiedData() const;
+
+    std::mutex& getMutex() const;
+    LineageHistoryData& getDataRef();
+    LineageHistoryData const& getDataRef() const;
+
+private:
+    mutable std::mutex _mutex;
+    LineageHistoryData _data;
+};

--- a/source/EngineInterface/LineageHistoryService.cpp
+++ b/source/EngineInterface/LineageHistoryService.cpp
@@ -61,7 +61,6 @@ LineageSample LineageHistoryService::mergeSamples(LineageSample const& earlierSa
         result.numGenomes = (lhs.numGenomes + rhs.numGenomes) / 2;
         result.sumCreatureCells = (lhs.sumCreatureCells + rhs.sumCreatureCells) / 2;
         result.sumCreatureGenerations = (lhs.sumCreatureGenerations + rhs.sumCreatureGenerations) / 2;
-        result.sumAccumulatedMutations = (lhs.sumAccumulatedMutations + rhs.sumAccumulatedMutations) / 2;
         result.sumGenomeNodes = (lhs.sumGenomeNodes + rhs.sumGenomeNodes) / 2;
         result.sumMutationRates = (lhs.sumMutationRates + rhs.sumMutationRates) / 2;
         result.sumCreatureEnergy = (lhs.sumCreatureEnergy + rhs.sumCreatureEnergy) / 2;

--- a/source/EngineInterface/LineageHistoryService.cpp
+++ b/source/EngineInterface/LineageHistoryService.cpp
@@ -1,0 +1,89 @@
+#include "LineageHistoryService.h"
+
+#include <algorithm>
+#include <chrono>
+
+#include <Base/Definitions.h>
+
+void LineageHistoryService::addSample(LineageHistory& history, RawLineageStatistics const& rawStatistics, uint64_t timestep)
+{
+    std::lock_guard lock(history.getMutex());
+    auto& historyData = history.getDataRef();
+
+    if (!historyData.empty() && historyData.back().time > toDouble(timestep) + NEAR_ZERO) {
+        historyData.clear();
+        _longtermTimestepDelta = DefaultTimestepDelta;
+    }
+
+    if (!historyData.empty() && toDouble(timestep) - historyData.back().time < _longtermTimestepDelta) {
+        return;
+    }
+
+    LineageSample sample;
+    sample.time = toDouble(timestep);
+    auto now = std::chrono::system_clock::now();
+    auto unixEpoch = std::chrono::time_point<std::chrono::system_clock>();
+    sample.systemClock = toDouble(std::chrono::duration_cast<std::chrono::seconds>(now - unixEpoch).count());
+    sample.entries = rawStatistics.entries;
+    std::sort(sample.entries.begin(), sample.entries.end(), [](auto const& lhs, auto const& rhs) { return lhs.lineageId < rhs.lineageId; });
+    historyData.emplace_back(std::move(sample));
+
+    if (historyData.size() > MaxSamples) {
+        LineageHistoryData newData;
+        newData.reserve(historyData.size() / 2 + 1);
+        for (size_t i = 0; i < (historyData.size() - 1) / 2; ++i) {
+            newData.emplace_back(mergeSamples(historyData.at(i * 2), historyData.at(i * 2 + 1)));
+        }
+        newData.emplace_back(historyData.back());
+        historyData.swap(newData);
+
+        _longtermTimestepDelta *= 2.0;
+    }
+}
+
+void LineageHistoryService::reset()
+{
+    _longtermTimestepDelta = DefaultTimestepDelta;
+}
+
+LineageSample LineageHistoryService::mergeSamples(LineageSample const& earlierSample, LineageSample const& laterSample)
+{
+    LineageSample result;
+    result.time = earlierSample.time;
+    result.systemClock = (earlierSample.systemClock + laterSample.systemClock) / 2;
+    result.entries.reserve(earlierSample.entries.size() + laterSample.entries.size());
+
+    auto mergeEntries = [](LineageStatisticsEntry const& lhs, LineageStatisticsEntry const& rhs) {
+        LineageStatisticsEntry result;
+        result.lineageId = lhs.lineageId;
+        result.colorBitset = lhs.colorBitset | rhs.colorBitset;
+        result.numCreatures = (lhs.numCreatures + rhs.numCreatures) / 2;
+        result.numGenomes = (lhs.numGenomes + rhs.numGenomes) / 2;
+        result.sumCreatureCells = (lhs.sumCreatureCells + rhs.sumCreatureCells) / 2;
+        result.sumCreatureGenerations = (lhs.sumCreatureGenerations + rhs.sumCreatureGenerations) / 2;
+        result.sumAccumulatedMutations = (lhs.sumAccumulatedMutations + rhs.sumAccumulatedMutations) / 2;
+        result.sumGenomeNodes = (lhs.sumGenomeNodes + rhs.sumGenomeNodes) / 2;
+        result.sumMutationRates = (lhs.sumMutationRates + rhs.sumMutationRates) / 2;
+        result.sumCreatureEnergy = (lhs.sumCreatureEnergy + rhs.sumCreatureEnergy) / 2;
+        result.numCreatedCreatures = std::max(lhs.numCreatedCreatures, rhs.numCreatedCreatures);
+        result.totalMutations = std::max(lhs.totalMutations, rhs.totalMutations);
+        return result;
+    };
+
+    auto earlierIter = earlierSample.entries.begin();
+    auto laterIter = laterSample.entries.begin();
+    while (earlierIter != earlierSample.entries.end() || laterIter != laterSample.entries.end()) {
+        if (laterIter == laterSample.entries.end() || (earlierIter != earlierSample.entries.end() && earlierIter->lineageId < laterIter->lineageId)) {
+            result.entries.emplace_back(*earlierIter);
+            ++earlierIter;
+        } else if (earlierIter == earlierSample.entries.end() || laterIter->lineageId < earlierIter->lineageId) {
+            result.entries.emplace_back(*laterIter);
+            ++laterIter;
+        } else {
+            result.entries.emplace_back(mergeEntries(*earlierIter, *laterIter));
+            ++earlierIter;
+            ++laterIter;
+        }
+    }
+    return result;
+}

--- a/source/EngineInterface/LineageHistoryService.h
+++ b/source/EngineInterface/LineageHistoryService.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+#include "LineageHistory.h"
+#include "LineageStatistics.h"
+
+class LineageHistoryService
+{
+public:
+    void addSample(LineageHistory& history, RawLineageStatistics const& rawStatistics, uint64_t timestep);
+    void reset();
+
+    // Merges two consecutive samples: union of the lineage ids, momentary values are averaged
+    // and accumulated values are maximized where a lineage is present in both samples.
+    static LineageSample mergeSamples(LineageSample const& earlierSample, LineageSample const& laterSample);
+
+private:
+    static auto constexpr MaxSamples = 1000;
+    static auto constexpr DefaultTimestepDelta = 10.0;
+
+    double _longtermTimestepDelta = DefaultTimestepDelta;
+};

--- a/source/EngineInterface/LineageStatistics.h
+++ b/source/EngineInterface/LineageStatistics.h
@@ -11,7 +11,6 @@ struct LineageStatisticsEntry
     uint32_t numGenomes = 0;
     float sumCreatureCells = 0;
     float sumCreatureGenerations = 0;
-    float sumAccumulatedMutations = 0;
     float sumGenomeNodes = 0;
     float sumMutationRates = 0;
     float sumCreatureEnergy = 0;

--- a/source/EngineInterface/LineageStatistics.h
+++ b/source/EngineInterface/LineageStatistics.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+struct LineageStatisticsEntry
+{
+    uint32_t lineageId = 0;
+    uint32_t colorBitset = 0;
+    uint32_t numCreatures = 0;
+    uint32_t numGenomes = 0;
+    float sumCreatureCells = 0;
+    float sumCreatureGenerations = 0;
+    float sumAccumulatedMutations = 0;
+    float sumGenomeNodes = 0;
+    float sumMutationRates = 0;
+    float sumCreatureEnergy = 0;
+    uint32_t numCreatedCreatures = 0;  // Accumulated, never reset
+    float totalMutations = 0;          // Accumulated, never reset
+};
+
+struct RawLineageStatistics
+{
+    std::vector<LineageStatisticsEntry> entries;
+};

--- a/source/EngineInterface/SimulationFacade.h
+++ b/source/EngineInterface/SimulationFacade.h
@@ -4,6 +4,8 @@
 #include "DataPointCollection.h"
 #include "Definitions.h"
 #include "GeometryBuffers.h"
+#include "LineageHistory.h"
+#include "LineageStatistics.h"
 #include "PreviewDesc.h"
 #include "SelectionShallowData.h"
 #include "SettingsForSimulation.h"
@@ -106,6 +108,8 @@ public:
     virtual StatisticsRawData getStatisticsRawData() const = 0;
     virtual StatisticsHistory const& getStatisticsHistory() const = 0;
     virtual void setStatisticsHistory(StatisticsHistoryData const& data) = 0;
+    virtual RawLineageStatistics getRawLineageStatistics() const = 0;
+    virtual LineageHistory const& getLineageHistory() const = 0;
 
     //********************
     //* Preview simulation

--- a/source/EngineInterface/StatisticsConverterService.cpp
+++ b/source/EngineInterface/StatisticsConverterService.cpp
@@ -100,6 +100,20 @@ DataPointCollection StatisticsConverterService::convert(
     result.averageNumCells = getDataPointByAveraging(data.timestep.numObjects, data.timestep.numSelfReplicators);
     result.totalEnergy = getDataPointBySummation(data.timestep.totalEnergy);
 
+    auto const& evolution = data.timestep.evolution;
+    result.numCreatures = toDouble(evolution.numCreatures);
+    result.averageCreatureCells = evolution.numCreatures > 0 ? toDouble(evolution.sumCreatureCells) / evolution.numCreatures : 0.0;
+    result.averageGeneration = evolution.numCreatures > 0 ? toDouble(evolution.sumCreatureGenerations) / evolution.numCreatures : 0.0;
+    result.averageGenomeNodes = evolution.numGenomes > 0 ? toDouble(evolution.sumGenomeNodes) / evolution.numGenomes : 0.0;
+    result.averageMutationRate = evolution.numGenomes > 0 ? toDouble(evolution.sumMutationRates) / evolution.numGenomes : 0.0;
+    result.creatureEnergy = toDouble(evolution.sumCreatureEnergy);
+    result.numLineages = toDouble(evolution.numActiveLineages);
+    result.numSolidObjects = toDouble(evolution.numSolidObjects);
+    result.numFluidObjects = toDouble(evolution.numFluidObjects);
+    result.numCellObjects = toDouble(evolution.numCellObjects);
+    result.accumCreatedCreatures = toDouble(data.accumulated.numCreatedCreatures);
+    result.accumMutations = data.accumulated.totalMutations;
+
     auto deltaTimesteps = lastTimestep ? toDouble(timestep) - toDouble(*lastTimestep) : 1.0;
     if (deltaTimesteps < NEAR_ZERO) {
         deltaTimesteps = 1.0;

--- a/source/EngineInterface/StatisticsRawData.h
+++ b/source/EngineInterface/StatisticsRawData.h
@@ -3,6 +3,23 @@
 #include <EngineInterface/Colors.h>
 #include <EngineInterface/EngineConstants.h>
 
+struct EvolutionStatistics
+{
+    int numCreatures = 0;
+    float sumCreatureCells = 0;
+    float sumCreatureGenerations = 0;
+    float sumAccumulatedMutations = 0;
+    int numGenomes = 0;
+    float sumGenomeNodes = 0;
+    float sumMutationRates = 0;  // Sum over genomes of the per-genome mean of all mutation probabilities
+    float sumCreatureEnergy = 0;
+    int numSolidObjects = 0;
+    int numFluidObjects = 0;
+    int numCellObjects = 0;
+    int numActiveLineages = 0;
+    int lineageMapOverflow = 0;
+};
+
 struct TimestepStatistics
 {
     ColorVector<int> numObjects = {};
@@ -12,6 +29,7 @@ struct TimestepStatistics
     ColorVector<int> numFreeCells = {};
     ColorVector<int> numEnergyParticles = {};
     ColorVector<float> totalEnergy = {};
+    EvolutionStatistics evolution;
 };
 
 struct AccumulatedStatistics
@@ -31,6 +49,8 @@ struct AccumulatedStatistics
     ColorVector<uint64_t> numReconnectorCreated = {};
     ColorVector<uint64_t> numReconnectorRemoved = {};
     ColorVector<uint64_t> numDetonations = {};
+    uint64_t numCreatedCreatures = 0;
+    double totalMutations = 0;
 };
 
 struct TimelineStatistics

--- a/source/EngineInterfaceTests/CMakeLists.txt
+++ b/source/EngineInterfaceTests/CMakeLists.txt
@@ -4,6 +4,7 @@ PUBLIC
     DescValidationServiceTests.cpp
     GenomeDescEditServiceTests.cpp
     GenomeDescInfoServiceTests.cpp
+    LineageHistoryServiceTests.cpp
     ParametersEditServiceTests.cpp
     PreviewDescConverterServiceTests.cpp
     SpecificationFilterServiceTests.cpp

--- a/source/EngineInterfaceTests/LineageHistoryServiceTests.cpp
+++ b/source/EngineInterfaceTests/LineageHistoryServiceTests.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/LineageHistoryService.h>
+
+class LineageHistoryServiceTests : public ::testing::Test
+{
+protected:
+    static LineageStatisticsEntry createEntry(uint32_t lineageId)
+    {
+        LineageStatisticsEntry result;
+        result.lineageId = lineageId;
+        return result;
+    }
+
+    static RawLineageStatistics createRawStatistics(std::vector<LineageStatisticsEntry> entries)
+    {
+        RawLineageStatistics result;
+        result.entries = std::move(entries);
+        return result;
+    }
+};
+
+TEST_F(LineageHistoryServiceTests, mergeSamples_disjointIds)
+{
+    LineageSample earlierSample;
+    earlierSample.time = 100;
+    earlierSample.systemClock = 10;
+    earlierSample.entries = {createEntry(1), createEntry(3)};
+
+    LineageSample laterSample;
+    laterSample.time = 200;
+    laterSample.systemClock = 20;
+    laterSample.entries = {createEntry(2), createEntry(4)};
+
+    auto result = LineageHistoryService::mergeSamples(earlierSample, laterSample);
+
+    EXPECT_EQ(100, result.time);
+    EXPECT_EQ(15, result.systemClock);
+    ASSERT_EQ(4, result.entries.size());
+    EXPECT_EQ(1, result.entries.at(0).lineageId);
+    EXPECT_EQ(2, result.entries.at(1).lineageId);
+    EXPECT_EQ(3, result.entries.at(2).lineageId);
+    EXPECT_EQ(4, result.entries.at(3).lineageId);
+}
+
+TEST_F(LineageHistoryServiceTests, mergeSamples_commonIds)
+{
+    auto entry1 = createEntry(7);
+    entry1.colorBitset = 0x01;
+    entry1.numCreatures = 10;
+    entry1.numGenomes = 8;
+    entry1.sumCreatureCells = 100;
+    entry1.sumCreatureGenerations = 50;
+    entry1.sumAccumulatedMutations = 20;
+    entry1.sumGenomeNodes = 300;
+    entry1.sumMutationRates = 4;
+    entry1.sumCreatureEnergy = 1000;
+    entry1.numCreatedCreatures = 40;
+    entry1.totalMutations = 5;
+
+    auto entry2 = createEntry(7);
+    entry2.colorBitset = 0x02;
+    entry2.numCreatures = 20;
+    entry2.numGenomes = 12;
+    entry2.sumCreatureCells = 200;
+    entry2.sumCreatureGenerations = 70;
+    entry2.sumAccumulatedMutations = 40;
+    entry2.sumGenomeNodes = 500;
+    entry2.sumMutationRates = 6;
+    entry2.sumCreatureEnergy = 3000;
+    entry2.numCreatedCreatures = 60;
+    entry2.totalMutations = 9;
+
+    LineageSample earlierSample;
+    earlierSample.time = 100;
+    earlierSample.systemClock = 10;
+    earlierSample.entries = {entry1};
+
+    LineageSample laterSample;
+    laterSample.time = 200;
+    laterSample.systemClock = 20;
+    laterSample.entries = {entry2};
+
+    auto result = LineageHistoryService::mergeSamples(earlierSample, laterSample);
+
+    ASSERT_EQ(1, result.entries.size());
+    auto const& merged = result.entries.front();
+    EXPECT_EQ(7, merged.lineageId);
+    EXPECT_EQ(0x03, merged.colorBitset);
+    EXPECT_EQ(15, merged.numCreatures);
+    EXPECT_EQ(10, merged.numGenomes);
+    EXPECT_FLOAT_EQ(150, merged.sumCreatureCells);
+    EXPECT_FLOAT_EQ(60, merged.sumCreatureGenerations);
+    EXPECT_FLOAT_EQ(30, merged.sumAccumulatedMutations);
+    EXPECT_FLOAT_EQ(400, merged.sumGenomeNodes);
+    EXPECT_FLOAT_EQ(5, merged.sumMutationRates);
+    EXPECT_FLOAT_EQ(2000, merged.sumCreatureEnergy);
+    EXPECT_EQ(60, merged.numCreatedCreatures);  //accumulated values are maximized
+    EXPECT_FLOAT_EQ(9, merged.totalMutations);
+}
+
+TEST_F(LineageHistoryServiceTests, addSample_sortsEntriesById)
+{
+    LineageHistoryService service;
+    LineageHistory history;
+
+    service.addSample(history, createRawStatistics({createEntry(5), createEntry(1), createEntry(3)}), 100);
+
+    auto data = history.getCopiedData();
+    ASSERT_EQ(1, data.size());
+    ASSERT_EQ(3, data.front().entries.size());
+    EXPECT_EQ(1, data.front().entries.at(0).lineageId);
+    EXPECT_EQ(3, data.front().entries.at(1).lineageId);
+    EXPECT_EQ(5, data.front().entries.at(2).lineageId);
+}
+
+TEST_F(LineageHistoryServiceTests, addSample_skipsSamplesBelowCadence)
+{
+    LineageHistoryService service;
+    LineageHistory history;
+
+    service.addSample(history, createRawStatistics({createEntry(1)}), 100);
+    service.addSample(history, createRawStatistics({createEntry(2)}), 105);  //below the default cadence of 10 timesteps
+    service.addSample(history, createRawStatistics({createEntry(3)}), 120);
+
+    auto data = history.getCopiedData();
+    ASSERT_EQ(2, data.size());
+    EXPECT_EQ(100, data.at(0).time);
+    EXPECT_EQ(120, data.at(1).time);
+}
+
+TEST_F(LineageHistoryServiceTests, addSample_clearsHistoryOnTimeRegression)
+{
+    LineageHistoryService service;
+    LineageHistory history;
+
+    service.addSample(history, createRawStatistics({createEntry(1)}), 1000);
+    service.addSample(history, createRawStatistics({createEntry(2)}), 100);
+
+    auto data = history.getCopiedData();
+    ASSERT_EQ(1, data.size());
+    EXPECT_EQ(100, data.front().time);
+    ASSERT_EQ(1, data.front().entries.size());
+    EXPECT_EQ(2, data.front().entries.front().lineageId);
+}
+
+TEST_F(LineageHistoryServiceTests, addSample_compressesHistory)
+{
+    LineageHistoryService service;
+    LineageHistory history;
+
+    auto timestep = uint64_t(0);
+    for (int i = 0; i < 1100; ++i) {
+        service.addSample(history, createRawStatistics({createEntry(1)}), timestep);
+        timestep += 10;
+    }
+
+    auto data = history.getCopiedData();
+    EXPECT_LE(data.size(), 1001);
+    for (size_t i = 1; i < data.size(); ++i) {
+        EXPECT_LT(data.at(i - 1).time, data.at(i).time);
+    }
+}

--- a/source/EngineInterfaceTests/LineageHistoryServiceTests.cpp
+++ b/source/EngineInterfaceTests/LineageHistoryServiceTests.cpp
@@ -51,7 +51,6 @@ TEST_F(LineageHistoryServiceTests, mergeSamples_commonIds)
     entry1.numGenomes = 8;
     entry1.sumCreatureCells = 100;
     entry1.sumCreatureGenerations = 50;
-    entry1.sumAccumulatedMutations = 20;
     entry1.sumGenomeNodes = 300;
     entry1.sumMutationRates = 4;
     entry1.sumCreatureEnergy = 1000;
@@ -64,7 +63,6 @@ TEST_F(LineageHistoryServiceTests, mergeSamples_commonIds)
     entry2.numGenomes = 12;
     entry2.sumCreatureCells = 200;
     entry2.sumCreatureGenerations = 70;
-    entry2.sumAccumulatedMutations = 40;
     entry2.sumGenomeNodes = 500;
     entry2.sumMutationRates = 6;
     entry2.sumCreatureEnergy = 3000;
@@ -91,7 +89,6 @@ TEST_F(LineageHistoryServiceTests, mergeSamples_commonIds)
     EXPECT_EQ(10, merged.numGenomes);
     EXPECT_FLOAT_EQ(150, merged.sumCreatureCells);
     EXPECT_FLOAT_EQ(60, merged.sumCreatureGenerations);
-    EXPECT_FLOAT_EQ(30, merged.sumAccumulatedMutations);
     EXPECT_FLOAT_EQ(400, merged.sumGenomeNodes);
     EXPECT_FLOAT_EQ(5, merged.sumMutationRates);
     EXPECT_FLOAT_EQ(2000, merged.sumCreatureEnergy);

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -40,8 +40,8 @@ private:
         float neededDepotEnergy;
     };
     __inline__ __device__ static void processCell(SimulationData& data, SimulationStatistics& statistics, Object* object, bool isPreview);
-    __inline__ __device__ static void mutateGenome(SimulationData& data, Object* object);
-    __inline__ __device__ static Creature* findOrCreateNewCreature(SimulationData& data, Object* object);
+    __inline__ __device__ static void mutateGenome(SimulationData& data, SimulationStatistics& statistics, Object* object);
+    __inline__ __device__ static Creature* findOrCreateNewCreature(SimulationData& data, SimulationStatistics& statistics, Object* object);
     __inline__ __device__ static ConstructionData createConstructionData(Object* object);
 
     __inline__ __device__ static Object*
@@ -179,14 +179,14 @@ __inline__ __device__ void ConstructorProcessor::processCell(SimulationData& dat
     }
 
     // Important: mutate the host genome before it is cloned for the offspring.
-    mutateGenome(data, object);
+    mutateGenome(data, statistics, object);
 
     // The actual construction runs on a single thread.
     if (threadIdx.x != 0) {
         return;
     }
 
-    constructor.offspring = findOrCreateNewCreature(data, object);
+    constructor.offspring = findOrCreateNewCreature(data, statistics, object);
 
     // Check again after cloning the creature, because the offspring genome may diverge from the host genome.
     if (ConstructorHelper::isFinished(object, *constructor.offspring->genome)) {
@@ -217,7 +217,7 @@ __inline__ __device__ void ConstructorProcessor::processCell(SimulationData& dat
     }
 }
 
-__inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& data, Object* object)
+__inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
     auto& cell = object->typeData.cell;
     auto& constructor = cell.constructor;
@@ -238,7 +238,7 @@ __inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& da
     __syncthreads();
 
     if (clonedGenome != nullptr) {
-        MutationProcessor::applyMutations(data, cell.creature, clonedGenome);
+        MutationProcessor::applyMutations(data, statistics, cell.creature, clonedGenome);
         MutationProcessor::removeUnreachableGenesFromRoot(data, clonedGenome);
         if (threadIdx.x == 0) {
             cell.creature->genome = clonedGenome;
@@ -247,7 +247,7 @@ __inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& da
     __syncthreads();
 }
 
-__inline__ __device__ Creature* ConstructorProcessor::findOrCreateNewCreature(SimulationData& data, Object* object)
+__inline__ __device__ Creature* ConstructorProcessor::findOrCreateNewCreature(SimulationData& data, SimulationStatistics& statistics, Object* object)
 {
     auto& constructor = object->typeData.cell.constructor;
 
@@ -274,6 +274,7 @@ __inline__ __device__ Creature* ConstructorProcessor::findOrCreateNewCreature(Si
     factory.init(&data);
     auto result = factory.cloneCreature(object->typeData.cell.creature);
     result->numCells = 0;
+    statistics.incCreatedCreature(result->lineageId);
 
     return result;
 }

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -19,7 +19,7 @@ namespace cg_mutation = cooperative_groups;
 class MutationProcessor
 {
 public:
-    __inline__ __device__ static void applyMutations(SimulationData& data, Creature* creature, Genome* genome);
+    __inline__ __device__ static void applyMutations(SimulationData& data, SimulationStatistics& statistics, Creature* creature, Genome* genome);
     __inline__ __device__ static void removeUnreachableGenesFromRoot(SimulationData& data, Genome* genome);
 
 private:
@@ -55,8 +55,12 @@ private:
     __inline__ __device__ static void removeNode(SimulationData& data, Gene& gene, int position);
     __inline__ __device__ static void correctGenome(SimulationData& data, Genome* genome);
 
-    __inline__ __device__ static void
-    updateAccumulatedMutationsAndLineageId(SimulationData& data, Creature* creature, Genome* genome, float& accumulatedMutations);
+    __inline__ __device__ static void updateAccumulatedMutationsAndLineageId(
+        SimulationData& data,
+        SimulationStatistics& statistics,
+        Creature* creature,
+        Genome* genome,
+        float& accumulatedMutations);
     __inline__ __device__ static float generateGaussian(SimulationData& data);
     __inline__ __device__ static bool isRandomEvent(SimulationData& data, float probability);
 
@@ -66,7 +70,7 @@ private:
 /************************************************************************/
 /* Implementation                                                       */
 /************************************************************************/
-__inline__ __device__ void MutationProcessor::applyMutations(SimulationData& data, Creature* creature, Genome* genome)
+__inline__ __device__ void MutationProcessor::applyMutations(SimulationData& data, SimulationStatistics& statistics, Creature* creature, Genome* genome)
 {
     __shared__ float accumulatedMutations;
     auto block = cg_mutation::this_thread_block();
@@ -128,7 +132,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     }
 
     block.sync();
-    updateAccumulatedMutationsAndLineageId(data, creature, genome, accumulatedMutations);
+    updateAccumulatedMutationsAndLineageId(data, statistics, creature, genome, accumulatedMutations);
 }
 
 __inline__ __device__ void MutationProcessor::applyMutations_neurons(SimulationData& data, Genome* genome, float& accumulatedMutations)
@@ -1866,8 +1870,12 @@ __inline__ __device__ void MutationProcessor::applyMutations_meta(SimulationData
     }
 }
 
-__inline__ __device__ void
-MutationProcessor::updateAccumulatedMutationsAndLineageId(SimulationData& data, Creature* creature, Genome* genome, float& accumulatedMutations)
+__inline__ __device__ void MutationProcessor::updateAccumulatedMutationsAndLineageId(
+    SimulationData& data,
+    SimulationStatistics& statistics,
+    Creature* creature,
+    Genome* genome,
+    float& accumulatedMutations)
 {
     auto laneId = cg_mutation::this_thread_block().thread_rank();
     if (laneId == 0) {
@@ -1877,6 +1885,9 @@ MutationProcessor::updateAccumulatedMutationsAndLineageId(SimulationData& data, 
         auto delta = accumulatedMutations / denominator;
         creature->accumulatedMutations += delta;
         creature->accumulatedMutationsInLineage += delta;
+        if (delta > 0) {
+            statistics.addMutations(creature->lineageId, delta);
+        }
         if (creature->accumulatedMutationsInLineage > cudaSimulationParameters.newLineageThreshold.value) {
             creature->lineageId = data.primaryNumberGen.createLineageId();
             creature->accumulatedMutationsInLineage = 0;

--- a/source/EngineKernels/SimulationStatistics.cuh
+++ b/source/EngineKernels/SimulationStatistics.cuh
@@ -152,7 +152,6 @@ public:
         slot.numGenomes = 0;
         slot.sumCreatureCells = 0;
         slot.sumCreatureGenerations = 0;
-        slot.sumAccumulatedMutations = 0;
         slot.sumGenomeNodes = 0;
         slot.sumMutationRates = 0;
         slot.sumCreatureEnergy = 0;
@@ -189,26 +188,25 @@ public:
         }
         return -1;
     }
-    __inline__ __device__ void addLineageCreatureData(int slotIndex, uint32_t numCells, uint32_t generation, float accumulatedMutations)
+    __inline__ __device__ void addLineageCreatureData(int slotIndex, uint32_t numCells, uint32_t generation)
     {
         auto& slot = _lineageMap[slotIndex];
         atomicAdd(&slot.numCreatures, 1u);
         atomicAdd(&slot.sumCreatureCells, toFloat(numCells));
         atomicAdd(&slot.sumCreatureGenerations, toFloat(generation));
-        atomicAdd(&slot.sumAccumulatedMutations, accumulatedMutations);
     }
-    __inline__ __device__ void addLineageGenomeData(int slotIndex, float numNodes, float meanMutationRate)
+    __inline__ __device__ void addLineageGenomeData(int slotIndex, float numNodes, float meanMutationRate, uint32_t nodeColorBitset)
     {
         auto& slot = _lineageMap[slotIndex];
         atomicAdd(&slot.numGenomes, 1u);
         atomicAdd(&slot.sumGenomeNodes, numNodes);
         atomicAdd(&slot.sumMutationRates, meanMutationRate);
+        atomicOr(&slot.colorBitset, nodeColorBitset);
     }
-    __inline__ __device__ void addLineageCellData(int slotIndex, float energy, int color)
+    __inline__ __device__ void addLineageEnergy(int slotIndex, float energy)
     {
         auto& slot = _lineageMap[slotIndex];
         atomicAdd(&slot.sumCreatureEnergy, energy);
-        atomicOr(&slot.colorBitset, 1u << color);
     }
     __inline__ __device__ void compactLineageSlot(int index)
     {
@@ -224,7 +222,6 @@ public:
         entry.numGenomes = slot.numGenomes;
         entry.sumCreatureCells = slot.sumCreatureCells;
         entry.sumCreatureGenerations = slot.sumCreatureGenerations;
-        entry.sumAccumulatedMutations = slot.sumAccumulatedMutations;
         entry.sumGenomeNodes = slot.sumGenomeNodes;
         entry.sumMutationRates = slot.sumMutationRates;
         entry.sumCreatureEnergy = slot.sumCreatureEnergy;
@@ -343,7 +340,6 @@ private:
         uint32_t numGenomes;
         float sumCreatureCells;
         float sumCreatureGenerations;
-        float sumAccumulatedMutations;
         float sumGenomeNodes;
         float sumMutationRates;
         float sumCreatureEnergy;

--- a/source/EngineKernels/SimulationStatistics.cuh
+++ b/source/EngineKernels/SimulationStatistics.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <EngineInterface/LineageStatistics.h>
 #include <EngineInterface/StatisticsRawData.h>
 
 #include "Base.cuh"
@@ -8,17 +9,40 @@
 class SimulationStatistics
 {
 public:
-    __host__ void init()
+    static auto constexpr DefaultLineageMapCapacity = 1 << 18;  // Power of two
+    static auto constexpr LineageIdEmpty = 0xffffffffu;
+
+    __host__ void init(int lineageMapCapacity = DefaultLineageMapCapacity)
     {
+        _lineageMapCapacity = lineageMapCapacity;
         CudaMemoryManager::getInstance().acquireMemory<StatisticsRawData>(1, _data);
         CudaMemoryManager::getInstance().acquireMemory<MutantStatistics>(MutantToColorCountMapSize, _mutantToMutantStatisticsMap);
+        CudaMemoryManager::getInstance().acquireMemory<LineageMapSlot>(_lineageMapCapacity, _lineageMap);
+        CudaMemoryManager::getInstance().acquireMemory<LineageStatisticsEntry>(_lineageMapCapacity, _lineageCompactData);
+        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[0]);
+        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[1]);
+        CudaMemoryManager::getInstance().acquireMemory<LineageMapControl>(1, _lineageMapControl);
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_data, 0, sizeof(StatisticsRawData)));
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageMapControl, 0, sizeof(LineageMapControl)));
+
+        // Values must start at zero; the lineageId key column (first member) is set to LineageIdEmpty
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageMap, 0, sizeof(LineageMapSlot) * _lineageMapCapacity));
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset2D(_lineageMap, sizeof(LineageMapSlot), 0xff, sizeof(uint32_t), _lineageMapCapacity));
+        for (int i = 0; i < 2; ++i) {
+            CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageAccumulatorMaps[i], 0, sizeof(LineageAccumulatorSlot) * _lineageMapCapacity));
+            CHECK_FOR_DEVICE_ERRORS(cudaMemset2D(_lineageAccumulatorMaps[i], sizeof(LineageAccumulatorSlot), 0xff, sizeof(uint32_t), _lineageMapCapacity));
+        }
     }
 
     __host__ void free()
     {
         CudaMemoryManager::getInstance().freeMemory(_data);
         CudaMemoryManager::getInstance().freeMemory(_mutantToMutantStatisticsMap);
+        CudaMemoryManager::getInstance().freeMemory(_lineageMap);
+        CudaMemoryManager::getInstance().freeMemory(_lineageCompactData);
+        CudaMemoryManager::getInstance().freeMemory(_lineageAccumulatorMaps[0]);
+        CudaMemoryManager::getInstance().freeMemory(_lineageAccumulatorMaps[1]);
+        CudaMemoryManager::getInstance().freeMemory(_lineageMapControl);
     }
 
     __host__ StatisticsRawData getStatistics()
@@ -26,6 +50,24 @@ public:
         StatisticsRawData result;
         CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(&result, _data, sizeof(StatisticsRawData), cudaMemcpyDeviceToHost));
         return result;
+    }
+
+    __host__ RawLineageStatistics getLineageStatistics()
+    {
+        auto control = getLineageMapControl();
+        RawLineageStatistics result;
+        result.entries.resize(control.numCompactEntries);
+        if (control.numCompactEntries > 0) {
+            CHECK_FOR_DEVICE_ERRORS(
+                cudaMemcpy(result.entries.data(), _lineageCompactData, sizeof(LineageStatisticsEntry) * control.numCompactEntries, cudaMemcpyDeviceToHost));
+        }
+        return result;
+    }
+
+    __host__ bool isLineageAccumulatorGCNeeded() const
+    {
+        auto control = getLineageMapControl();
+        return control.numUsedAccumulatorSlots[control.activeAccumulatorBuffer] > static_cast<uint32_t>(_lineageMapCapacity) / 2;
     }
 
     //timestep statistics
@@ -78,6 +120,158 @@ public:
         }
     }
 
+    //evolution statistics (timestep)
+    __inline__ __device__ void incNumSolidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numSolidObjects, 1); }
+    __inline__ __device__ void incNumFluidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numFluidObjects, 1); }
+    __inline__ __device__ void incNumCellObjects() { atomicAdd(&_data->timeline.timestep.evolution.numCellObjects, 1); }
+    __inline__ __device__ void addCreatureStatistics(uint32_t numCells, uint32_t generation, float accumulatedMutations)
+    {
+        auto& evolution = _data->timeline.timestep.evolution;
+        atomicAdd(&evolution.numCreatures, 1);
+        atomicAdd(&evolution.sumCreatureCells, toFloat(numCells));
+        atomicAdd(&evolution.sumCreatureGenerations, toFloat(generation));
+        atomicAdd(&evolution.sumAccumulatedMutations, accumulatedMutations);
+    }
+    __inline__ __device__ void addGenomeStatistics(float numNodes, float meanMutationRate)
+    {
+        auto& evolution = _data->timeline.timestep.evolution;
+        atomicAdd(&evolution.numGenomes, 1);
+        atomicAdd(&evolution.sumGenomeNodes, numNodes);
+        atomicAdd(&evolution.sumMutationRates, meanMutationRate);
+    }
+    __inline__ __device__ void addCreatureEnergy(float value) { atomicAdd(&_data->timeline.timestep.evolution.sumCreatureEnergy, value); }
+
+    //lineage statistics
+    __inline__ __device__ int getLineageMapCapacity() const { return _lineageMapCapacity; }
+    __inline__ __device__ void resetLineageMapSlot(int index)
+    {
+        auto& slot = _lineageMap[index];
+        slot.lineageId = LineageIdEmpty;
+        slot.colorBitset = 0;
+        slot.numCreatures = 0;
+        slot.numGenomes = 0;
+        slot.sumCreatureCells = 0;
+        slot.sumCreatureGenerations = 0;
+        slot.sumAccumulatedMutations = 0;
+        slot.sumGenomeNodes = 0;
+        slot.sumMutationRates = 0;
+        slot.sumCreatureEnergy = 0;
+    }
+    __inline__ __device__ void resetCompactLineageCounter() { _lineageMapControl->numCompactEntries = 0; }
+
+    __inline__ __device__ int insertOrFindLineageSlot(uint32_t lineageId)
+    {
+        auto mask = _lineageMapCapacity - 1;
+        auto index = toInt((lineageId * 2654435761u) & mask);
+        for (int i = 0; i < _lineageMapCapacity; ++i) {
+            auto origLineageId = atomicCAS(&_lineageMap[index].lineageId, LineageIdEmpty, lineageId);
+            if (origLineageId == LineageIdEmpty || origLineageId == lineageId) {
+                return index;
+            }
+            index = (index + 1) & mask;
+        }
+        _data->timeline.timestep.evolution.lineageMapOverflow = 1;
+        return -1;
+    }
+    __inline__ __device__ int findLineageSlot(uint32_t lineageId) const
+    {
+        auto mask = _lineageMapCapacity - 1;
+        auto index = toInt((lineageId * 2654435761u) & mask);
+        for (int i = 0; i < _lineageMapCapacity; ++i) {
+            auto slotLineageId = _lineageMap[index].lineageId;
+            if (slotLineageId == lineageId) {
+                return index;
+            }
+            if (slotLineageId == LineageIdEmpty) {
+                return -1;
+            }
+            index = (index + 1) & mask;
+        }
+        return -1;
+    }
+    __inline__ __device__ void addLineageCreatureData(int slotIndex, uint32_t numCells, uint32_t generation, float accumulatedMutations)
+    {
+        auto& slot = _lineageMap[slotIndex];
+        atomicAdd(&slot.numCreatures, 1u);
+        atomicAdd(&slot.sumCreatureCells, toFloat(numCells));
+        atomicAdd(&slot.sumCreatureGenerations, toFloat(generation));
+        atomicAdd(&slot.sumAccumulatedMutations, accumulatedMutations);
+    }
+    __inline__ __device__ void addLineageGenomeData(int slotIndex, float numNodes, float meanMutationRate)
+    {
+        auto& slot = _lineageMap[slotIndex];
+        atomicAdd(&slot.numGenomes, 1u);
+        atomicAdd(&slot.sumGenomeNodes, numNodes);
+        atomicAdd(&slot.sumMutationRates, meanMutationRate);
+    }
+    __inline__ __device__ void addLineageCellData(int slotIndex, float energy, int color)
+    {
+        auto& slot = _lineageMap[slotIndex];
+        atomicAdd(&slot.sumCreatureEnergy, energy);
+        atomicOr(&slot.colorBitset, 1u << color);
+    }
+    __inline__ __device__ void compactLineageSlot(int index)
+    {
+        auto const& slot = _lineageMap[index];
+        if (slot.lineageId == LineageIdEmpty || slot.numCreatures == 0) {
+            return;
+        }
+        auto entryIndex = atomicAdd(&_lineageMapControl->numCompactEntries, 1u);
+        auto& entry = _lineageCompactData[entryIndex];
+        entry.lineageId = slot.lineageId;
+        entry.colorBitset = slot.colorBitset;
+        entry.numCreatures = slot.numCreatures;
+        entry.numGenomes = slot.numGenomes;
+        entry.sumCreatureCells = slot.sumCreatureCells;
+        entry.sumCreatureGenerations = slot.sumCreatureGenerations;
+        entry.sumAccumulatedMutations = slot.sumAccumulatedMutations;
+        entry.sumGenomeNodes = slot.sumGenomeNodes;
+        entry.sumMutationRates = slot.sumMutationRates;
+        entry.sumCreatureEnergy = slot.sumCreatureEnergy;
+        entry.numCreatedCreatures = 0;
+        entry.totalMutations = 0;
+        auto accumulatorIndex = findAccumulatorSlot(slot.lineageId);
+        if (accumulatorIndex >= 0) {
+            auto const& accumulatorSlot = getActiveAccumulatorMap()[accumulatorIndex];
+            entry.numCreatedCreatures = accumulatorSlot.numCreatedCreatures;
+            entry.totalMutations = accumulatorSlot.totalMutations;
+        }
+    }
+    __inline__ __device__ void finalizeLineageStatistics()
+    {
+        _data->timeline.timestep.evolution.numActiveLineages = toInt(_lineageMapControl->numCompactEntries);
+    }
+
+    //lineage accumulator map (persistent, garbage-collected occasionally)
+    __inline__ __device__ void resetInactiveAccumulatorSlot(int index)
+    {
+        auto& slot = _lineageAccumulatorMaps[1 - _lineageMapControl->activeAccumulatorBuffer][index];
+        slot.lineageId = LineageIdEmpty;
+        slot.numCreatedCreatures = 0;
+        slot.totalMutations = 0;
+        if (index == 0) {
+            _lineageMapControl->numUsedAccumulatorSlots[1 - _lineageMapControl->activeAccumulatorBuffer] = 0;
+        }
+    }
+    __inline__ __device__ void migrateActiveAccumulatorSlot(int index)
+    {
+        auto activeBuffer = _lineageMapControl->activeAccumulatorBuffer;
+        auto const& slot = _lineageAccumulatorMaps[activeBuffer][index];
+        if (slot.lineageId == LineageIdEmpty) {
+            return;
+        }
+        if (findLineageSlot(slot.lineageId) < 0) {
+            return;
+        }
+        auto targetIndex = insertAccumulatorSlot(1 - activeBuffer, slot.lineageId);
+        if (targetIndex >= 0) {
+            auto& targetSlot = _lineageAccumulatorMaps[1 - activeBuffer][targetIndex];
+            targetSlot.numCreatedCreatures = slot.numCreatedCreatures;
+            targetSlot.totalMutations = slot.totalMutations;
+        }
+    }
+    __inline__ __device__ void flipAccumulatorBuffers() { _lineageMapControl->activeAccumulatorBuffer = 1 - _lineageMapControl->activeAccumulatorBuffer; }
+
     //accumulated statistics
     __host__ void resetAccumulatedStatistics()
     {
@@ -109,6 +303,23 @@ public:
     __inline__ __device__ void incNumReconnectorRemoved(int color) { alienAtomicAdd64(&_data->timeline.accumulated.numReconnectorRemoved[color], uint64_t(1)); }
     __inline__ __device__ void incNumDetonations(int color) { alienAtomicAdd64(&_data->timeline.accumulated.numDetonations[color], uint64_t(1)); }
 
+    __inline__ __device__ void incCreatedCreature(uint32_t lineageId)
+    {
+        alienAtomicAdd64(&_data->timeline.accumulated.numCreatedCreatures, uint64_t(1));
+        auto slotIndex = findOrInsertAccumulatorSlot(lineageId);
+        if (slotIndex >= 0) {
+            atomicAdd(&getActiveAccumulatorMap()[slotIndex].numCreatedCreatures, 1u);
+        }
+    }
+    __inline__ __device__ void addMutations(uint32_t lineageId, float value)
+    {
+        atomicAdd(&_data->timeline.accumulated.totalMutations, toDouble(value));
+        auto slotIndex = findOrInsertAccumulatorSlot(lineageId);
+        if (slotIndex >= 0) {
+            atomicAdd(&getActiveAccumulatorMap()[slotIndex].totalMutations, value);
+        }
+    }
+
     //histogram
     __inline__ __device__ void resetHistogramData()
     {
@@ -124,7 +335,88 @@ public:
     __inline__ __device__ int getMaxAge() const { return _data->histogram.maxAge; }
 
 private:
+    struct LineageMapSlot
+    {
+        uint32_t lineageId;  // LineageIdEmpty = slot is unused
+        uint32_t colorBitset;
+        uint32_t numCreatures;
+        uint32_t numGenomes;
+        float sumCreatureCells;
+        float sumCreatureGenerations;
+        float sumAccumulatedMutations;
+        float sumGenomeNodes;
+        float sumMutationRates;
+        float sumCreatureEnergy;
+    };
+    struct LineageAccumulatorSlot
+    {
+        uint32_t lineageId;  // LineageIdEmpty = slot is unused
+        uint32_t numCreatedCreatures;
+        float totalMutations;
+    };
+    struct LineageMapControl
+    {
+        uint32_t numCompactEntries;
+        uint32_t activeAccumulatorBuffer;
+        uint32_t numUsedAccumulatorSlots[2];
+    };
+
+    __host__ LineageMapControl getLineageMapControl() const
+    {
+        LineageMapControl result;
+        CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(&result, _lineageMapControl, sizeof(LineageMapControl), cudaMemcpyDeviceToHost));
+        return result;
+    }
+
+    __inline__ __device__ LineageAccumulatorSlot* getActiveAccumulatorMap() { return _lineageAccumulatorMaps[_lineageMapControl->activeAccumulatorBuffer]; }
+
+    __inline__ __device__ int insertAccumulatorSlot(uint32_t bufferIndex, uint32_t lineageId)
+    {
+        auto map = _lineageAccumulatorMaps[bufferIndex];
+        auto mask = _lineageMapCapacity - 1;
+        auto index = toInt((lineageId * 2654435761u) & mask);
+        for (int i = 0; i < _lineageMapCapacity; ++i) {
+            auto origLineageId = atomicCAS(&map[index].lineageId, LineageIdEmpty, lineageId);
+            if (origLineageId == LineageIdEmpty) {
+                atomicAdd(&_lineageMapControl->numUsedAccumulatorSlots[bufferIndex], 1u);
+                return index;
+            }
+            if (origLineageId == lineageId) {
+                return index;
+            }
+            index = (index + 1) & mask;
+        }
+        return -1;
+    }
+    __inline__ __device__ int findOrInsertAccumulatorSlot(uint32_t lineageId)
+    {
+        return insertAccumulatorSlot(_lineageMapControl->activeAccumulatorBuffer, lineageId);
+    }
+    __inline__ __device__ int findAccumulatorSlot(uint32_t lineageId)
+    {
+        auto map = getActiveAccumulatorMap();
+        auto mask = _lineageMapCapacity - 1;
+        auto index = toInt((lineageId * 2654435761u) & mask);
+        for (int i = 0; i < _lineageMapCapacity; ++i) {
+            auto slotLineageId = map[index].lineageId;
+            if (slotLineageId == lineageId) {
+                return index;
+            }
+            if (slotLineageId == LineageIdEmpty) {
+                return -1;
+            }
+            index = (index + 1) & mask;
+        }
+        return -1;
+    }
+
     StatisticsRawData* _data;
+    int _lineageMapCapacity;
+
+    LineageMapSlot* _lineageMap;
+    LineageStatisticsEntry* _lineageCompactData;
+    LineageAccumulatorSlot* _lineageAccumulatorMaps[2];
+    LineageMapControl* _lineageMapControl;
 
     //for diversity calculation
     static auto constexpr MutantToColorCountMapSize = 1 << 20;

--- a/source/EngineKernels/SimulationStatistics.cuh
+++ b/source/EngineKernels/SimulationStatistics.cuh
@@ -19,8 +19,8 @@ public:
         CudaMemoryManager::getInstance().acquireMemory<MutantStatistics>(MutantToColorCountMapSize, _mutantToMutantStatisticsMap);
         CudaMemoryManager::getInstance().acquireMemory<LineageMapSlot>(_lineageMapCapacity, _lineageMap);
         CudaMemoryManager::getInstance().acquireMemory<LineageStatisticsEntry>(_lineageMapCapacity, _lineageCompactData);
-        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[0]);
-        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[1]);
+        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorMapSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[0]);
+        CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorMapSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[1]);
         CudaMemoryManager::getInstance().acquireMemory<LineageMapControl>(1, _lineageMapControl);
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_data, 0, sizeof(StatisticsRawData)));
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageMapControl, 0, sizeof(LineageMapControl)));
@@ -29,8 +29,8 @@ public:
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageMap, 0, sizeof(LineageMapSlot) * _lineageMapCapacity));
         CHECK_FOR_DEVICE_ERRORS(cudaMemset2D(_lineageMap, sizeof(LineageMapSlot), 0xff, sizeof(uint32_t), _lineageMapCapacity));
         for (int i = 0; i < 2; ++i) {
-            CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageAccumulatorMaps[i], 0, sizeof(LineageAccumulatorSlot) * _lineageMapCapacity));
-            CHECK_FOR_DEVICE_ERRORS(cudaMemset2D(_lineageAccumulatorMaps[i], sizeof(LineageAccumulatorSlot), 0xff, sizeof(uint32_t), _lineageMapCapacity));
+            CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageAccumulatorMaps[i], 0, sizeof(LineageAccumulatorMapSlot) * _lineageMapCapacity));
+            CHECK_FOR_DEVICE_ERRORS(cudaMemset2D(_lineageAccumulatorMaps[i], sizeof(LineageAccumulatorMapSlot), 0xff, sizeof(uint32_t), _lineageMapCapacity));
         }
     }
 
@@ -349,7 +349,7 @@ private:
         float sumMutationRates;
         float sumCreatureEnergy;
     };
-    struct LineageAccumulatorSlot
+    struct LineageAccumulatorMapSlot
     {
         uint32_t lineageId;  // LineageIdEmpty = slot is unused
         uint32_t numCreatedCreatures;
@@ -369,7 +369,7 @@ private:
         return result;
     }
 
-    __inline__ __device__ LineageAccumulatorSlot* getActiveAccumulatorMap() { return _lineageAccumulatorMaps[_lineageMapControl->activeAccumulatorBuffer]; }
+    __inline__ __device__ LineageAccumulatorMapSlot* getActiveAccumulatorMap() { return _lineageAccumulatorMaps[_lineageMapControl->activeAccumulatorBuffer]; }
 
     __inline__ __device__ int insertAccumulatorSlot(uint32_t bufferIndex, uint32_t lineageId)
     {
@@ -415,9 +415,10 @@ private:
     int _lineageMapCapacity;
 
     LineageMapSlot* _lineageMap;
-    LineageStatisticsEntry* _lineageCompactData;
-    LineageAccumulatorSlot* _lineageAccumulatorMaps[2];
+    LineageAccumulatorMapSlot* _lineageAccumulatorMaps[2];
+
     LineageMapControl* _lineageMapControl;
+    LineageStatisticsEntry* _lineageCompactData;
 
     //for diversity calculation
     static auto constexpr MutantToColorCountMapSize = 1 << 20;

--- a/source/EngineKernels/SimulationStatistics.cuh
+++ b/source/EngineKernels/SimulationStatistics.cuh
@@ -74,7 +74,11 @@ public:
     __inline__ __device__ void resetTimestepData()
     {
         if (threadIdx.x == 0 && blockIdx.x == 0) {
+            // Evolution statistics are collected at deterministic timesteps (separate kernel sequence)
+            // and must survive the wall-clock-throttled timestep statistics updates.
+            auto evolution = _data->timeline.timestep.evolution;
             _data->timeline.timestep = TimestepStatistics();
+            _data->timeline.timestep.evolution = evolution;
         }
         auto partition = calcSystemThreadPartition(MutantToColorCountMapSize);
         for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
@@ -121,6 +125,7 @@ public:
     }
 
     //evolution statistics (timestep)
+    __inline__ __device__ void resetEvolutionStatistics() { _data->timeline.timestep.evolution = EvolutionStatistics(); }
     __inline__ __device__ void incNumSolidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numSolidObjects, 1); }
     __inline__ __device__ void incNumFluidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numFluidObjects, 1); }
     __inline__ __device__ void incNumCellObjects() { atomicAdd(&_data->timeline.timestep.evolution.numCellObjects, 1); }

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -17,12 +17,6 @@ __global__ void cudaUpdateTimestepStatistics_substep2(SimulationData data, Simul
             statistics.addEnergy(object->color, object->getEnergy());
             if (object->type == ObjectType_FreeCell) {
                 statistics.incNumFreeCells(object->color);
-            } else if (object->type == ObjectType_Solid) {
-                statistics.incNumSolidObjects();
-            } else if (object->type == ObjectType_Fluid) {
-                statistics.incNumFluidObjects();
-            } else if (object->type == ObjectType_Cell) {
-                statistics.incNumCellObjects();
             }
             //if (object->typeData.cell.cellType == CellType_Constructor && GenomeDecoder::containsSelfReplication(object->typeData.cell.cellTypeData.constructor)) {
             //    statistics.incNumReplicator(object->color);
@@ -111,6 +105,7 @@ namespace
 __global__ void cudaUpdateEvolutionStatistics_substep1(SimulationData data, SimulationStatistics statistics)
 {
     if (threadIdx.x == 0 && blockIdx.x == 0) {
+        statistics.resetEvolutionStatistics();
         statistics.resetCompactLineageCounter();
     }
     {
@@ -144,6 +139,13 @@ __global__ void cudaUpdateEvolutionStatistics_substep2(SimulationData data, Simu
 
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
+        if (object->type == ObjectType_Solid) {
+            statistics.incNumSolidObjects();
+        } else if (object->type == ObjectType_Fluid) {
+            statistics.incNumFluidObjects();
+        } else if (object->type == ObjectType_Cell) {
+            statistics.incNumCellObjects();
+        }
         if (object->type != ObjectType_Cell) {
             continue;
         }
@@ -159,6 +161,9 @@ __global__ void cudaUpdateEvolutionStatistics_substep2(SimulationData data, Simu
                 statistics.addLineageCreatureData(slotIndex, creature->numCells, creature->generation);
                 alienAtomicExch64(&creature->creatureIndex, static_cast<uint64_t>(slotIndex) + 1);
             }
+        } else if (origCreatureIndex != 0) {
+            // Another thread already finished the initialization; restore its value (see DataAccessKernels)
+            alienAtomicExch64(&creature->creatureIndex, origCreatureIndex);
         }
     }
 }

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -156,7 +156,7 @@ __global__ void cudaUpdateEvolutionStatistics_substep2(SimulationData data, Simu
             statistics.addCreatureStatistics(creature->numCells, creature->generation, creature->accumulatedMutations);
             auto slotIndex = statistics.insertOrFindLineageSlot(creature->lineageId);
             if (slotIndex >= 0) {
-                statistics.addLineageCreatureData(slotIndex, creature->numCells, creature->generation, creature->accumulatedMutations);
+                statistics.addLineageCreatureData(slotIndex, creature->numCells, creature->generation);
                 alienAtomicExch64(&creature->creatureIndex, static_cast<uint64_t>(slotIndex) + 1);
             }
         }
@@ -183,20 +183,25 @@ __global__ void cudaUpdateEvolutionStatistics_substep3(SimulationData data, Simu
         auto origGenomeIndex = alienAtomicExch64(&genome->genomeIndex, static_cast<uint64_t>(0));
         if (origGenomeIndex == VALUE_NOT_SET_UINT64) {
             auto numNodes = 0;
+            auto nodeColorBitset = 0u;
             for (int i = 0; i < genome->numGenes; ++i) {
-                numNodes += genome->genes[i].numNodes;
+                auto const& gene = genome->genes[i];
+                numNodes += gene.numNodes;
+                for (int j = 0; j < gene.numNodes; ++j) {
+                    nodeColorBitset |= 1u << gene.nodes[j].color;
+                }
             }
             auto meanMutationRate = calcMeanMutationRate(genome->mutationRates);
             statistics.addGenomeStatistics(toFloat(numNodes), meanMutationRate);
             if (slotIndex >= 0) {
-                statistics.addLineageGenomeData(slotIndex, toFloat(numNodes), meanMutationRate);
+                statistics.addLineageGenomeData(slotIndex, toFloat(numNodes), meanMutationRate, nodeColorBitset);
             }
         }
 
         auto energy = object->getEnergy();
         statistics.addCreatureEnergy(energy);
         if (slotIndex >= 0) {
-            statistics.addLineageCellData(slotIndex, energy, object->color);
+            statistics.addLineageEnergy(slotIndex, energy);
         }
     }
 }

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -17,6 +17,12 @@ __global__ void cudaUpdateTimestepStatistics_substep2(SimulationData data, Simul
             statistics.addEnergy(object->color, object->getEnergy());
             if (object->type == ObjectType_FreeCell) {
                 statistics.incNumFreeCells(object->color);
+            } else if (object->type == ObjectType_Solid) {
+                statistics.incNumSolidObjects();
+            } else if (object->type == ObjectType_Fluid) {
+                statistics.incNumFluidObjects();
+            } else if (object->type == ObjectType_Cell) {
+                statistics.incNumCellObjects();
             }
             //if (object->typeData.cell.cellType == CellType_Constructor && GenomeDecoder::containsSelfReplication(object->typeData.cell.cellTypeData.constructor)) {
             //    statistics.incNumReplicator(object->color);
@@ -64,6 +70,169 @@ __global__ void cudaUpdateTimestepStatistics_substep3(SimulationData data, Simul
         //}
         //}
     }
+}
+
+namespace
+{
+    __device__ float calcMeanMutationRate(MutationRates const& rates)
+    {
+        auto sum = 0.0f;
+        for (int i = 0; i < 2; ++i) {
+            sum += rates.neuronMutations[i].nodeProbability;
+            sum += rates.connectionMutations[i].nodeProbability;
+            sum += rates.cellTypePropertiesMutations[i].nodeProbability;
+            sum += rates.geometryMutations[i].geneProbability;
+            sum += rates.constructorMutations[i].nodeProbability;
+        }
+        sum += rates.cellTypeModeMutation.nodeProbability;
+        sum += rates.cellTypeMutation.nodeProbability;
+        sum += rates.voidMutation.nodeProbability;
+        sum += rates.extendGeneMutation.geneProbability;
+        sum += rates.addNodeMutation.nodeProbability;
+        sum += rates.trimGeneMutation.geneProbability;
+        sum += rates.deleteNodeMutation.nodeProbability;
+        sum += rates.copyNodeSectionMutation.geneProbability;
+        sum += rates.moveNodeSectionMutation.geneProbability;
+        sum += rates.duplicateGeneMutation.geneProbability;
+        sum += rates.deleteGeneMutation.geneProbability;
+        return sum / 21.0f;
+    }
+
+    __device__ int getCachedLineageSlot(Creature* creature, int lineageMapCapacity)
+    {
+        auto slotIndexPlusOne = creature->creatureIndex;
+        if (slotIndexPlusOne >= 1 && slotIndexPlusOne <= static_cast<uint64_t>(lineageMapCapacity)) {
+            return toInt(slotIndexPlusOne) - 1;
+        }
+        return -1;
+    }
+}
+
+__global__ void cudaUpdateEvolutionStatistics_substep1(SimulationData data, SimulationStatistics statistics)
+{
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        statistics.resetCompactLineageCounter();
+    }
+    {
+        auto const partition = calcSystemThreadPartition(statistics.getLineageMapCapacity());
+        for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+            statistics.resetLineageMapSlot(index);
+        }
+    }
+    {
+        auto& objects = data.entities.objects;
+        auto const partition = calcSystemThreadPartition(objects.getNumEntries());
+        for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+            auto& object = objects.at(index);
+            if (object->type != ObjectType_Cell) {
+                continue;
+            }
+            auto creature = object->typeData.cell.creature;
+            if (!creature) {
+                continue;
+            }
+            creature->creatureIndex = VALUE_NOT_SET_UINT64;
+            creature->genome->genomeIndex = VALUE_NOT_SET_UINT64;
+        }
+    }
+}
+
+__global__ void cudaUpdateEvolutionStatistics_substep2(SimulationData data, SimulationStatistics statistics)
+{
+    auto& objects = data.entities.objects;
+    auto const partition = calcSystemThreadPartition(objects.getNumEntries());
+
+    for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+        auto& object = objects.at(index);
+        if (object->type != ObjectType_Cell) {
+            continue;
+        }
+        auto creature = object->typeData.cell.creature;
+        if (!creature) {
+            continue;
+        }
+        auto origCreatureIndex = alienAtomicExch64(&creature->creatureIndex, static_cast<uint64_t>(0));  // 0 = member is currently initialized
+        if (origCreatureIndex == VALUE_NOT_SET_UINT64) {
+            statistics.addCreatureStatistics(creature->numCells, creature->generation, creature->accumulatedMutations);
+            auto slotIndex = statistics.insertOrFindLineageSlot(creature->lineageId);
+            if (slotIndex >= 0) {
+                statistics.addLineageCreatureData(slotIndex, creature->numCells, creature->generation, creature->accumulatedMutations);
+                alienAtomicExch64(&creature->creatureIndex, static_cast<uint64_t>(slotIndex) + 1);
+            }
+        }
+    }
+}
+
+__global__ void cudaUpdateEvolutionStatistics_substep3(SimulationData data, SimulationStatistics statistics)
+{
+    auto& objects = data.entities.objects;
+    auto const partition = calcSystemThreadPartition(objects.getNumEntries());
+
+    for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+        auto& object = objects.at(index);
+        if (object->type != ObjectType_Cell) {
+            continue;
+        }
+        auto creature = object->typeData.cell.creature;
+        if (!creature) {
+            continue;
+        }
+        auto slotIndex = getCachedLineageSlot(creature, statistics.getLineageMapCapacity());
+
+        auto genome = creature->genome;
+        auto origGenomeIndex = alienAtomicExch64(&genome->genomeIndex, static_cast<uint64_t>(0));
+        if (origGenomeIndex == VALUE_NOT_SET_UINT64) {
+            auto numNodes = 0;
+            for (int i = 0; i < genome->numGenes; ++i) {
+                numNodes += genome->genes[i].numNodes;
+            }
+            auto meanMutationRate = calcMeanMutationRate(genome->mutationRates);
+            statistics.addGenomeStatistics(toFloat(numNodes), meanMutationRate);
+            if (slotIndex >= 0) {
+                statistics.addLineageGenomeData(slotIndex, toFloat(numNodes), meanMutationRate);
+            }
+        }
+
+        auto energy = object->getEnergy();
+        statistics.addCreatureEnergy(energy);
+        if (slotIndex >= 0) {
+            statistics.addLineageCellData(slotIndex, energy, object->color);
+        }
+    }
+}
+
+__global__ void cudaUpdateEvolutionStatistics_substep4(SimulationData data, SimulationStatistics statistics)
+{
+    auto const partition = calcSystemThreadPartition(statistics.getLineageMapCapacity());
+    for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+        statistics.compactLineageSlot(index);
+    }
+}
+
+__global__ void cudaUpdateEvolutionStatistics_substep5(SimulationData data, SimulationStatistics statistics)
+{
+    statistics.finalizeLineageStatistics();
+}
+
+__global__ void cudaPrepareLineageAccumulatorGC(SimulationStatistics statistics)
+{
+    auto const partition = calcSystemThreadPartition(statistics.getLineageMapCapacity());
+    for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+        statistics.resetInactiveAccumulatorSlot(index);
+    }
+}
+
+__global__ void cudaLineageAccumulatorGC(SimulationStatistics statistics)
+{
+    auto const partition = calcSystemThreadPartition(statistics.getLineageMapCapacity());
+    for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
+        statistics.migrateActiveAccumulatorSlot(index);
+    }
+}
+
+__global__ void cudaFinishLineageAccumulatorGC(SimulationStatistics statistics)
+{
+    statistics.flipAccumulatorBuffers();
 }
 
 __global__ void cudaUpdateHistogramData_substep1(SimulationData data, SimulationStatistics statistics)

--- a/source/EngineKernels/StatisticsKernels.cuh
+++ b/source/EngineKernels/StatisticsKernels.cuh
@@ -10,6 +10,16 @@ __global__ void cudaUpdateTimestepStatistics_substep1(SimulationData data, Simul
 __global__ void cudaUpdateTimestepStatistics_substep2(SimulationData data, SimulationStatistics statistics);
 __global__ void cudaUpdateTimestepStatistics_substep3(SimulationData data, SimulationStatistics statistics);
 
+__global__ void cudaUpdateEvolutionStatistics_substep1(SimulationData data, SimulationStatistics statistics);
+__global__ void cudaUpdateEvolutionStatistics_substep2(SimulationData data, SimulationStatistics statistics);
+__global__ void cudaUpdateEvolutionStatistics_substep3(SimulationData data, SimulationStatistics statistics);
+__global__ void cudaUpdateEvolutionStatistics_substep4(SimulationData data, SimulationStatistics statistics);
+__global__ void cudaUpdateEvolutionStatistics_substep5(SimulationData data, SimulationStatistics statistics);
+
+__global__ void cudaPrepareLineageAccumulatorGC(SimulationStatistics statistics);
+__global__ void cudaLineageAccumulatorGC(SimulationStatistics statistics);
+__global__ void cudaFinishLineageAccumulatorGC(SimulationStatistics statistics);
+
 __global__ void cudaUpdateHistogramData_substep1(SimulationData data, SimulationStatistics statistics);
 __global__ void cudaUpdateHistogramData_substep2(SimulationData data, SimulationStatistics statistics);
 __global__ void cudaUpdateHistogramData_substep3(SimulationData data, SimulationStatistics statistics);

--- a/source/EngineKernels/TestKernels.cu
+++ b/source/EngineKernels/TestKernels.cu
@@ -4,7 +4,7 @@
 #include "ObjectConnectionProcessor.cuh"
 #include "TestKernels.cuh"
 
-__global__ void cudaTestMutate(SimulationData data, uint64_t objectId)
+__global__ void cudaTestMutate(SimulationData data, SimulationStatistics statistics, uint64_t objectId)
 {
     DEVICE_CHECK(blockDim.x == NEURONS_PER_CELL);
 
@@ -25,7 +25,7 @@ __global__ void cudaTestMutate(SimulationData data, uint64_t objectId)
         block.sync();
 
         if (shouldMutate) {
-            MutationProcessor::applyMutations(data, object->typeData.cell.creature, object->typeData.cell.creature->genome);
+            MutationProcessor::applyMutations(data, statistics, object->typeData.cell.creature, object->typeData.cell.creature->genome);
         }
         block.sync();
     }

--- a/source/EngineKernels/TestKernels.cuh
+++ b/source/EngineKernels/TestKernels.cuh
@@ -4,8 +4,9 @@
 #include "sm_60_atomic_functions.h"
 
 #include "SimulationData.cuh"
+#include "SimulationStatistics.cuh"
 
-__global__ void cudaTestMutate(SimulationData data, uint64_t objectId);
+__global__ void cudaTestMutate(SimulationData data, SimulationStatistics statistics, uint64_t objectId);
 __global__ void cudaTestRemoveUnreachableGenesFromRoot(SimulationData data, uint64_t objectId);
 __global__ void cudaTestCreateConnection(SimulationData data, uint64_t objectId1, uint64_t objectId2);
 __global__ void cudaTestCreateConnectionWithAbsAngle(

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -25,6 +25,7 @@ PUBLIC
     DetonatorTests.cpp
     DuplicateGeneMutationTests.cpp
     EditTests.cpp
+    EvolutionStatisticsTests.cpp
     DigestorTests.cpp
     EnergyFlowTests.cpp
     EnergyParticleTests.cpp
@@ -55,9 +56,7 @@ PUBLIC
     TrimGeneMutationTests.cpp
     UnusedGeneRemovalTests.cpp
     VoidMutationTests.cpp
-    VoidTests.cpp
-    # Runs last: consumes GPU RNG state, which would otherwise shift the mutation sequences of subsequent suites
-    EvolutionStatisticsTests.cpp)
+    VoidTests.cpp)
 
 target_link_libraries(EngineTests Base)
 target_link_libraries(EngineTests EngineKernels)

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -55,7 +55,9 @@ PUBLIC
     TrimGeneMutationTests.cpp
     UnusedGeneRemovalTests.cpp
     VoidMutationTests.cpp
-    VoidTests.cpp)
+    VoidTests.cpp
+    # Runs last: consumes GPU RNG state, which would otherwise shift the mutation sequences of subsequent suites
+    EvolutionStatisticsTests.cpp)
 
 target_link_libraries(EngineTests Base)
 target_link_libraries(EngineTests EngineKernels)

--- a/source/EngineTests/CreatureTests.cpp
+++ b/source/EngineTests/CreatureTests.cpp
@@ -261,17 +261,23 @@ TEST_P(CreatureTests_BendingMuscles, constructCreatureWithOneLegAndSpikes)
     // Check front angles
     if (muscleMode != MuscleMode_AngleBending) {
         for (int i = 0; i < 5; ++i) {
-            EXPECT_TRUE(approxCompareAngles(0.0f, body.at(i).getCellRef()._frontAngle.value()));
+            EXPECT_TRUE(approxCompareAngles(0.0f, body.at(i).getCellRef()._frontAngle.value()))
+                << "body " << i << ": " << body.at(i).getCellRef()._frontAngle.value();
         }
-        EXPECT_TRUE(approxCompareAngles(-180.0f, body.at(5).getCellRef()._frontAngle.value()));
+        EXPECT_TRUE(approxCompareAngles(-180.0f, body.at(5).getCellRef()._frontAngle.value())) << "body 5: " << body.at(5).getCellRef()._frontAngle.value();
 
         for (int i = 0; i < 4; ++i) {
-            EXPECT_TRUE(approxCompareAngles(90.0f, leg.at(i).getCellRef()._frontAngle.value()));
+            EXPECT_TRUE(approxCompareAngles(90.0f, leg.at(i).getCellRef()._frontAngle.value()))
+                << "leg " << i << ": " << leg.at(i).getCellRef()._frontAngle.value();
         }
-        EXPECT_TRUE(approxCompareAngles(0.0f, spikes1.at(0).getCellRef()._frontAngle.value()));
-        EXPECT_TRUE(approxCompareAngles(0.0f, spikes1.at(1).getCellRef()._frontAngle.value()));
-        EXPECT_TRUE(approxCompareAngles(180.0f, spikes2.at(0).getCellRef()._frontAngle.value()));
-        EXPECT_TRUE(approxCompareAngles(180.0f, spikes2.at(1).getCellRef()._frontAngle.value()));
+        EXPECT_TRUE(approxCompareAngles(0.0f, spikes1.at(0).getCellRef()._frontAngle.value()))
+            << "spikes1 0: " << spikes1.at(0).getCellRef()._frontAngle.value();
+        EXPECT_TRUE(approxCompareAngles(0.0f, spikes1.at(1).getCellRef()._frontAngle.value()))
+            << "spikes1 1: " << spikes1.at(1).getCellRef()._frontAngle.value();
+        EXPECT_TRUE(approxCompareAngles(180.0f, spikes2.at(0).getCellRef()._frontAngle.value()))
+            << "spikes2 0: " << spikes2.at(0).getCellRef()._frontAngle.value();
+        EXPECT_TRUE(approxCompareAngles(180.0f, spikes2.at(1).getCellRef()._frontAngle.value()))
+            << "spikes2 1: " << spikes2.at(1).getCellRef()._frontAngle.value();
     }
 
     // Check angles without muscle distortions
@@ -290,21 +296,26 @@ TEST_P(CreatureTests_BendingMuscles, constructCreatureWithOneLegAndSpikes)
     // Check angles for first cell leg
     ASSERT_EQ(1, leg.at(0)._connections.size());
 
-    // Check angles for second cell leg
+    // Check angles for second cell leg (the initial angle of a connection is stored in the connected muscle)
     ASSERT_EQ(4, leg.at(1)._connections.size());
-    EXPECT_TRUE(approxCompareAngles(90.0f, getInitialAngle(leg.at(0))));  // initial angle connection is stored in connected muscle
-    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(1)._connections.at(0)._angleFromPrevious));
-    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(1)._connections.at(1)._angleFromPrevious));
+    EXPECT_TRUE(approxCompareAngles(90.0f, getInitialAngle(leg.at(0)))) << "initialAngle leg 0: " << getInitialAngle(leg.at(0));
+    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(1)._connections.at(0)._angleFromPrevious))
+        << "leg 1 conn 0: " << leg.at(1)._connections.at(0)._angleFromPrevious;
+    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(1)._connections.at(1)._angleFromPrevious))
+        << "leg 1 conn 1: " << leg.at(1)._connections.at(1)._angleFromPrevious;
 
     // Check angles for third cell leg
     ASSERT_EQ(2, leg.at(2)._connections.size());
-    EXPECT_TRUE(approxCompareAngles(180.0, leg.at(2)._connections.at(0)._angleFromPrevious));
+    EXPECT_TRUE(approxCompareAngles(180.0, leg.at(2)._connections.at(0)._angleFromPrevious))
+        << "leg 2 conn 0: " << leg.at(2)._connections.at(0)._angleFromPrevious;
 
-    // Check angles for forth cell leg
+    // Check angles for forth cell leg (the initial angle of a connection is stored in the connected muscle)
     ASSERT_EQ(4, leg.at(3)._connections.size());
-    EXPECT_TRUE(approxCompareAngles(90.0f, getInitialAngle(leg.at(2))));  // initial angle connection is stored in connected muscle
-    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(3)._connections.at(0)._angleFromPrevious));
-    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(3)._connections.at(1)._angleFromPrevious));
+    EXPECT_TRUE(approxCompareAngles(90.0f, getInitialAngle(leg.at(2)))) << "initialAngle leg 2: " << getInitialAngle(leg.at(2));
+    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(3)._connections.at(0)._angleFromPrevious))
+        << "leg 3 conn 0: " << leg.at(3)._connections.at(0)._angleFromPrevious;
+    EXPECT_TRUE(approxCompareAngles(90.0, leg.at(3)._connections.at(1)._angleFromPrevious))
+        << "leg 3 conn 1: " << leg.at(3)._connections.at(1)._angleFromPrevious;
 }
 
 // Regression test for issue where muscles connected to void were not constructed with the correct angles

--- a/source/EngineTests/EvolutionStatisticsTests.cpp
+++ b/source/EngineTests/EvolutionStatisticsTests.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/Desc.h>
+#include <EngineInterface/SimulationFacade.h>
+#include <EngineInterface/StatisticsRawData.h>
+
+#include "MutationTestsBase.h"
+
+class EvolutionStatisticsTests : public MutationTestsBase
+{};
+
+TEST_F(EvolutionStatisticsTests, basicCounts)
+{
+    auto data = Desc()
+                    .addCreature({ObjectDesc().id(1), ObjectDesc().id(2).pos({1.0f, 0.0f})}, CreatureDesc().lineageId(42).generation(3), GenomeDesc())
+                    .addCreature({ObjectDesc().id(3).pos({10.0f, 10.0f})}, CreatureDesc().lineageId(43).generation(5), GenomeDesc());
+
+    _simulationFacade->setSimulationData(data);
+
+    auto statistics = _simulationFacade->getStatisticsRawData();
+    auto const& evolution = statistics.timeline.timestep.evolution;
+    EXPECT_EQ(2, evolution.numCreatures);
+    EXPECT_EQ(2, evolution.numGenomes);
+    EXPECT_EQ(2, evolution.numActiveLineages);
+    EXPECT_EQ(3, evolution.numCellObjects);
+    EXPECT_EQ(0, evolution.numSolidObjects);
+    EXPECT_EQ(0, evolution.numFluidObjects);
+    EXPECT_EQ(0, evolution.lineageMapOverflow);
+    EXPECT_FLOAT_EQ(3.0f, evolution.sumCreatureCells);
+    EXPECT_FLOAT_EQ(8.0f, evolution.sumCreatureGenerations);
+    EXPECT_GT(evolution.sumCreatureEnergy, 0.0f);
+
+    auto lineageStatistics = _simulationFacade->getRawLineageStatistics();
+    ASSERT_EQ(2, lineageStatistics.entries.size());
+    auto findEntry = [&](uint32_t lineageId) -> LineageStatisticsEntry const* {
+        for (auto const& entry : lineageStatistics.entries) {
+            if (entry.lineageId == lineageId) {
+                return &entry;
+            }
+        }
+        return nullptr;
+    };
+    auto const* entry42 = findEntry(42);
+    ASSERT_TRUE(entry42 != nullptr);
+    EXPECT_EQ(1, entry42->numCreatures);
+    EXPECT_EQ(1, entry42->numGenomes);
+    EXPECT_FLOAT_EQ(2.0f, entry42->sumCreatureCells);
+    EXPECT_FLOAT_EQ(3.0f, entry42->sumCreatureGenerations);
+    EXPECT_GT(entry42->sumCreatureEnergy, 0.0f);
+    EXPECT_NE(0, entry42->colorBitset);
+
+    auto const* entry43 = findEntry(43);
+    ASSERT_TRUE(entry43 != nullptr);
+    EXPECT_EQ(1, entry43->numCreatures);
+    EXPECT_FLOAT_EQ(1.0f, entry43->sumCreatureCells);
+    EXPECT_FLOAT_EQ(5.0f, entry43->sumCreatureGenerations);
+}
+
+TEST_F(EvolutionStatisticsTests, genomeNodesAndMutationRates)
+{
+    auto genome = createTestGenome();
+    auto numNodes = 0;
+    for (auto const& gene : genome._genes) {
+        numNodes += toInt(gene._nodes.size());
+    }
+    genome._mutationRates._voidMutation = VoidMutationDesc().nodeProbability(0.21f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42), genome);
+    _simulationFacade->setSimulationData(data);
+
+    auto statistics = _simulationFacade->getStatisticsRawData();
+    auto const& evolution = statistics.timeline.timestep.evolution;
+    EXPECT_EQ(1, evolution.numGenomes);
+    EXPECT_FLOAT_EQ(toFloat(numNodes), evolution.sumGenomeNodes);
+    EXPECT_FLOAT_EQ(0.01f, evolution.sumMutationRates);  //mean over 21 probability values: 0.21 / 21
+}
+
+TEST_F(EvolutionStatisticsTests, accumulatedMutations)
+{
+    auto genome = createTestGenome();
+    genome._mutationRates._neuronMutations[0] =
+        NeuronMutationDesc().nodeProbability(1.0f).weightChangeSigma(1.0f).biasChangeSigma(1.0f).actfnChangeProbability(1.0f);
+
+    auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42), genome);
+
+    auto parameters = _parameters;
+    parameters.newLineageThreshold.value = 1.0e30f;
+    _simulationFacade->setSimulationParameters(parameters);
+
+    _simulationFacade->setSimulationData(data);
+    for (int i = 0; i < 10; ++i) {
+        _simulationFacade->testOnly_mutate(1);
+    }
+    _simulationFacade->calcTimesteps(1);
+
+    auto statistics = _simulationFacade->getStatisticsRawData();
+    EXPECT_GT(statistics.timeline.timestep.evolution.sumAccumulatedMutations, 0.0f);
+    EXPECT_GT(statistics.timeline.accumulated.totalMutations, 0.0);
+
+    auto lineageStatistics = _simulationFacade->getRawLineageStatistics();
+    ASSERT_EQ(1, lineageStatistics.entries.size());
+    EXPECT_EQ(42, lineageStatistics.entries.front().lineageId);
+    EXPECT_GT(lineageStatistics.entries.front().totalMutations, 0.0f);
+}

--- a/source/EngineTests/EvolutionStatisticsTests.cpp
+++ b/source/EngineTests/EvolutionStatisticsTests.cpp
@@ -11,8 +11,9 @@ class EvolutionStatisticsTests : public MutationTestsBase
 
 TEST_F(EvolutionStatisticsTests, basicCounts)
 {
+    auto genome42 = GenomeDesc().genes({GeneDesc().nodes({NodeDesc().color(2), NodeDesc().color(5)})});
     auto data = Desc()
-                    .addCreature({ObjectDesc().id(1), ObjectDesc().id(2).pos({1.0f, 0.0f})}, CreatureDesc().lineageId(42).generation(3), GenomeDesc())
+                    .addCreature({ObjectDesc().id(1), ObjectDesc().id(2).pos({1.0f, 0.0f})}, CreatureDesc().lineageId(42).generation(3), genome42)
                     .addCreature({ObjectDesc().id(3).pos({10.0f, 10.0f})}, CreatureDesc().lineageId(43).generation(5), GenomeDesc());
 
     _simulationFacade->setSimulationData(data);
@@ -47,7 +48,7 @@ TEST_F(EvolutionStatisticsTests, basicCounts)
     EXPECT_FLOAT_EQ(2.0f, entry42->sumCreatureCells);
     EXPECT_FLOAT_EQ(3.0f, entry42->sumCreatureGenerations);
     EXPECT_GT(entry42->sumCreatureEnergy, 0.0f);
-    EXPECT_NE(0, entry42->colorBitset);
+    EXPECT_EQ((1u << 2) | (1u << 5), entry42->colorBitset);  //derived from genome node colors, not cell colors
 
     auto const* entry43 = findEntry(43);
     ASSERT_TRUE(entry43 != nullptr);

--- a/source/Gui/EvolutionDashboardWindow.cpp
+++ b/source/Gui/EvolutionDashboardWindow.cpp
@@ -3,12 +3,13 @@
 #include <algorithm>
 #include <bit>
 #include <cmath>
-#include <random>
+#include <limits>
 #include <cstdio>
 
 #include <imgui.h>
 #include <implot.h>
 
+#include <Base/Definitions.h>
 #include <Base/GlobalSettings.h>
 #include <Base/StringHelper.h>
 
@@ -19,6 +20,10 @@
 
 namespace
 {
+    auto constexpr LiveStatisticsDeltaTime = 50;  //in millisec
+    auto constexpr MaxLiveHistory = 240.0;        //in seconds
+    auto constexpr NumSparklinePoints = 40;
+
     auto constexpr SparklineWidth = 90.0f;
     auto constexpr SparklineHeight = 26.0f;
     auto constexpr ColorChipSize = 22.0f;
@@ -28,35 +33,31 @@ namespace
     auto constexpr PlotHeight = 60.0f;
     auto constexpr PlotHeightWithAxis = 80.0f;
     auto constexpr DefaultTimelinesHeight = 380.0f;
-    auto constexpr TimeSpan = 1250000.0;
 
     ImColor const CardBackgroundColor = ImColor(0.095f, 0.117f, 0.165f, 1.0f);
     ImColor const CardBorderColor = ImColor(0.165f, 0.196f, 0.270f, 1.0f);
     ImColor const PositiveDeltaColor = ImColor(0.19f, 0.77f, 0.55f, 1.0f);
     ImColor const NegativeDeltaColor = ImColor(0.94f, 0.32f, 0.32f, 1.0f);
     ImColor const SumSeriesColor = ImColor(0.78f, 0.78f, 0.78f, 1.0f);
+    ImColor const OverflowWarningColor = ImColor(0.94f, 0.62f, 0.22f, 1.0f);
 
     struct MetricDef
     {
         char const* tableHeader;
         char const* plotName;
-        double baseValue;
         int decimals;  //-1: scientific notation
     };
 
     MetricDef const Metrics[EvolutionDashboardWindow::NumMetrics] = {
-        {"Creatures", "Creatures", 1500.0, 0},
-        {"Avg size", "Avg creature size", 15.0, 1},
-        {"Avg cells", "Avg cells", 40.0, 1},
-        {"Avg nodes", "Avg nodes", 60.0, 1},
-        {"Sum energy", "Sum energy", 150000.0, 0},
-        {"Avg mut. rate", "Avg mutation rate", 2.0e-4, -1},
-        {"Avg age (gen)", "Avg age (generations)", 200.0, 0},
-        {"Created /s", "Created creatures / s", 3.0, 1},
-        {"Mutations /s", "Mutations / s", 1.0, 1},
+        {"Creatures", "Creatures", 0},
+        {"Avg cells", "Avg cells", 1},
+        {"Avg nodes", "Avg nodes", 1},
+        {"Sum energy", "Sum energy", 0},
+        {"Avg mut. rate", "Avg mutation rate", -1},
+        {"Avg age (gen)", "Avg age (generations)", 0},
+        {"Created /s", "Created creatures / s", 2},
+        {"Mutations /s", "Mutations / s", 1},
     };
-
-    float const MetricDeltas[EvolutionDashboardWindow::NumMetrics] = {4.1f, 0.6f, 1.2f, 0.0f, -0.4f, -2.3f, 5.0f, 1.1f, -0.8f};
 
     ImColor toImColor(uint32_t rgb, float alpha = 1.0f)
     {
@@ -110,18 +111,96 @@ namespace
         return x - pos.x;
     }
 
-    std::vector<double> createRandomWalk(std::mt19937& rng, int count, double baseValue, double volatility, double trend)
+    double calcRate(double accumValue, double lastAccumValue, double clock, double lastClock)
     {
-        std::uniform_real_distribution<double> distribution(-1.0, 1.0);
-        std::vector<double> result;
-        result.reserve(count);
-        auto value = baseValue * (0.4 + 0.4 * (distribution(rng) + 1.0) / 2);
-        for (int i = 0; i < count; ++i) {
-            value += baseValue * (distribution(rng) * volatility + trend);
-            value = std::max(baseValue * 0.05, value);
-            result.emplace_back(value);
+        auto deltaClock = clock - lastClock;
+        if (deltaClock <= 0) {
+            return 0.0;
         }
-        return result;
+        return std::max(0.0, (accumValue - lastAccumValue) / deltaClock);  //negative deltas occur after accumulated statistics have been reset
+    }
+
+    double getGlobalMetricValue(DataPointCollection const& dataPoints, DataPointCollection const* lastDataPoints, bool clockFromTime, int metricIndex)
+    {
+        switch (metricIndex) {
+        case 0:
+            return dataPoints.numCreatures;
+        case 1:
+            return dataPoints.averageCreatureCells;
+        case 2:
+            return dataPoints.averageGenomeNodes;
+        case 3:
+            return dataPoints.creatureEnergy;
+        case 4:
+            return dataPoints.averageMutationRate;
+        case 5:
+            return dataPoints.averageGeneration;
+        case 6:
+        case 7: {
+            if (!lastDataPoints) {
+                return 0.0;
+            }
+            auto clock = clockFromTime ? dataPoints.time : dataPoints.systemClock;
+            auto lastClock = clockFromTime ? lastDataPoints->time : lastDataPoints->systemClock;
+            if (metricIndex == 6) {
+                return calcRate(dataPoints.accumCreatedCreatures, lastDataPoints->accumCreatedCreatures, clock, lastClock);
+            } else {
+                return calcRate(dataPoints.accumMutations, lastDataPoints->accumMutations, clock, lastClock);
+            }
+        }
+        default:
+            return 0.0;
+        }
+    }
+
+    double getLineageMetricValue(LineageStatisticsEntry const& entry, LineageStatisticsEntry const* lastEntry, double clock, double lastClock, int metricIndex)
+    {
+        switch (metricIndex) {
+        case 0:
+            return toDouble(entry.numCreatures);
+        case 1:
+            return entry.numCreatures > 0 ? toDouble(entry.sumCreatureCells) / entry.numCreatures : 0.0;
+        case 2:
+            return entry.numGenomes > 0 ? toDouble(entry.sumGenomeNodes) / entry.numGenomes : 0.0;
+        case 3:
+            return toDouble(entry.sumCreatureEnergy);
+        case 4:
+            return entry.numGenomes > 0 ? toDouble(entry.sumMutationRates) / entry.numGenomes : 0.0;
+        case 5:
+            return entry.numCreatures > 0 ? toDouble(entry.sumCreatureGenerations) / entry.numCreatures : 0.0;
+        case 6:
+            return lastEntry ? calcRate(toDouble(entry.numCreatedCreatures), toDouble(lastEntry->numCreatedCreatures), clock, lastClock) : 0.0;
+        case 7:
+            return lastEntry ? calcRate(toDouble(entry.totalMutations), toDouble(lastEntry->totalMutations), clock, lastClock) : 0.0;
+        default:
+            return 0.0;
+        }
+    }
+
+    LineageStatisticsEntry const* findLineageEntry(LineageSample const& sample, uint32_t lineageId)
+    {
+        auto it =
+            std::lower_bound(sample.entries.begin(), sample.entries.end(), lineageId, [](auto const& entry, uint32_t id) { return entry.lineageId < id; });
+        if (it != sample.entries.end() && it->lineageId == lineageId) {
+            return &*it;
+        }
+        return nullptr;
+    }
+
+    double calcWindowDeltaPercent(std::vector<double> const& series)
+    {
+        if (series.size() < 2 || std::abs(series.front()) < NEAR_ZERO) {
+            return 0.0;
+        }
+        return (series.back() / series.front() - 1.0) * 100;
+    }
+
+    double calcDeltaPercentPerMinute(std::vector<double> const& series, double windowInSeconds)
+    {
+        if (windowInSeconds < NEAR_ZERO) {
+            return 0.0;
+        }
+        return calcWindowDeltaPercent(series) / (windowInSeconds / 60);
     }
 }
 
@@ -137,8 +216,6 @@ void EvolutionDashboardWindow::initIntern()
     _lastSteps = GlobalSettings::get().getValue("windows.evolution dashboard.last steps", _lastSteps);
     _colorFilter = GlobalSettings::get().getValue("windows.evolution dashboard.color filter", _colorFilter);
     validateAndCorrect();
-
-    generateDummyData();
 }
 
 void EvolutionDashboardWindow::shutdownIntern()
@@ -150,9 +227,43 @@ void EvolutionDashboardWindow::shutdownIntern()
     GlobalSettings::get().setValue("windows.evolution dashboard.color filter", _colorFilter);
 }
 
+void EvolutionDashboardWindow::processBackground()
+{
+    auto timepoint = std::chrono::steady_clock::now();
+    auto duration =
+        _lastTimepoint.has_value() ? static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(timepoint - *_lastTimepoint).count()) : 0;
+    if (_lastTimepoint && duration <= LiveStatisticsDeltaTime) {
+        return;
+    }
+    _lastTimepoint = timepoint;
+    _timeSinceSimStart += toDouble(duration) / 1000;
+
+    auto rawStatistics = _SimulationFacade::get()->getStatisticsRawData();
+    _timelineLiveStatistics.update(rawStatistics.timeline, _SimulationFacade::get()->getCurrentTimestep());
+    _lineageMapOverflow = rawStatistics.timeline.timestep.evolution.lineageMapOverflow != 0;
+
+    auto rawLineageStatistics = _SimulationFacade::get()->getRawLineageStatistics();
+    LineageSample sample;
+    sample.time = _timeSinceSimStart;
+    sample.systemClock = _timeSinceSimStart;
+    sample.entries = std::move(rawLineageStatistics.entries);
+    std::sort(sample.entries.begin(), sample.entries.end(), [](auto const& lhs, auto const& rhs) { return lhs.lineageId < rhs.lineageId; });
+    _liveLineageHistory.emplace_back(std::move(sample));
+    while (!_liveLineageHistory.empty() && _liveLineageHistory.back().time - _liveLineageHistory.front().time > MaxLiveHistory + 1.0) {
+        _liveLineageHistory.erase(_liveLineageHistory.begin());
+    }
+
+    _externalEnergySeries.emplace_back(toDouble(_SimulationFacade::get()->getSimulationParameters().externalEnergy.value));
+    auto maxExternalEnergyValues = toInt(std::lround(MaxLiveHistory * 1000 / LiveStatisticsDeltaTime));
+    while (toInt(_externalEnergySeries.size()) > maxExternalEnergyValues) {
+        _externalEnergySeries.erase(_externalEnergySeries.begin());
+    }
+}
+
 void EvolutionDashboardWindow::processIntern()
 {
     updateCellColors();
+    updateDisplayData();
     processHeader();
     processFilterBar();
 
@@ -177,6 +288,157 @@ void EvolutionDashboardWindow::updateCellColors()
     }
 }
 
+void EvolutionDashboardWindow::updateDisplayData()
+{
+    //rebuild only when the underlying data or view settings have changed
+    auto liveBackTime = !_liveLineageHistory.empty() ? _liveLineageHistory.back().time : -1.0;
+    auto historyBackTime = -1.0;
+    if (_timelineMode != TimelineMode_RealTime) {
+        auto const& statisticsHistory = _SimulationFacade::get()->getStatisticsHistory();
+        std::lock_guard lock(statisticsHistory.getMutex());
+        if (!statisticsHistory.getDataRef().empty()) {
+            historyBackTime = statisticsHistory.getDataRef().back().time;
+        }
+    }
+    RebuildKey key{_timelineMode, _lastSteps, liveBackTime, historyBackTime, _selectedLineageIds};
+    if (_lastRebuildKey && *_lastRebuildKey == key) {
+        return;
+    }
+    _lastRebuildKey = std::move(key);
+
+    //table rows from the latest live sample
+    _lineages.clear();
+    if (!_liveLineageHistory.empty()) {
+        auto const& lastSample = _liveLineageHistory.back();
+        auto const* previousSample = _liveLineageHistory.size() >= 2 ? &_liveLineageHistory.at(_liveLineageHistory.size() - 2) : nullptr;
+        for (auto const& entry : lastSample.entries) {
+            LineageDisplayData lineage;
+            lineage.id = toInt(entry.lineageId);
+            lineage.colorBitset = toInt(entry.colorBitset);
+            auto const* previousEntry = previousSample ? findLineageEntry(*previousSample, entry.lineageId) : nullptr;
+            for (int i = 0; i < NumMetrics; ++i) {
+                lineage.currentValues.at(i) = getLineageMetricValue(entry, previousEntry, lastSample.time, previousSample ? previousSample->time : 0.0, i);
+            }
+            _lineages.emplace_back(std::move(lineage));
+        }
+        std::sort(_lineages.begin(), _lineages.end(), [](auto const& lhs, auto const& rhs) { return lhs.currentValues.at(0) > rhs.currentValues.at(0); });
+    }
+
+    //data source for the timeline plots
+    auto useTimeAsClock = _timelineMode == TimelineMode_RealTime;
+    std::vector<DataPointCollection> globalSource;
+    LineageHistoryData lineageSource;
+    if (_timelineMode == TimelineMode_RealTime) {
+        globalSource = _timelineLiveStatistics.getDataPointCollectionHistory();
+        lineageSource = _liveLineageHistory;
+    } else {
+        auto const& statisticsHistory = _SimulationFacade::get()->getStatisticsHistory();
+        {
+            std::lock_guard lock(statisticsHistory.getMutex());
+            globalSource = statisticsHistory.getDataRef();
+        }
+        lineageSource = _SimulationFacade::get()->getLineageHistory().getCopiedData();
+        if (_timelineMode == TimelineMode_LastSteps && !globalSource.empty()) {
+            auto startTime = globalSource.back().time - toDouble(_lastSteps);
+            std::erase_if(globalSource, [&](auto const& dataPoints) { return dataPoints.time < startTime; });
+            std::erase_if(lineageSource, [&](auto const& sample) { return sample.time < startTime; });
+        }
+    }
+
+    //"all lineages" series
+    _allLineages.id = -1;
+    _allLineages.colorBitset = 0;
+    _allLineages.timePoints.clear();
+    for (int i = 0; i < NumMetrics; ++i) {
+        _allLineages.series.at(i).clear();
+    }
+    for (size_t sampleIndex = 0; sampleIndex < globalSource.size(); ++sampleIndex) {
+        auto const& dataPoints = globalSource.at(sampleIndex);
+        auto const* lastDataPoints = sampleIndex > 0 ? &globalSource.at(sampleIndex - 1) : nullptr;
+        _allLineages.timePoints.emplace_back(dataPoints.time);
+        for (int i = 0; i < NumMetrics; ++i) {
+            _allLineages.series.at(i).emplace_back(getGlobalMetricValue(dataPoints, lastDataPoints, useTimeAsClock, i));
+        }
+    }
+    auto const& liveGlobalHistory = _timelineLiveStatistics.getDataPointCollectionHistory();
+    if (!liveGlobalHistory.empty()) {
+        auto const& lastDataPoints = liveGlobalHistory.back();
+        auto const* previousDataPoints = liveGlobalHistory.size() >= 2 ? &liveGlobalHistory.at(liveGlobalHistory.size() - 2) : nullptr;
+        for (int i = 0; i < NumMetrics; ++i) {
+            _allLineages.currentValues.at(i) = getGlobalMetricValue(lastDataPoints, previousDataPoints, true, i);
+        }
+    }
+    for (int i = 0; i < NumMetrics; ++i) {
+        _metricWindowDeltas.at(i) = calcWindowDeltaPercent(_allLineages.series.at(i));
+    }
+
+    //per-lineage series for the selected lineages
+    _plottedLineages.clear();
+    if (!_selectedLineageIds.empty()) {
+        for (auto const& selectedId : _selectedLineageIds) {
+            LineageDisplayData lineage;
+            lineage.id = selectedId;
+            LineageSample const* lastSampleWithEntry = nullptr;
+            LineageStatisticsEntry const* lastEntry = nullptr;
+            for (auto const& sample : lineageSource) {
+                auto const* entry = findLineageEntry(sample, toUInt32(selectedId));
+                if (!entry) {
+                    continue;
+                }
+                lineage.colorBitset = toInt(entry->colorBitset);
+                lineage.timePoints.emplace_back(sample.time);
+                auto clock = useTimeAsClock ? sample.time : sample.systemClock;
+                auto lastClock = lastSampleWithEntry ? (useTimeAsClock ? lastSampleWithEntry->time : lastSampleWithEntry->systemClock) : 0.0;
+                for (int i = 0; i < NumMetrics; ++i) {
+                    lineage.series.at(i).emplace_back(getLineageMetricValue(*entry, lastEntry, clock, lastClock, i));
+                }
+                lastSampleWithEntry = &sample;
+                lastEntry = entry;
+            }
+            for (auto const& tableLineage : _lineages) {
+                if (tableLineage.id == selectedId) {
+                    lineage.currentValues = tableLineage.currentValues;
+                    if (lineage.colorBitset == 0) {
+                        lineage.colorBitset = tableLineage.colorBitset;
+                    }
+                }
+            }
+            _plottedLineages.emplace_back(std::move(lineage));
+        }
+    }
+
+    //header sparklines and deltas from the live statistics
+    auto liveWindowInSeconds = liveGlobalHistory.size() >= 2 ? liveGlobalHistory.back().time - liveGlobalHistory.front().time : 0.0;
+    for (int cardIndex = 0; cardIndex < 4; ++cardIndex) {
+        auto& sparkline = _headerSparklines.at(cardIndex);
+        sparkline.clear();
+        std::vector<double> fullSeries;
+        if (cardIndex == 1) {
+            fullSeries = _externalEnergySeries;
+        } else {
+            fullSeries.reserve(liveGlobalHistory.size());
+            for (auto const& dataPoints : liveGlobalHistory) {
+                switch (cardIndex) {
+                case 0:
+                    fullSeries.emplace_back(dataPoints.totalEnergy.summedValues);
+                    break;
+                case 2:
+                    fullSeries.emplace_back(dataPoints.numLineages);
+                    break;
+                case 3:
+                    fullSeries.emplace_back(dataPoints.numCreatures);
+                    break;
+                }
+            }
+        }
+        _headerDeltas.at(cardIndex) = calcDeltaPercentPerMinute(fullSeries, liveWindowInSeconds);
+        auto stride = std::max(size_t(1), fullSeries.size() / NumSparklinePoints);
+        for (size_t i = 0; i < fullSeries.size(); i += stride) {
+            sparkline.emplace_back(fullSeries.at(i));
+        }
+    }
+}
+
 void EvolutionDashboardWindow::processHeader()
 {
     auto const& style = ImGui::GetStyle();
@@ -184,15 +446,21 @@ void EvolutionDashboardWindow::processHeader()
     auto cardHeight =
         style.WindowPadding.y * 2 + ImGui::GetTextLineHeight() * 3 + StyleRepository::get().getLargeFont()->FontSize + style.ItemSpacing.y * 3 + scale(6.0f);
 
+    auto const& liveGlobalHistory = _timelineLiveStatistics.getDataPointCollectionHistory();
+    auto const* lastDataPoints = !liveGlobalHistory.empty() ? &liveGlobalHistory.back() : nullptr;
+
     processEntitiesCard(cardWidth * 2, cardHeight);
     ImGui::SameLine();
-    processKpiCard("SUM ENERGY", "1.24 M", 0.8f, 0, cardWidth, cardHeight);
+    auto sumEnergy = lastDataPoints ? lastDataPoints->totalEnergy.summedValues : 0.0;
+    processKpiCard("SUM ENERGY", formatMetricValue(sumEnergy, 0), toFloat(_headerDeltas.at(0)), 0, cardWidth, cardHeight);
     ImGui::SameLine();
-    processKpiCard("EXTERNAL ENERGY", "356 K", -1.2f, 1, cardWidth, cardHeight);
+    auto externalEnergy = !_externalEnergySeries.empty() ? _externalEnergySeries.back() : 0.0;
+    processKpiCard("EXTERNAL ENERGY", formatMetricValue(externalEnergy, 0), toFloat(_headerDeltas.at(1)), 1, cardWidth, cardHeight);
     ImGui::SameLine();
-    processKpiCard("LINEAGES", StringHelper::format(toFloat(_lineages.size()), 0), 2.4f, 2, cardWidth, cardHeight);
+    auto numLineages = lastDataPoints ? lastDataPoints->numLineages : 0.0;
+    processKpiCard("LINEAGES", formatMetricValue(numLineages, 0), toFloat(_headerDeltas.at(2)), 2, cardWidth, cardHeight);
     ImGui::SameLine();
-    processKpiCard("CREATURES", formatMetricValue(_allLineages.currentValues.at(0), 0), 0.5f, 3, cardWidth, cardHeight);
+    processKpiCard("CREATURES", formatMetricValue(_allLineages.currentValues.at(0), 0), toFloat(_headerDeltas.at(3)), 3, cardWidth, cardHeight);
 }
 
 void EvolutionDashboardWindow::processKpiCard(std::string const& label, std::string const& value, float delta, int sparklineIndex, float width, float height)
@@ -216,22 +484,25 @@ void EvolutionDashboardWindow::processKpiCard(std::string const& label, std::str
         ImGui::PopStyleColor();
 
         auto const& sparkline = _headerSparklines.at(sparklineIndex);
-        ImGui::SetCursorPos({width - scale(SparklineWidth + 12.0f), height - scale(SparklineHeight + 12.0f)});
-        ImPlot::PushStyleVar(ImPlotStyleVar_PlotPadding, ImVec2(0, 0));
-        ImPlot::PushStyleColor(ImPlotCol_FrameBg, (ImU32)ImColor(0, 0, 0, 0));
-        ImPlot::PushStyleColor(ImPlotCol_PlotBg, (ImU32)ImColor(0, 0, 0, 0));
-        ImPlot::PushStyleColor(ImPlotCol_PlotBorder, (ImU32)ImColor(0, 0, 0, 0));
-        if (ImPlot::BeginPlot(("##spark" + label).c_str(), {scale(SparklineWidth), scale(SparklineHeight)}, ImPlotFlags_CanvasOnly | ImPlotFlags_NoInputs)) {
-            ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
-            auto [minIt, maxIt] = std::minmax_element(sparkline.begin(), sparkline.end());
-            ImPlot::SetupAxesLimits(0, toDouble(sparkline.size() - 1), *minIt * 0.9, *maxIt * 1.1, ImGuiCond_Always);
-            ImPlot::PushStyleColor(ImPlotCol_Line, delta >= 0 ? (ImU32)PositiveDeltaColor : (ImU32)NegativeDeltaColor);
-            ImPlot::PlotLine("##", sparkline.data(), toInt(sparkline.size()));
-            ImPlot::PopStyleColor();
-            ImPlot::EndPlot();
+        if (sparkline.size() >= 2) {
+            ImGui::SetCursorPos({width - scale(SparklineWidth + 12.0f), height - scale(SparklineHeight + 12.0f)});
+            ImPlot::PushStyleVar(ImPlotStyleVar_PlotPadding, ImVec2(0, 0));
+            ImPlot::PushStyleColor(ImPlotCol_FrameBg, (ImU32)ImColor(0, 0, 0, 0));
+            ImPlot::PushStyleColor(ImPlotCol_PlotBg, (ImU32)ImColor(0, 0, 0, 0));
+            ImPlot::PushStyleColor(ImPlotCol_PlotBorder, (ImU32)ImColor(0, 0, 0, 0));
+            if (ImPlot::BeginPlot(
+                    ("##spark" + label).c_str(), {scale(SparklineWidth), scale(SparklineHeight)}, ImPlotFlags_CanvasOnly | ImPlotFlags_NoInputs)) {
+                ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
+                auto [minIt, maxIt] = std::minmax_element(sparkline.begin(), sparkline.end());
+                ImPlot::SetupAxesLimits(0, toDouble(sparkline.size() - 1), *minIt * 0.9, *maxIt * 1.1 + NEAR_ZERO, ImGuiCond_Always);
+                ImPlot::PushStyleColor(ImPlotCol_Line, delta >= 0 ? (ImU32)PositiveDeltaColor : (ImU32)NegativeDeltaColor);
+                ImPlot::PlotLine("##", sparkline.data(), toInt(sparkline.size()));
+                ImPlot::PopStyleColor();
+                ImPlot::EndPlot();
+            }
+            ImPlot::PopStyleColor(3);
+            ImPlot::PopStyleVar();
         }
-        ImPlot::PopStyleColor(3);
-        ImPlot::PopStyleVar();
     }
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
@@ -240,6 +511,21 @@ void EvolutionDashboardWindow::processKpiCard(std::string const& label, std::str
 
 void EvolutionDashboardWindow::processEntitiesCard(float width, float height)
 {
+    auto const& liveGlobalHistory = _timelineLiveStatistics.getDataPointCollectionHistory();
+    auto solids = 0.0;
+    auto fluids = 0.0;
+    auto cells = 0.0;
+    auto energyParticles = 0.0;
+    auto total = 0.0;
+    if (!liveGlobalHistory.empty()) {
+        auto const& dataPoints = liveGlobalHistory.back();
+        solids = dataPoints.numSolidObjects;
+        fluids = dataPoints.numFluidObjects;
+        cells = dataPoints.numCellObjects;
+        energyParticles = dataPoints.numEnergyParticles.summedValues;
+        total = dataPoints.numObjects.summedValues + energyParticles;
+    }
+
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, scale(6.0f));
     ImGui::PushStyleColor(ImGuiCol_ChildBg, (ImU32)CardBackgroundColor);
     ImGui::PushStyleColor(ImGuiCol_Border, (ImU32)CardBorderColor);
@@ -249,21 +535,21 @@ void EvolutionDashboardWindow::processEntitiesCard(float width, float height)
         ImGui::PopStyleColor();
 
         ImGui::PushFont(StyleRepository::get().getLargeFont());
-        AlienGui::Text("486,120");
+        AlienGui::Text(formatMetricValue(total, 0));
         ImGui::PopFont();
 
-        std::pair<char const*, char const*> const subValues[] = {
-            {"Solids", "12,410"},
-            {"Fluid particles", "213,880"},
-            {"Cells", "245,230"},
-            {"Energy particles", "14,600"},
+        std::pair<char const*, double> const subValues[] = {
+            {"Solids", solids},
+            {"Fluid particles", fluids},
+            {"Cells", cells},
+            {"Energy particles", energyParticles},
         };
         for (auto const& [subLabel, subValue] : subValues) {
             ImGui::BeginGroup();
             ImGui::PushStyleColor(ImGuiCol_Text, (ImU32)Const::TextDecentColor);
             AlienGui::Text(subLabel);
             ImGui::PopStyleColor();
-            AlienGui::Text(subValue);
+            AlienGui::Text(formatMetricValue(subValue, 0));
             ImGui::EndGroup();
             ImGui::SameLine(0, scale(18.0f));
         }
@@ -306,6 +592,12 @@ void EvolutionDashboardWindow::processFilterBar()
         drawList->AddText({pos.x + (chipSize - labelSize.x) / 2, pos.y + (chipSize - labelSize.y) / 2}, ImColor(0, 0, 0, active ? 220 : 120), label.c_str());
         ImGui::PopID();
         ImGui::SameLine(0, scale(5.0f));
+    }
+    if (_lineageMapOverflow) {
+        ImGui::SameLine(0, scale(20.0f));
+        ImGui::PushStyleColor(ImGuiCol_Text, (ImU32)OverflowWarningColor);
+        AlienGui::Text("Too many lineages: some are not tracked");
+        ImGui::PopStyleColor();
     }
     ImGui::NewLine();
     ImGui::Spacing();
@@ -359,7 +651,7 @@ void EvolutionDashboardWindow::processLineageTable()
             if ((_colorFilter & lineage.colorBitset) == 0) {
                 continue;
             }
-            ImGui::PushID(lineage.id);
+            ImGui::PushID(toInt(lineage.id));
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
             auto selected = _selectedLineageIds.contains(lineage.id);
@@ -422,10 +714,7 @@ void EvolutionDashboardWindow::processTimelineHeader()
         AlienGui::Text("All lineages");
     } else {
         auto drawList = ImGui::GetWindowDrawList();
-        for (auto const& lineage : _lineages) {
-            if (!_selectedLineageIds.contains(lineage.id)) {
-                continue;
-            }
+        for (auto const& lineage : _plottedLineages) {
             auto swatchesWidth = drawColorSwatches(drawList, ImGui::GetCursorScreenPos(), lineage.colorBitset, ImGui::GetTextLineHeight(), _cellColors);
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + swatchesWidth + scale(4.0f));
             AlienGui::Text("Lineage #" + std::to_string(lineage.id));
@@ -450,8 +739,8 @@ void EvolutionDashboardWindow::processTimelinePlots()
             AlienGui::Text(formatMetricValue(_allLineages.currentValues.at(i), Metrics[i].decimals));
             ImGui::PopFont();
             char deltaText[32];
-            snprintf(deltaText, sizeof(deltaText), "%+.1f %%", MetricDeltas[i]);
-            ImGui::PushStyleColor(ImGuiCol_Text, MetricDeltas[i] >= 0 ? (ImU32)PositiveDeltaColor : (ImU32)NegativeDeltaColor);
+            snprintf(deltaText, sizeof(deltaText), "%+.1f %%", _metricWindowDeltas.at(i));
+            ImGui::PushStyleColor(ImGuiCol_Text, _metricWindowDeltas.at(i) >= 0 ? (ImU32)PositiveDeltaColor : (ImU32)NegativeDeltaColor);
             AlienGui::Text(deltaText);
             ImGui::PopStyleColor();
 
@@ -464,33 +753,35 @@ void EvolutionDashboardWindow::processTimelinePlots()
 
 void EvolutionDashboardWindow::processTimelinePlot(int metricIndex, bool showTimeAxis)
 {
-    auto count = toInt(_timePoints.size());
-    auto offset = 0;
-    if (_timelineMode == TimelineMode_RealTime) {
-        offset = count * 9 / 10;
-    } else if (_timelineMode == TimelineMode_LastSteps) {
-        auto numPoints = toInt(std::lround(toDouble(_lastSteps) / TimeSpan * count));
-        offset = std::max(0, count - std::max(2, numPoints));
-    }
-    count -= offset;
-
-    std::vector<DummyLineage const*> plottedLineages;
+    std::vector<LineageDisplayData const*> plottedLineages;
     if (_selectedLineageIds.empty()) {
         plottedLineages.emplace_back(&_allLineages);
     } else {
-        for (auto const& lineage : _lineages) {
-            if (_selectedLineageIds.contains(lineage.id)) {
-                plottedLineages.emplace_back(&lineage);
-            }
+        for (auto const& lineage : _plottedLineages) {
+            plottedLineages.emplace_back(&lineage);
         }
     }
 
     auto upperBound = 0.0;
+    auto minTime = std::numeric_limits<double>::max();
+    auto maxTime = std::numeric_limits<double>::lowest();
+    auto hasData = false;
     for (auto const* lineage : plottedLineages) {
-        auto const& series = lineage->series.at(metricIndex);
-        for (int i = offset; i < offset + count; ++i) {
-            upperBound = std::max(upperBound, series.at(i));
+        if (lineage->timePoints.size() < 2) {
+            continue;
         }
+        hasData = true;
+        minTime = std::min(minTime, lineage->timePoints.front());
+        maxTime = std::max(maxTime, lineage->timePoints.back());
+        for (auto const& value : lineage->series.at(metricIndex)) {
+            upperBound = std::max(upperBound, value);
+        }
+    }
+    if (!hasData) {
+        ImGui::PushStyleColor(ImGuiCol_Text, (ImU32)Const::TextDecentColor);
+        AlienGui::Text("No data");
+        ImGui::PopStyleColor();
+        return;
     }
     upperBound *= 1.35;
 
@@ -499,7 +790,7 @@ void EvolutionDashboardWindow::processTimelinePlot(int metricIndex, bool showTim
     ImPlot::PushStyleColor(ImPlotCol_PlotBg, (ImU32)ImColor(0.0f, 0.0f, 0.0f, ImGui::GetStyle().Alpha));
     ImPlot::PushStyleColor(ImPlotCol_PlotBorder, (ImU32)ImColor(0.3f, 0.3f, 0.3f, ImGui::GetStyle().Alpha));
     ImPlot::PushStyleVar(ImPlotStyleVar_PlotPadding, ImVec2(0, 0));
-    ImPlot::SetNextAxesLimits(_timePoints.at(offset), _timePoints.at(offset + count - 1), 0, upperBound, ImGuiCond_Always);
+    ImPlot::SetNextAxesLimits(minTime, maxTime, 0, upperBound + NEAR_ZERO, ImGuiCond_Always);
 
     auto height = showTimeAxis ? PlotHeightWithAxis : PlotHeight;
     if (ImPlot::BeginPlot(
@@ -514,26 +805,30 @@ void EvolutionDashboardWindow::processTimelinePlot(int metricIndex, bool showTim
                 [](double value, void* userData) { return (pow(2.0, value) - 1.0) / 1000; });
         }
         for (auto const* lineage : plottedLineages) {
-            ImGui::PushID(lineage->id + 1);
+            auto count = toInt(lineage->timePoints.size());
+            if (count < 2) {
+                continue;
+            }
+            ImGui::PushID(toInt(lineage->id) + 1);
             auto color = lineage->id == -1 ? SumSeriesColor : toImColor(_cellColors.at(getFirstColor(lineage->colorBitset)));
             auto const& series = lineage->series.at(metricIndex);
             ImPlot::PushStyleColor(ImPlotCol_Line, (ImU32)color);
-            ImPlot::PlotLine("##line", _timePoints.data() + offset, series.data() + offset, count);
+            ImPlot::PlotLine("##line", lineage->timePoints.data(), series.data(), count);
             if (_plotScale == PlotScale_Linear) {
                 ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.15f * ImGui::GetStyle().Alpha);
-                ImPlot::PlotShaded("##shaded", _timePoints.data() + offset, series.data() + offset, count);
+                ImPlot::PlotShaded("##shaded", lineage->timePoints.data(), series.data(), count);
                 ImPlot::PopStyleVar();
             }
             ImPlot::PopStyleColor();
             if (ImGui::GetStyle().Alpha == 1.0f) {
                 ImPlot::Annotation(
-                    _timePoints.at(offset + count - 1),
-                    series.at(offset + count - 1),
+                    lineage->timePoints.back(),
+                    series.back(),
                     color,
                     ImVec2(-10.0f, 10.0f),
                     true,
                     "%s",
-                    formatMetricValue(series.at(offset + count - 1), Metrics[metricIndex].decimals).c_str());
+                    formatMetricValue(series.back(), Metrics[metricIndex].decimals).c_str());
             }
             ImGui::PopID();
         }
@@ -544,63 +839,12 @@ void EvolutionDashboardWindow::processTimelinePlot(int metricIndex, bool showTim
     ImGui::PopID();
 }
 
-void EvolutionDashboardWindow::generateDummyData()
-{
-    std::mt19937 rng(20260711);
-    std::uniform_int_distribution<int> colorDistribution(0, MAX_COLORS - 1);
-    std::uniform_int_distribution<int> numColorsDistribution(1, 3);
-    std::uniform_real_distribution<double> trendDistribution(-0.002, 0.004);
-
-    _timePoints.clear();
-    for (int i = 0; i < NumTimePoints; ++i) {
-        _timePoints.emplace_back(TimeSpan * i / (NumTimePoints - 1));
-    }
-
-    _lineages.clear();
-    int const lineageIds[] = {3, 7, 12, 18, 21, 24, 29, 33, 38, 42, 47, 51};
-    for (auto id : lineageIds) {
-        DummyLineage lineage;
-        lineage.id = id;
-        auto numColors = numColorsDistribution(rng);
-        while (std::popcount(static_cast<unsigned>(lineage.colorBitset)) < numColors) {
-            lineage.colorBitset |= 1 << colorDistribution(rng);
-        }
-        for (int i = 0; i < NumMetrics; ++i) {
-            lineage.series.at(i) = createRandomWalk(rng, NumTimePoints, Metrics[i].baseValue, 0.015, trendDistribution(rng));
-            lineage.currentValues.at(i) = lineage.series.at(i).back();
-        }
-        _lineages.emplace_back(lineage);
-    }
-
-    _allLineages.id = -1;
-    for (int i = 0; i < NumMetrics; ++i) {
-        auto& sumSeries = _allLineages.series.at(i);
-        sumSeries.assign(NumTimePoints, 0.0);
-        auto isSummable = i == 0 || i == 4 || i == 7 || i == 8;  //creatures, sum energy, created/s, mutations/s
-        for (auto const& lineage : _lineages) {
-            for (int j = 0; j < NumTimePoints; ++j) {
-                sumSeries.at(j) += lineage.series.at(i).at(j);
-            }
-        }
-        if (!isSummable) {
-            for (auto& value : sumSeries) {
-                value /= toDouble(_lineages.size());
-            }
-        }
-        _allLineages.currentValues.at(i) = sumSeries.back();
-    }
-
-    for (auto& sparkline : _headerSparklines) {
-        sparkline = createRandomWalk(rng, 40, 1.0, 0.03, trendDistribution(rng));
-    }
-}
-
 void EvolutionDashboardWindow::validateAndCorrect()
 {
     _timelinesHeight = std::max(scale(100.0f), _timelinesHeight);
     _timelineMode = std::clamp(_timelineMode, static_cast<TimelineMode>(TimelineMode_RealTime), static_cast<TimelineMode>(TimelineMode_LastSteps));
     _plotScale = std::clamp(_plotScale, static_cast<PlotScale>(PlotScale_Linear), static_cast<PlotScale>(PlotScale_Logarithmic));
-    _lastSteps = std::clamp(_lastSteps, 1000, toInt(TimeSpan));
+    _lastSteps = std::clamp(_lastSteps, 1000, 1000000000);
     _colorFilter &= (1 << MAX_COLORS) - 1;
     if (_colorFilter == 0) {
         _colorFilter = (1 << MAX_COLORS) - 1;

--- a/source/Gui/EvolutionDashboardWindow.h
+++ b/source/Gui/EvolutionDashboardWindow.h
@@ -1,24 +1,28 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <cstdint>
+#include <optional>
 #include <set>
 #include <vector>
 
 #include <Base/Singleton.h>
 
 #include <EngineInterface/EngineConstants.h>
+#include <EngineInterface/LineageHistory.h>
+#include <EngineInterface/LineageStatistics.h>
 
 #include "AlienWindow.h"
 #include "Definitions.h"
+#include "TimelineLiveStatistics.h"
 
 class EvolutionDashboardWindow : public AlienWindow
 {
     MAKE_SINGLETON_NO_DEFAULT_CONSTRUCTION(EvolutionDashboardWindow);
 
 public:
-    static auto constexpr NumMetrics = 9;
-    static auto constexpr NumTimePoints = 300;
+    static auto constexpr NumMetrics = 8;
 
 private:
     EvolutionDashboardWindow();
@@ -26,8 +30,10 @@ private:
     void initIntern() override;
     void shutdownIntern() override;
     void processIntern() override;
+    void processBackground() override;
 
     void updateCellColors();
+    void updateDisplayData();
     void processHeader();
     void processKpiCard(std::string const& label, std::string const& value, float delta, int sparklineIndex, float width, float height);
     void processEntitiesCard(float width, float height);
@@ -38,25 +44,28 @@ private:
     void processTimelinePlots();
     void processTimelinePlot(int metricIndex, bool showTimeAxis);
 
-    void generateDummyData();
     void validateAndCorrect();
 
-    struct DummyLineage
+    struct LineageDisplayData
     {
-        int id = 0;
-        int colorBitset = 0;  //at least one of the MAX_COLORS cell colors
+        int64_t id = 0;  //-1 = "all lineages"
+        int colorBitset = 0;
         std::array<double, NumMetrics> currentValues = {};
-        std::array<std::vector<double>, NumMetrics> series = {};
+        std::array<std::vector<double>, NumMetrics> series = {};  //only filled for plotted lineages
+        std::vector<double> timePoints;                           //only filled for plotted lineages
     };
 
-    std::vector<DummyLineage> _lineages;
-    DummyLineage _allLineages;
-    std::vector<double> _timePoints;
+    std::vector<LineageDisplayData> _lineages;  //table rows from the latest sample, sorted by creature count
+    std::vector<LineageDisplayData> _plottedLineages;
+    LineageDisplayData _allLineages;
+    std::array<double, NumMetrics> _metricWindowDeltas = {};
     std::array<std::vector<double>, 4> _headerSparklines = {};
+    std::array<double, 4> _headerDeltas = {};
+    bool _lineageMapOverflow = false;
 
     std::array<uint32_t, MAX_COLORS> _cellColors = {};
 
-    std::set<int> _selectedLineageIds;
+    std::set<int64_t> _selectedLineageIds;
     int _colorFilter = 0x3ff;  //bitset for MAX_COLORS cell colors
 
     using TimelineMode = int;
@@ -78,4 +87,23 @@ private:
 
     int _lastSteps = 100000;
     float _timelinesHeight = 0;
+
+    struct RebuildKey
+    {
+        int timelineMode = 0;
+        int lastSteps = 0;
+        double liveBackTime = 0;
+        double historyBackTime = 0;
+        std::set<int64_t> selectedLineageIds;
+
+        bool operator==(RebuildKey const&) const = default;
+    };
+    std::optional<RebuildKey> _lastRebuildKey;
+
+    //live statistics
+    TimelineLiveStatistics _timelineLiveStatistics;
+    LineageHistoryData _liveLineageHistory;
+    std::vector<double> _externalEnergySeries;
+    double _timeSinceSimStart = 0;  //in seconds
+    std::optional<std::chrono::steady_clock::time_point> _lastTimepoint;
 };

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -2292,7 +2292,19 @@ namespace
         {"Genome complexity average", true},
         {"Genome complexity Maximum", true},
         {"Genome complexity variance", true},
-        {"System clock", false}};
+        {"System clock", false},
+        {"Creature count", false},
+        {"Average creature cells", false},
+        {"Average genome nodes", false},
+        {"Creature energy", false},
+        {"Average mutation rate", false},
+        {"Average generation", false},
+        {"Lineage count", false},
+        {"Solid objects", false},
+        {"Fluid objects", false},
+        {"Cell objects", false},
+        {"Accumulated created creatures", false},
+        {"Accumulated mutations", false}};
 
     std::variant<DataPoint*, double*> getDataRef(int colIndex, DataPointCollection& dataPoints)
     {
@@ -2350,6 +2362,30 @@ namespace
             return &dataPoints.varianceNumCells;
         } else if (colIndex == 26) {
             return &dataPoints.systemClock;
+        } else if (colIndex == 27) {
+            return &dataPoints.numCreatures;
+        } else if (colIndex == 28) {
+            return &dataPoints.averageCreatureCells;
+        } else if (colIndex == 29) {
+            return &dataPoints.averageGenomeNodes;
+        } else if (colIndex == 30) {
+            return &dataPoints.creatureEnergy;
+        } else if (colIndex == 31) {
+            return &dataPoints.averageMutationRate;
+        } else if (colIndex == 32) {
+            return &dataPoints.averageGeneration;
+        } else if (colIndex == 33) {
+            return &dataPoints.numLineages;
+        } else if (colIndex == 34) {
+            return &dataPoints.numSolidObjects;
+        } else if (colIndex == 35) {
+            return &dataPoints.numFluidObjects;
+        } else if (colIndex == 36) {
+            return &dataPoints.numCellObjects;
+        } else if (colIndex == 37) {
+            return &dataPoints.accumCreatedCreatures;
+        } else if (colIndex == 38) {
+            return &dataPoints.accumMutations;
         }
         THROW_NOT_IMPLEMENTED();
     }


### PR DESCRIPTION
Implements the data supply plan for the Evolution Dashboard prototype (Phases 1–3); Phase 0 was merged in #801.

## Phase 1 — engine-side collection
- `TimestepStatistics` gains a nested `EvolutionStatistics` block: creature/genome counts and sums (cells, generations, accumulated mutations, genome nodes, mean mutation rates, creature energy), per-type object counters and lineage-map status.
- `AccumulatedStatistics` gains monotonic `numCreatedCreatures` and `totalMutations` (per open question 2: dedicated counter instead of the sum-based variant; incremented in `updateAccumulatedMutationsAndLineageId`, so it measures genuine mutation events only).
- New evolution substeps in `StatisticsKernels.cu` using the `DataAccessKernels` dedup pattern (`atomicExch` sentinels on `creatureIndex`/`genomeIndex`); the discovered lineage-map slot is cached in `creatureIndex` so genome/cell passes are O(1).
- `SimulationStatistics` was threaded into `ConstructorProcessor::mutateGenome`/`findOrCreateNewCreature` and `MutationProcessor::applyMutations` (incl. `cudaTestMutate`).

## Phase 2 — transport to the GUI
- `DataPointCollection` gains the momentary values plus raw accumulated values; rates ("/s") are derived GUI-side from consecutive samples (negative deltas after accumulated-statistics resets are clamped to 0).
- CSV persistence extended additively; old `.statistics.csv` files load fine (name-matched columns).

## Phase 3 — per-lineage data
- Exact open-addressing hash map on the GPU keyed by `lineageId` (default 2^18 slots, insert via `atomicCAS`, linear probing; overflow flag shown as a warning in the GUI). Compaction writes active lineages into a compact array; only that array is copied to the host.
- Persistent per-lineage accumulator map (`createdCreatures`, `totalMutations`) with occasional garbage collection: when more than half the slots are used, live entries are migrated into a shadow buffer and the buffers are flipped (per open question 6).
- Host side: `LineageHistory` + `LineageHistoryService` (downsampling merges samples by lineage-id union: momentary values averaged, accumulated values maximized), exposed through the facade next to the existing statistics accessors. No persistence of the lineage history in this iteration ("Entire history" covers the session).
- `EvolutionDashboardWindow`: dummy data replaced. Live mode uses a `TimelineLiveStatistics`-style buffer, "Entire history"/"Last X steps" use the histories. Header cards (Entities, Sum/External energy, Lineages, Creatures) are fed from real data; "Avg size" metric dropped (NumMetrics 9 → 8).

## Tests
- `LineageHistoryServiceTests` (EngineInterfaceTests): merge/downsampling, cadence, time regression, compression.
- `EvolutionStatisticsTests` (EngineTests, GPU): global counts, genome nodes/mutation-rate means, accumulated mutation counters incl. per-lineage values. The suite is linked last because it consumes GPU RNG state; linking it mid-list shifted the mutation sequences of later suites and pushed the (pre-existing) borderline heap usage of `MetaMutationTests.metaMutation_addNodeRatesActuallyChange` over the limit.
- Full runs: EngineInterfaceTests 170/170, PersisterTests 64/64, NetworkTests 4/4, EngineTests 3080/3080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)