### PR TITLE
Replace evolution statistics with dedicated OverallStatisticsEntry

### DIFF
--- a/source/EngineImpl/EngineWorker.cpp
+++ b/source/EngineImpl/EngineWorker.cpp
@@ -119,6 +119,11 @@ RawLineageStatistics EngineWorker::getRawLineageStatistics() const
     return _simulationCudaFacade->getRawLineageStatistics();
 }
 
+OverallStatisticsEntry EngineWorker::getOverallStatistics() const
+{
+    return _simulationCudaFacade->getOverallStatistics();
+}
+
 LineageHistory const& EngineWorker::getLineageHistory() const
 {
     return _simulationCudaFacade->getLineageHistory();

--- a/source/EngineImpl/EngineWorker.h
+++ b/source/EngineImpl/EngineWorker.h
@@ -16,6 +16,7 @@
 #include <EngineInterface/GeometryBuffers.h>
 #include <EngineInterface/LineageHistory.h>
 #include <EngineInterface/LineageStatistics.h>
+#include <EngineInterface/OverallStatistics.h>
 #include <EngineInterface/PreviewDesc.h>
 #include <EngineInterface/SelectionShallowData.h>
 #include <EngineInterface/SettingsForSimulation.h>
@@ -61,6 +62,7 @@ public:
     StatisticsHistory const& getStatisticsHistory() const;
     void setStatisticsHistory(StatisticsHistoryData const& data);
     RawLineageStatistics getRawLineageStatistics() const;
+    OverallStatisticsEntry getOverallStatistics() const;
     LineageHistory const& getLineageHistory() const;
 
     void addAndSelectSimulationData(Desc&& dataToUpdate);

--- a/source/EngineImpl/SimulationCudaFacade.cu
+++ b/source/EngineImpl/SimulationCudaFacade.cu
@@ -458,11 +458,13 @@ void _SimulationCudaFacade::updateTimestepStatistics()
     StatisticsKernelsService::get().updateStatistics(_settings.cudaSettings, getSimulationDataPtrCopy(), *_cudaSimulationStatistics);
     syncAndCheck();
 
+    OverallStatisticsEntry overallStatistics;
     {
         std::lock_guard lock(_mutexForStatistics);
         _statisticsData = _cudaSimulationStatistics->getStatistics();
+        overallStatistics = _overallStatisticsData.value_or(OverallStatisticsEntry());
     }
-    StatisticsService::get().addDataPoint(_statisticsHistory, _statisticsData->timeline, getCurrentTimestep());
+    StatisticsService::get().addDataPoint(_statisticsHistory, _statisticsData->timeline, overallStatistics, getCurrentTimestep());
 }
 
 void _SimulationCudaFacade::updateEvolutionStatistics()
@@ -471,9 +473,11 @@ void _SimulationCudaFacade::updateEvolutionStatistics()
     syncAndCheck();
 
     auto lineageStatistics = _cudaSimulationStatistics->getLineageStatistics();
+    auto overallStatistics = _cudaSimulationStatistics->getOverallStatistics();
     {
         std::lock_guard lock(_mutexForStatistics);
         _lineageStatisticsData = lineageStatistics;
+        _overallStatisticsData = overallStatistics;
     }
     _lineageHistoryService.addSample(_lineageHistory, lineageStatistics, getCurrentTimestep());
 }
@@ -490,6 +494,16 @@ RawLineageStatistics _SimulationCudaFacade::getRawLineageStatistics()
         return *_lineageStatisticsData;
     } else {
         return RawLineageStatistics();
+    }
+}
+
+OverallStatisticsEntry _SimulationCudaFacade::getOverallStatistics()
+{
+    std::lock_guard lock(_mutexForStatistics);
+    if (_overallStatisticsData) {
+        return *_overallStatisticsData;
+    } else {
+        return OverallStatisticsEntry();
     }
 }
 

--- a/source/EngineImpl/SimulationCudaFacade.cuh
+++ b/source/EngineImpl/SimulationCudaFacade.cuh
@@ -16,6 +16,7 @@
 #include <EngineInterface/LineageHistory.h>
 #include <EngineInterface/LineageHistoryService.h>
 #include <EngineInterface/LineageStatistics.h>
+#include <EngineInterface/OverallStatistics.h>
 #include <EngineInterface/SelectionShallowData.h>
 #include <EngineInterface/SettingsForSimulation.h>
 #include <EngineInterface/ShallowUpdateSelectionData.h>
@@ -91,6 +92,7 @@ public:
     StatisticsHistory const& getStatisticsHistory() const;
     void setStatisticsHistory(StatisticsHistoryData const& data);
     RawLineageStatistics getRawLineageStatistics();
+    OverallStatisticsEntry getOverallStatistics();
     LineageHistory const& getLineageHistory() const;
 
     void resetTimeIntervalStatistics();
