### PR TITLE
fix: delete corrupted autosave on load failure to prevent crash loops

### DIFF
--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -2,6 +2,8 @@
 
 #include <thread>
 
+#include <filesystem>
+
 #include <glad/glad.h>
 
 #include <imgui.h>
@@ -164,6 +166,11 @@ void MainLoopController::processLoadingScreen()
         }
         if (requestedSimState.value() == PersisterRequestState::Error) {
             GenericMessageDialog::get().information("Error", "The default simulation file could not be read.\nAn empty simulation will be created.");
+
+            try {
+                std::filesystem::remove_all(Const::AutosavePath);
+            } catch (...) {
+            }
 
             DeserializedSimulation deserializedSim;
             deserializedSim.auxiliaryData.worldSize.x = 1000;


### PR DESCRIPTION
## Summary

When the autosave file contains a simulation too large for the available GPU memory, the program crashes on every subsequent startup in an unrecoverable loop. This fix deletes the corrupted autosave files on load failure so the program can start fresh.

### Changes

- Delete autosave directory (`resources/autosave/`) when loading the default simulation fails
- Wrapped in try-catch to avoid secondary failures from filesystem operations

> **Note**: Generated by opencode (agent tool) with model deepseek-v4-flash-free. Reviewed by a human.