### PR TITLE
Keep void-node constructor in homogeneous gene during validation

### DIFF
--- a/source/EngineInterface/DescValidationService.cpp
+++ b/source/EngineInterface/DescValidationService.cpp
@@ -284,8 +284,10 @@ void DescValidationService::validateAndCorrect(GenomeDesc& genome)
                 }
             }
 
-            // Validate optional constructor field (void cells cannot have a constructor)
-            if (nodeType == CellType_Void) {
+            // Validate optional constructor field. A void node normally cannot have a constructor, but in a homogeneous gene the
+            // effective cell type is taken from the first node, so a void node is actually expressed as that type and keeps its
+            // constructor (see MutationProcessor::applyMutations and ConstructorProcessor::createConstructionData).
+            if (nodeType == CellType_Void && !gene._homogeneousCellType) {
                 node._constructor = std::nullopt;
             } else if (node._constructor.has_value()) {
                 auto& constructor = node._constructor.value();

--- a/source/EngineInterfaceTests/DescValidationServiceTests.cpp
+++ b/source/EngineInterfaceTests/DescValidationServiceTests.cpp
@@ -29,6 +29,23 @@ TEST_F(DescValidationServiceTests, genome_removesConstructorFromVoidCell)
     EXPECT_FALSE(genome._genes.at(0)._nodes.at(1)._constructor.has_value());
 }
 
+TEST_F(DescValidationServiceTests, genome_keepsConstructorOnVoidCellInHomogeneousGene)
+{
+    // In a homogeneous gene the effective cell type comes from the first node, so a void node is expressed as that type
+    // and legitimately keeps its constructor (matching ConstructorProcessor and MutationProcessor).
+    auto genome = GenomeDesc().genes({
+        GeneDesc().homogeneousCellType(true).nodes({
+            NodeDesc(),
+            NodeDesc().cellType(VoidGenomeDesc()).constructor(ConstructorGenomeDesc().geneIndex(0).separation(true)),
+            NodeDesc(),
+        }),
+    });
+
+    _descValidationService.validateAndCorrect(genome);
+
+    EXPECT_TRUE(genome._genes.at(0)._nodes.at(1)._constructor.has_value());
+}
+
 TEST_F(DescValidationServiceTests, genome_keepsConstructorOnNonVoidCell)
 {
     auto genome = GenomeDesc().genes({


### PR DESCRIPTION
## Problem

In the genome editor, genes reachable only through a homogeneous gene's void nodes were shown as **unreachable** (e.g. the whole graph collapsing to just gene 0 + gene 4), even though the engine keeps and builds them.

Root cause: the editor runs `DescValidationService::validateAndCorrect` when a genome is set (`GenomeTabWidget`), and that function stripped the constructor from **every** void node:

```cpp
if (nodeType == CellType_Void) {
    node._constructor = std::nullopt;
}
```

But in a homogeneous gene the effective cell type is taken from the first node, so a void node is actually expressed as that type and legitimately keeps its constructor — exactly as `ConstructorProcessor::createConstructionData` (uses `result.node->constructor`) and `MutationProcessor::applyMutations` (`MutationProcessor.cuh:823` only clears `constructorAvailable` when `!homogeneousCellType`) do. So the display dropped live references the engine relies on.

## Reproduction (References.sim, one timestep)

| Genome | reachable genes | gene 4 refs |
|---|---|---|
| Engine (raw) | 12 | `[0,5]` |
| After `validateAndCorrect` (before fix) | **2** | `[]` |
| After `validateAndCorrect` (after fix) | 12 | `[0,5]` |

The `reachable=2` case exactly matches the reported "only gene 0 and gene 4 reachable" symptom.

## Fix

Strip the constructor from a void node only in **non-homogeneous** genes, mirroring the engine.

## Tests

- New regression test `genome_keepsConstructorOnVoidCellInHomogeneousGene`.
- Existing `genome_removesConstructorFromVoidCell` (non-homogeneous) still passes.
- All 171 EngineInterfaceTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)