@@ -165,6 +167,7 @@ private:
     std::optional<StatisticsRawData> _statisticsData;
     StatisticsHistory _statisticsHistory;
     std::optional<RawLineageStatistics> _lineageStatisticsData;
+    std::optional<OverallStatisticsEntry> _overallStatisticsData;
     LineageHistory _lineageHistory;
     LineageHistoryService _lineageHistoryService;
     std::shared_ptr<SimulationStatistics> _cudaSimulationStatistics;

--- a/source/EngineImpl/SimulationFacadeImpl.cpp
+++ b/source/EngineImpl/SimulationFacadeImpl.cpp
@@ -340,6 +340,11 @@ RawLineageStatistics _SimulationFacadeImpl::getRawLineageStatistics() const
     return _worker.getRawLineageStatistics();
 }
 
+OverallStatisticsEntry _SimulationFacadeImpl::getOverallStatistics() const
+{
+    return _worker.getOverallStatistics();
+}
+
 LineageHistory const& _SimulationFacadeImpl::getLineageHistory() const
 {
     return _worker.getLineageHistory();

--- a/source/EngineImpl/SimulationFacadeImpl.h
+++ b/source/EngineImpl/SimulationFacadeImpl.h
@@ -92,6 +92,7 @@ public:
     StatisticsHistory const& getStatisticsHistory() const override;
     void setStatisticsHistory(StatisticsHistoryData const& data) override;
     RawLineageStatistics getRawLineageStatistics() const override;
+    OverallStatisticsEntry getOverallStatistics() const override;
     LineageHistory const& getLineageHistory() const override;
 
     std::optional<int> getTpsRestriction() const override;

--- a/source/EngineImpl/StatisticsService.cu
+++ b/source/EngineImpl/StatisticsService.cu
@@ -10,7 +10,11 @@ namespace
     auto constexpr MaxSamples = 1000;
 }
 
-void StatisticsService::addDataPoint(StatisticsHistory& history, TimelineStatistics const& newTimelineStatistics, uint64_t timestep)
+void StatisticsService::addDataPoint(
+    StatisticsHistory& history,
+    TimelineStatistics const& newTimelineStatistics,
+    OverallStatisticsEntry const& overallStatistics,
+    uint64_t timestep)
 {
     std::lock_guard lock(history.getMutex());
     auto& historyData = history.getDataRef();
@@ -28,7 +32,8 @@ void StatisticsService::addDataPoint(StatisticsHistory& history, TimelineStatist
                 result.time = toDouble(timestep);
                 return result;
             } else {
-                return StatisticsConverterService::get().convert(newTimelineStatistics, timestep, toDouble(timestep), _lastTimelineStatistics, _lastTimestep);
+                return StatisticsConverterService::get().convert(
+                    newTimelineStatistics, overallStatistics, timestep, toDouble(timestep), _lastTimelineStatistics, _lastTimestep);
             }
         }();
 

--- a/source/EngineImpl/StatisticsService.cuh
+++ b/source/EngineImpl/StatisticsService.cuh
@@ -2,6 +2,7 @@
 
 #include <Base/Singleton.h>
 
+#include <EngineInterface/OverallStatistics.h>
 #include <EngineInterface/StatisticsHistory.h>
 
 #include <EngineKernels/Definitions.cuh>
@@ -11,7 +12,11 @@ class StatisticsService
     MAKE_SINGLETON(StatisticsService);
 
 public:
-    void addDataPoint(StatisticsHistory& history, TimelineStatistics const& newTimelineStatistics, uint64_t timestep);
+    void addDataPoint(
+        StatisticsHistory& history,
+        TimelineStatistics const& newTimelineStatistics,
+        OverallStatisticsEntry const& overallStatistics,
+        uint64_t timestep);
     void resetTime(StatisticsHistory& history, uint64_t timestep);
     void rewriteHistory(StatisticsHistory& history, StatisticsHistoryData const& newHistoryData, uint64_t timestep);
 

--- a/source/EngineInterface/CMakeLists.txt
+++ b/source/EngineInterface/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(EngineInterface
     NeuralNetWeight.h
     NumberGenerator.cpp
     NumberGenerator.h
+    OverallStatistics.h
     ParametersEditService.cpp
     ParametersEditService.h
     ParametersFilter.h

--- a/source/EngineInterface/OverallStatistics.h
+++ b/source/EngineInterface/OverallStatistics.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+struct OverallStatisticsEntry
+{
+    uint32_t numCreatures = 0;
+    uint32_t numGenomes = 0;
+    float sumCreatureCells = 0;
+    float sumCreatureGenerations = 0;
+    float sumGenomeNodes = 0;
+    float sumMutationRates = 0;
+    float sumCreatureEnergy = 0;
+    float sumAccumulatedMutations = 0;
+    uint32_t numSolidObjects = 0;
+    uint32_t numFluidObjects = 0;
+    uint32_t numCellObjects = 0;
+    uint32_t numActiveLineages = 0;
+    uint32_t lineageMapOverflow = 0;
+    uint32_t numCreatedCreatures = 0;  // Accumulated, never reset
+    float totalMutations = 0;          // Accumulated, never reset
+};

--- a/source/EngineInterface/SimulationFacade.h
+++ b/source/EngineInterface/SimulationFacade.h
@@ -6,6 +6,7 @@
 #include "GeometryBuffers.h"
 #include "LineageHistory.h"
 #include "LineageStatistics.h"
+#include "OverallStatistics.h"
 #include "PreviewDesc.h"
 #include "SelectionShallowData.h"
 #include "SettingsForSimulation.h"
@@ -109,6 +110,7 @@ public:
     virtual StatisticsHistory const& getStatisticsHistory() const = 0;
     virtual void setStatisticsHistory(StatisticsHistoryData const& data) = 0;
     virtual RawLineageStatistics getRawLineageStatistics() const = 0;
+    virtual OverallStatisticsEntry getOverallStatistics() const = 0;
     virtual LineageHistory const& getLineageHistory() const = 0;
 
     //********************

--- a/source/EngineInterface/StatisticsConverterService.cpp
+++ b/source/EngineInterface/StatisticsConverterService.cpp
@@ -79,6 +79,7 @@ namespace
 
 DataPointCollection StatisticsConverterService::convert(
     TimelineStatistics const& data,
+    OverallStatisticsEntry const& overallStatistics,
     uint64_t timestep,
     double time,
     std::optional<TimelineStatistics> const& lastData,
@@ -100,19 +101,19 @@ DataPointCollection StatisticsConverterService::convert(
     result.averageNumCells = getDataPointByAveraging(data.timestep.numObjects, data.timestep.numSelfReplicators);
     result.totalEnergy = getDataPointBySummation(data.timestep.totalEnergy);
 
-    auto const& evolution = data.timestep.evolution;
-    result.numCreatures = toDouble(evolution.numCreatures);
-    result.averageCreatureCells = evolution.numCreatures > 0 ? toDouble(evolution.sumCreatureCells) / evolution.numCreatures : 0.0;
-    result.averageGeneration = evolution.numCreatures > 0 ? toDouble(evolution.sumCreatureGenerations) / evolution.numCreatures : 0.0;
-    result.averageGenomeNodes = evolution.numGenomes > 0 ? toDouble(evolution.sumGenomeNodes) / evolution.numGenomes : 0.0;
-    result.averageMutationRate = evolution.numGenomes > 0 ? toDouble(evolution.sumMutationRates) / evolution.numGenomes : 0.0;
-    result.creatureEnergy = toDouble(evolution.sumCreatureEnergy);
-    result.numLineages = toDouble(evolution.numActiveLineages);
-    result.numSolidObjects = toDouble(evolution.numSolidObjects);
-    result.numFluidObjects = toDouble(evolution.numFluidObjects);
-    result.numCellObjects = toDouble(evolution.numCellObjects);
-    result.accumCreatedCreatures = toDouble(data.accumulated.numCreatedCreatures);
-    result.accumMutations = data.accumulated.totalMutations;
+    auto const& overall = overallStatistics;
+    result.numCreatures = toDouble(overall.numCreatures);
+    result.averageCreatureCells = overall.numCreatures > 0 ? toDouble(overall.sumCreatureCells) / overall.numCreatures : 0.0;
+    result.averageGeneration = overall.numCreatures > 0 ? toDouble(overall.sumCreatureGenerations) / overall.numCreatures : 0.0;
+    result.averageGenomeNodes = overall.numGenomes > 0 ? toDouble(overall.sumGenomeNodes) / overall.numGenomes : 0.0;
+    result.averageMutationRate = overall.numGenomes > 0 ? toDouble(overall.sumMutationRates) / overall.numGenomes : 0.0;
+    result.creatureEnergy = toDouble(overall.sumCreatureEnergy);
+    result.numLineages = toDouble(overall.numActiveLineages);
+    result.numSolidObjects = toDouble(overall.numSolidObjects);
+    result.numFluidObjects = toDouble(overall.numFluidObjects);
+    result.numCellObjects = toDouble(overall.numCellObjects);
+    result.accumCreatedCreatures = toDouble(overall.numCreatedCreatures);
+    result.accumMutations = toDouble(overall.totalMutations);
 
     auto deltaTimesteps = lastTimestep ? toDouble(timestep) - toDouble(*lastTimestep) : 1.0;
     if (deltaTimesteps < NEAR_ZERO) {

--- a/source/EngineInterface/StatisticsConverterService.h
+++ b/source/EngineInterface/StatisticsConverterService.h
@@ -3,6 +3,7 @@
 #include <Base/Singleton.h>
 
 #include <EngineInterface/DataPointCollection.h>
+#include <EngineInterface/OverallStatistics.h>
 
 class StatisticsConverterService
 {
@@ -11,6 +12,7 @@ class StatisticsConverterService
 public:
     DataPointCollection convert(
         TimelineStatistics const& newData,
+        OverallStatisticsEntry const& overallStatistics,
         uint64_t timestep,
         double time,
         std::optional<TimelineStatistics> const& lastData,

--- a/source/EngineInterface/StatisticsRawData.h
+++ b/source/EngineInterface/StatisticsRawData.h
@@ -3,23 +3,6 @@
 #include <EngineInterface/Colors.h>
 #include <EngineInterface/EngineConstants.h>
 
-struct EvolutionStatistics
-{
-    int numCreatures = 0;
-    float sumCreatureCells = 0;
-    float sumCreatureGenerations = 0;
-    float sumAccumulatedMutations = 0;
-    int numGenomes = 0;
-    float sumGenomeNodes = 0;
-    float sumMutationRates = 0;  // Sum over genomes of the per-genome mean of all mutation probabilities
-    float sumCreatureEnergy = 0;
-    int numSolidObjects = 0;
-    int numFluidObjects = 0;
-    int numCellObjects = 0;
-    int numActiveLineages = 0;
-    int lineageMapOverflow = 0;
-};
-
 struct TimestepStatistics
 {
     ColorVector<int> numObjects = {};
@@ -29,7 +12,6 @@ struct TimestepStatistics
     ColorVector<int> numFreeCells = {};
     ColorVector<int> numEnergyParticles = {};
     ColorVector<float> totalEnergy = {};
-    EvolutionStatistics evolution;
 };
 
 struct AccumulatedStatistics
@@ -49,8 +31,6 @@ struct AccumulatedStatistics
     ColorVector<uint64_t> numReconnectorCreated = {};
     ColorVector<uint64_t> numReconnectorRemoved = {};
     ColorVector<uint64_t> numDetonations = {};
-    uint64_t numCreatedCreatures = 0;
-    double totalMutations = 0;
 };
 
 struct TimelineStatistics

--- a/source/EngineKernels/SimulationStatistics.cuh
+++ b/source/EngineKernels/SimulationStatistics.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <EngineInterface/LineageStatistics.h>
+#include <EngineInterface/OverallStatistics.h>
 #include <EngineInterface/StatisticsRawData.h>
 
 #include "Base.cuh"
@@ -16,13 +17,14 @@ public:
     {
         _lineageMapCapacity = lineageMapCapacity;
         CudaMemoryManager::getInstance().acquireMemory<StatisticsRawData>(1, _data);
-        CudaMemoryManager::getInstance().acquireMemory<MutantStatistics>(MutantToColorCountMapSize, _mutantToMutantStatisticsMap);
+        CudaMemoryManager::getInstance().acquireMemory<OverallStatisticsEntry>(1, _overallStatisticsEntry);
         CudaMemoryManager::getInstance().acquireMemory<LineageMapSlot>(_lineageMapCapacity, _lineageMap);
         CudaMemoryManager::getInstance().acquireMemory<LineageStatisticsEntry>(_lineageMapCapacity, _lineageCompactData);
         CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorMapSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[0]);
         CudaMemoryManager::getInstance().acquireMemory<LineageAccumulatorMapSlot>(_lineageMapCapacity, _lineageAccumulatorMaps[1]);
         CudaMemoryManager::getInstance().acquireMemory<LineageMapControl>(1, _lineageMapControl);
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_data, 0, sizeof(StatisticsRawData)));
+        CHECK_FOR_DEVICE_ERRORS(cudaMemset(_overallStatisticsEntry, 0, sizeof(OverallStatisticsEntry)));
         CHECK_FOR_DEVICE_ERRORS(cudaMemset(_lineageMapControl, 0, sizeof(LineageMapControl)));
 
         // Values must start at zero; the lineageId key column (first member) is set to LineageIdEmpty
@@ -37,7 +39,7 @@ public:
     __host__ void free()
     {
         CudaMemoryManager::getInstance().freeMemory(_data);
-        CudaMemoryManager::getInstance().freeMemory(_mutantToMutantStatisticsMap);
+        CudaMemoryManager::getInstance().freeMemory(_overallStatisticsEntry);
         CudaMemoryManager::getInstance().freeMemory(_lineageMap);
         CudaMemoryManager::getInstance().freeMemory(_lineageCompactData);
         CudaMemoryManager::getInstance().freeMemory(_lineageAccumulatorMaps[0]);
@@ -49,6 +51,13 @@ public:
     {
         StatisticsRawData result;
         CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(&result, _data, sizeof(StatisticsRawData), cudaMemcpyDeviceToHost));
+        return result;
+    }
+
+    __host__ OverallStatisticsEntry getOverallStatistics()
+    {
+        OverallStatisticsEntry result;
+        CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(&result, _overallStatisticsEntry, sizeof(OverallStatisticsEntry), cudaMemcpyDeviceToHost));
         return result;
     }
 
@@ -74,17 +83,7 @@ public:
     __inline__ __device__ void resetTimestepData()
     {
         if (threadIdx.x == 0 && blockIdx.x == 0) {
-            // Evolution statistics are collected at deterministic timesteps (separate kernel sequence)
-            // and must survive the wall-clock-throttled timestep statistics updates.
-            auto evolution = _data->timeline.timestep.evolution;
             _data->timeline.timestep = TimestepStatistics();
-            _data->timeline.timestep.evolution = evolution;
-        }
-        auto partition = calcSystemThreadPartition(MutantToColorCountMapSize);
-        for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
-            _mutantToMutantStatisticsMap[index].count = 0;
-            _mutantToMutantStatisticsMap[index].numObjects = 0;
-            _mutantToMutantStatisticsMap[index].color = 0;
         }
     }
 
@@ -111,12 +110,6 @@ public:
         }
         return result;
     }
-    __inline__ __device__ void incMutant(int color, uint32_t lineageId, float numCells)
-    {
-        atomicAdd(&_mutantToMutantStatisticsMap[lineageId % MutantToColorCountMapSize].count, 1);
-        atomicMax(&_mutantToMutantStatisticsMap[lineageId % MutantToColorCountMapSize].color, color);
-        atomicAdd(&_mutantToMutantStatisticsMap[lineageId % MutantToColorCountMapSize].numObjects, numCells);
-    }
     __inline__ __device__ void halveNumConnections()
     {
         for (int i = 0; i < MAX_COLORS; ++i) {
@@ -125,26 +118,43 @@ public:
     }
 
     //evolution statistics (timestep)
-    __inline__ __device__ void resetEvolutionStatistics() { _data->timeline.timestep.evolution = EvolutionStatistics(); }
-    __inline__ __device__ void incNumSolidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numSolidObjects, 1); }
-    __inline__ __device__ void incNumFluidObjects() { atomicAdd(&_data->timeline.timestep.evolution.numFluidObjects, 1); }
-    __inline__ __device__ void incNumCellObjects() { atomicAdd(&_data->timeline.timestep.evolution.numCellObjects, 1); }
+    __inline__ __device__ void resetEvolutionStatistics()
+    {
+        // numCreatedCreatures and totalMutations are accumulated, never reset here
+        auto& overall = *_overallStatisticsEntry;
+        overall.numCreatures = 0;
+        overall.numGenomes = 0;
+        overall.sumCreatureCells = 0;
+        overall.sumCreatureGenerations = 0;
+        overall.sumGenomeNodes = 0;
+        overall.sumMutationRates = 0;
+        overall.sumCreatureEnergy = 0;
+        overall.sumAccumulatedMutations = 0;
+        overall.numSolidObjects = 0;
+        overall.numFluidObjects = 0;
+        overall.numCellObjects = 0;
+        overall.numActiveLineages = 0;
+        overall.lineageMapOverflow = 0;
+    }
+    __inline__ __device__ void incNumSolidObjects() { atomicAdd(&_overallStatisticsEntry->numSolidObjects, 1u); }
+    __inline__ __device__ void incNumFluidObjects() { atomicAdd(&_overallStatisticsEntry->numFluidObjects, 1u); }
+    __inline__ __device__ void incNumCellObjects() { atomicAdd(&_overallStatisticsEntry->numCellObjects, 1u); }
     __inline__ __device__ void addCreatureStatistics(uint32_t numCells, uint32_t generation, float accumulatedMutations)
     {
-        auto& evolution = _data->timeline.timestep.evolution;
-        atomicAdd(&evolution.numCreatures, 1);
-        atomicAdd(&evolution.sumCreatureCells, toFloat(numCells));
-        atomicAdd(&evolution.sumCreatureGenerations, toFloat(generation));
-        atomicAdd(&evolution.sumAccumulatedMutations, accumulatedMutations);
+        auto& overall = *_overallStatisticsEntry;
+        atomicAdd(&overall.numCreatures, 1u);
+        atomicAdd(&overall.sumCreatureCells, toFloat(numCells));
+        atomicAdd(&overall.sumCreatureGenerations, toFloat(generation));
+        atomicAdd(&overall.sumAccumulatedMutations, accumulatedMutations);
     }
     __inline__ __device__ void addGenomeStatistics(float numNodes, float meanMutationRate)
     {
-        auto& evolution = _data->timeline.timestep.evolution;
-        atomicAdd(&evolution.numGenomes, 1);
-        atomicAdd(&evolution.sumGenomeNodes, numNodes);
-        atomicAdd(&evolution.sumMutationRates, meanMutationRate);
+        auto& overall = *_overallStatisticsEntry;
+        atomicAdd(&overall.numGenomes, 1u);
+        atomicAdd(&overall.sumGenomeNodes, numNodes);
+        atomicAdd(&overall.sumMutationRates, meanMutationRate);
     }
-    __inline__ __device__ void addCreatureEnergy(float value) { atomicAdd(&_data->timeline.timestep.evolution.sumCreatureEnergy, value); }
+    __inline__ __device__ void addCreatureEnergy(float value) { atomicAdd(&_overallStatisticsEntry->sumCreatureEnergy, value); }
 
     //lineage statistics
     __inline__ __device__ int getLineageMapCapacity() const { return _lineageMapCapacity; }
@@ -174,7 +184,7 @@ public:
             }
             index = (index + 1) & mask;
         }
-        _data->timeline.timestep.evolution.lineageMapOverflow = 1;
+        _overallStatisticsEntry->lineageMapOverflow = 1;
         return -1;
     }
     __inline__ __device__ int findLineageSlot(uint32_t lineageId) const
@@ -239,10 +249,7 @@ public:
             entry.totalMutations = accumulatorSlot.totalMutations;
         }
     }
-    __inline__ __device__ void finalizeLineageStatistics()
-    {
-        _data->timeline.timestep.evolution.numActiveLineages = toInt(_lineageMapControl->numCompactEntries);
-    }
+    __inline__ __device__ void finalizeLineageStatistics() { _overallStatisticsEntry->numActiveLineages = _lineageMapControl->numCompactEntries; }
 
     //lineage accumulator map (persistent, garbage-collected occasionally)
     __inline__ __device__ void resetInactiveAccumulatorSlot(int index)
@@ -307,7 +314,7 @@ public:
 
     __inline__ __device__ void incCreatedCreature(uint32_t lineageId)
     {
-        alienAtomicAdd64(&_data->timeline.accumulated.numCreatedCreatures, uint64_t(1));
+        atomicAdd(&_overallStatisticsEntry->numCreatedCreatures, 1u);
         auto slotIndex = findOrInsertAccumulatorSlot(lineageId);
         if (slotIndex >= 0) {
             atomicAdd(&getActiveAccumulatorMap()[slotIndex].numCreatedCreatures, 1u);
@@ -315,7 +322,7 @@ public:
     }
     __inline__ __device__ void addMutations(uint32_t lineageId, float value)
     {
-        atomicAdd(&_data->timeline.accumulated.totalMutations, toDouble(value));
+        atomicAdd(&_overallStatisticsEntry->totalMutations, value);
         auto slotIndex = findOrInsertAccumulatorSlot(lineageId);
         if (slotIndex >= 0) {
             atomicAdd(&getActiveAccumulatorMap()[slotIndex].totalMutations, value);
@@ -412,6 +419,7 @@ private:
     }
 
     StatisticsRawData* _data;
+    OverallStatisticsEntry* _overallStatisticsEntry;
     int _lineageMapCapacity;
 
     LineageMapSlot* _lineageMap;
@@ -419,14 +427,4 @@ private:
 
     LineageMapControl* _lineageMapControl;
     LineageStatisticsEntry* _lineageCompactData;
-
-    //for diversity calculation
-    static auto constexpr MutantToColorCountMapSize = 1 << 20;
-    struct MutantStatistics
-    {
-        uint32_t color;
-        uint32_t count;
-        float numObjects;
-    };
-    MutantStatistics* _mutantToMutantStatisticsMap;
 };

--- a/source/EngineKernels/StatisticsKernels.cu
+++ b/source/EngineKernels/StatisticsKernels.cu
@@ -20,7 +20,6 @@ __global__ void cudaUpdateTimestepStatistics_substep2(SimulationData data, Simul
             }
             //if (object->typeData.cell.cellType == CellType_Constructor && GenomeDecoder::containsSelfReplication(object->typeData.cell.cellTypeData.constructor)) {
             //    statistics.incNumReplicator(object->color);
-            //    statistics.incMutant(object->color, object->lineageId, object->numObjects);
             //    auto numNodes = GenomeDecoder::getNumNodesRecursively(object->typeData.cell.cellTypeData.constructor.genome, object->typeData.cell.cellTypeData.constructor.genomeSize, true, true);
             //    statistics.addNumGenomeNodes(object->color, numNodes);
             //    statistics.addNumCells(object->color, object->numObjects);

--- a/source/EngineTests/EvolutionStatisticsTests.cpp
+++ b/source/EngineTests/EvolutionStatisticsTests.cpp
@@ -2,7 +2,6 @@
 
 #include <EngineInterface/Desc.h>
 #include <EngineInterface/SimulationFacade.h>
-#include <EngineInterface/StatisticsRawData.h>
 
 #include "MutationTestsBase.h"
 
@@ -18,18 +17,17 @@ TEST_F(EvolutionStatisticsTests, basicCounts)
 
     _simulationFacade->setSimulationData(data);
 
-    auto statistics = _simulationFacade->getStatisticsRawData();
-    auto const& evolution = statistics.timeline.timestep.evolution;
-    EXPECT_EQ(2, evolution.numCreatures);
-    EXPECT_EQ(2, evolution.numGenomes);
-    EXPECT_EQ(2, evolution.numActiveLineages);
-    EXPECT_EQ(3, evolution.numCellObjects);
-    EXPECT_EQ(0, evolution.numSolidObjects);
-    EXPECT_EQ(0, evolution.numFluidObjects);
-    EXPECT_EQ(0, evolution.lineageMapOverflow);
-    EXPECT_FLOAT_EQ(3.0f, evolution.sumCreatureCells);
-    EXPECT_FLOAT_EQ(8.0f, evolution.sumCreatureGenerations);
-    EXPECT_GT(evolution.sumCreatureEnergy, 0.0f);
+    auto overall = _simulationFacade->getOverallStatistics();
+    EXPECT_EQ(2u, overall.numCreatures);
+    EXPECT_EQ(2u, overall.numGenomes);
+    EXPECT_EQ(2u, overall.numActiveLineages);
+    EXPECT_EQ(3u, overall.numCellObjects);
+    EXPECT_EQ(0u, overall.numSolidObjects);
+    EXPECT_EQ(0u, overall.numFluidObjects);
+    EXPECT_EQ(0u, overall.lineageMapOverflow);
+    EXPECT_FLOAT_EQ(3.0f, overall.sumCreatureCells);
+    EXPECT_FLOAT_EQ(8.0f, overall.sumCreatureGenerations);
+    EXPECT_GT(overall.sumCreatureEnergy, 0.0f);
 
     auto lineageStatistics = _simulationFacade->getRawLineageStatistics();
     ASSERT_EQ(2, lineageStatistics.entries.size());
@@ -69,11 +67,10 @@ TEST_F(EvolutionStatisticsTests, genomeNodesAndMutationRates)
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc().lineageId(42), genome);
     _simulationFacade->setSimulationData(data);
 
-    auto statistics = _simulationFacade->getStatisticsRawData();
-    auto const& evolution = statistics.timeline.timestep.evolution;
-    EXPECT_EQ(1, evolution.numGenomes);
-    EXPECT_FLOAT_EQ(toFloat(numNodes), evolution.sumGenomeNodes);
-    EXPECT_FLOAT_EQ(0.01f, evolution.sumMutationRates);  //mean over 21 probability values: 0.21 / 21
+    auto overall = _simulationFacade->getOverallStatistics();
+    EXPECT_EQ(1u, overall.numGenomes);
+    EXPECT_FLOAT_EQ(toFloat(numNodes), overall.sumGenomeNodes);
+    EXPECT_FLOAT_EQ(0.01f, overall.sumMutationRates);  //mean over 21 probability values: 0.21 / 21
 }
 
 TEST_F(EvolutionStatisticsTests, accumulatedMutations)
@@ -94,9 +91,9 @@ TEST_F(EvolutionStatisticsTests, accumulatedMutations)
     }
     _simulationFacade->calcTimesteps(1);
 
-    auto statistics = _simulationFacade->getStatisticsRawData();
-    EXPECT_GT(statistics.timeline.timestep.evolution.sumAccumulatedMutations, 0.0f);
-    EXPECT_GT(statistics.timeline.accumulated.totalMutations, 0.0);
+    auto overall = _simulationFacade->getOverallStatistics();
+    EXPECT_GT(overall.sumAccumulatedMutations, 0.0f);
+    EXPECT_GT(overall.totalMutations, 0.0f);
 
     auto lineageStatistics = _simulationFacade->getRawLineageStatistics();
     ASSERT_EQ(1, lineageStatistics.entries.size());

--- a/source/Gui/EvolutionDashboardWindow.cpp
+++ b/source/Gui/EvolutionDashboardWindow.cpp
@@ -239,8 +239,9 @@ void EvolutionDashboardWindow::processBackground()
     _timeSinceSimStart += toDouble(duration) / 1000;
 
     auto rawStatistics = _SimulationFacade::get()->getStatisticsRawData();
-    _timelineLiveStatistics.update(rawStatistics.timeline, _SimulationFacade::get()->getCurrentTimestep());
-    _lineageMapOverflow = rawStatistics.timeline.timestep.evolution.lineageMapOverflow != 0;
+    auto overallStatistics = _SimulationFacade::get()->getOverallStatistics();
+    _timelineLiveStatistics.update(rawStatistics.timeline, overallStatistics, _SimulationFacade::get()->getCurrentTimestep());
+    _lineageMapOverflow = overallStatistics.lineageMapOverflow != 0;
 
     auto rawLineageStatistics = _SimulationFacade::get()->getRawLineageStatistics();
     LineageSample sample;
@@ -814,11 +815,9 @@ void EvolutionDashboardWindow::processTimelinePlot(int metricIndex, bool showTim
             auto const& series = lineage->series.at(metricIndex);
             ImPlot::PushStyleColor(ImPlotCol_Line, (ImU32)color);
             ImPlot::PlotLine("##line", lineage->timePoints.data(), series.data(), count);
-            if (_plotScale == PlotScale_Linear) {
-                ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.15f * ImGui::GetStyle().Alpha);
-                ImPlot::PlotShaded("##shaded", lineage->timePoints.data(), series.data(), count);
-                ImPlot::PopStyleVar();
-            }
+            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.5f * ImGui::GetStyle().Alpha);
+            ImPlot::PlotShaded("##shaded", lineage->timePoints.data(), series.data(), count);
+            ImPlot::PopStyleVar();
             ImPlot::PopStyleColor();
             if (ImGui::GetStyle().Alpha == 1.0f) {
                 ImPlot::Annotation(

--- a/source/Gui/StatisticsWindow.cpp
+++ b/source/Gui/StatisticsWindow.cpp
@@ -535,8 +535,9 @@ void StatisticsWindow::processBackground()
     if (!_lastTimepoint || duration > LiveStatisticsDeltaTime) {
         _lastTimepoint = timepoint;
         auto rawStatistics = _SimulationFacade::get()->getStatisticsRawData();
+        auto overallStatistics = _SimulationFacade::get()->getOverallStatistics();
         _histogramLiveStatistics.update(rawStatistics.histogram);
-        _timelineLiveStatistics.update(rawStatistics.timeline, _SimulationFacade::get()->getCurrentTimestep());
+        _timelineLiveStatistics.update(rawStatistics.timeline, overallStatistics, _SimulationFacade::get()->getCurrentTimestep());
         _tableLiveStatistics.update(rawStatistics.timeline);
     }
 }

--- a/source/Gui/TimelineLiveStatistics.cpp
+++ b/source/Gui/TimelineLiveStatistics.cpp
@@ -14,7 +14,7 @@ std::vector<DataPointCollection> const& TimelineLiveStatistics::getDataPointColl
     return _dataPointCollectionHistory;
 }
 
-void TimelineLiveStatistics::update(TimelineStatistics const& data, uint64_t timestep)
+void TimelineLiveStatistics::update(TimelineStatistics const& data, OverallStatisticsEntry const& overallStatistics, uint64_t timestep)
 {
     truncate();
 
@@ -24,7 +24,7 @@ void TimelineLiveStatistics::update(TimelineStatistics const& data, uint64_t tim
 
     _timeSinceSimStart += toDouble(duration) / 1000;
 
-    auto newDataPoint = StatisticsConverterService::get().convert(data, timestep, _timeSinceSimStart, _lastData, _lastTimestep);
+    auto newDataPoint = StatisticsConverterService::get().convert(data, overallStatistics, timestep, _timeSinceSimStart, _lastData, _lastTimestep);
     _dataPointCollectionHistory.emplace_back(newDataPoint);
     _lastData = data;
     _lastTimestep = timestep;

--- a/source/Gui/TimelineLiveStatistics.h
+++ b/source/Gui/TimelineLiveStatistics.h
@@ -6,6 +6,7 @@
 
 #include <EngineInterface/Colors.h>
 #include <EngineInterface/DataPointCollection.h>
+#include <EngineInterface/OverallStatistics.h>
 #include <EngineInterface/StatisticsRawData.h>
 
 class TimelineLiveStatistics
@@ -14,7 +15,7 @@ public:
     static auto constexpr MaxLiveHistory = 240.0f;  //in seconds
 
     std::vector<DataPointCollection> const& getDataPointCollectionHistory() const;
-    void update(TimelineStatistics const& statistics, uint64_t timestep);
+    void update(TimelineStatistics const& statistics, OverallStatisticsEntry const& overallStatistics, uint64_t timestep);
 
 private:
     void truncate();


### PR DESCRIPTION
## Summary
- Replace `EvolutionStatistics` (embedded in `StatisticsRawData`) and the accumulated `numCreatedCreatures`/`totalMutations` fields with a new `OverallStatisticsEntry` struct, analogous to `LineageStatisticsEntry` but without a lineage id. It lives in its own device buffer on `SimulationStatistics`, fetched via `getOverallStatistics()`, and is plumbed through `SimulationCudaFacade` → `EngineWorker` → `SimulationFacade` → GUI.
- Remove the unused `MutantStatistics`/`MutantToColorCountMapSize` diversity-tracking map and its consumer code (only a dead, commented-out call site referenced it).
- `EvolutionDashboardWindow::processTimelinePlot` now always renders the filled area under the curve (previously only for linear scale, with a different alpha), matching `StatisticsWindow`'s style.

## Test plan
- [x] `build-windows-ninja.bat` Release build, 271/271 targets, no warnings
- [x] `EngineTests.exe` full suite: 3080 passed, 3 skipped / 2 disabled (all pre-existing, unrelated to this change)
- [x] `EngineInterfaceTests.exe`, `PersisterTests.exe`: all pass