### PR TITLE
Normalize code comment style

### DIFF
--- a/source/Base/GlobalSettings.cpp
+++ b/source/Base/GlobalSettings.cpp
@@ -199,7 +199,7 @@ namespace
                 stream.close();
             }
         } catch (...) {
-            //do nothing
+            // Do nothing
         }
     }
 }
@@ -343,7 +343,7 @@ namespace
 
 void GlobalSettings::loadImGuiSettings(std::string const& defaultSettings)
 {
-    ImGui::GetIO().IniFilename = nullptr;  //no imgui.ini file; the state is persisted here instead
+    ImGui::GetIO().IniFilename = nullptr;  // No imgui.ini file; the state is persisted here instead
     auto settings = getValue(ImGuiSettingsKey, defaultSettings);
     if (!settings.empty()) {
         ImGui::LoadIniSettingsFromMemory(settings.c_str(), settings.size());
@@ -355,7 +355,7 @@ void GlobalSettings::saveImGuiSettingsIfDirty()
     auto& io = ImGui::GetIO();
     if (io.WantSaveIniSettings) {
         saveImGuiSettings();
-        io.WantSaveIniSettings = false;  //IniFilename is null, so we must clear the flag ourselves
+        io.WantSaveIniSettings = false;  // IniFilename is null, so we must clear the flag ourselves
     }
 }
 
@@ -383,7 +383,7 @@ GlobalSettings::GlobalSettings()
         ss << data;
         boost::property_tree::read_json(ss, _impl->_tree);
     } catch (...) {
-        //do nothing
+        // Do nothing
     }
 #endif
 }

--- a/source/Base/JsonParser.h
+++ b/source/Base/JsonParser.h
@@ -14,7 +14,7 @@ enum class ParserTask
 class JsonParser
 {
 public:
-    //returns true if defaultValue has been applied
+    // Returns true if defaultValue has been applied
     template <typename T>
     static bool encodeDecode(boost::property_tree::ptree& tree, T& value, T const& defaultValue, std::string const& node, ParserTask task);
 

--- a/source/Base/Math.h
+++ b/source/Base/Math.h
@@ -17,7 +17,7 @@ public:
     static float angle(RealVector2D const& a, RealVector2D const& b, RealVector2D const& c);  // Returns the angle ABC in degrees
     static RealVector2D rotateQuarterCounterClockwise(RealVector2D v);
     static RealVector2D unitVectorOfAngle(float angleInDeg);
-    static RealMatrix2D calcRotationMatrix(float angleInDeg);  //rotation is clockwise
+    static RealMatrix2D calcRotationMatrix(float angleInDeg);  // Rotation is clockwise
     static RealVector2D rotateClockwise(RealVector2D const& v, float angle);
     static void normalize(RealVector2D& v);
     static RealVector2D getNormalized(RealVector2D const& v);

--- a/source/Base/StringHelper.h
+++ b/source/Base/StringHelper.h
@@ -15,7 +15,7 @@ public:
     static std::string format(std::chrono::milliseconds duration);
     static std::string format(std::chrono::system_clock::time_point const& timePoint);
     static std::string formatInHex(uint64_t value);
-    static std::string formatInThousands(double value);  //e.g. 12000 -> "12K", 1000000 -> "1,000K"
+    static std::string formatInThousands(double value);  // e.g. 12000 -> "12K", 1000000 -> "1,000K"
 
     static void copy(char* target, int maxSize, std::string const& source);
     static bool compare(char const* target, int maxSize, char const* source);

--- a/source/Cli/Main.cpp
+++ b/source/Cli/Main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
 
         CLI::App app{"Command-line interface for ALIEN v" + Const::ProgramVersion};
 
-        //parse command line arguments
+        // Parse command line arguments
         std::string inputFilename;
         std::string outputFilename;
         std::string statisticsFilename;
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
             KernelProfiler::get().setEnabled(true);
         }
 
-        //read input
+        // Read input
         std::cout << "Reading input" << std::endl;
         if (inputFilename.empty()) {
             std::cout << "No input file given." << std::endl;
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        //run simulation
+        // Run simulation
         auto startTimepoint = std::chrono::steady_clock::now();
 
         auto simulationFacade = std::make_shared<_SimulationFacadeImpl>();
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
         }
 
 
-        //write output simulation file
+        // Write output simulation file
         std::cout << "Writing output" << std::endl;
         simData.auxiliaryData.timestep = static_cast<uint32_t>(simulationFacade->getCurrentTimestep());
         simData.mainData = simulationFacade->getSimulationData();

--- a/source/EngineImpl/EditKernelsService.cu
+++ b/source/EngineImpl/EditKernelsService.cu
@@ -42,7 +42,7 @@ void EditKernelsService::shallowUpdateSelectedObjects(CudaSettings const& gpuSet
 {
     bool reconnectionRequired = !updateData.considerClusters && (updateData.posDeltaX != 0 || updateData.posDeltaY != 0 || updateData.angleDelta != 0);
 
-    //disconnect selection in case of reconnection
+    // Disconnect selection in case of reconnection
     if (reconnectionRequired) {
         int counter = 10;
         do {
@@ -54,7 +54,7 @@ void EditKernelsService::shallowUpdateSelectedObjects(CudaSettings const& gpuSet
             KERNEL_CALL(cudaProcessDeleteConnectionChanges, data);
             KERNEL_CALL(cudaProcessAddConnectionChanges, data);
             cudaDeviceSynchronize();
-        } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  //due to locking not all affecting connections may be removed at first => repeat
+        } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  // Due to locking not all affecting connections may be removed at first => repeat
     }
 
     if (updateData.posDeltaX != 0 || updateData.posDeltaY != 0 || updateData.velX != 0 || updateData.velY != 0) {
@@ -80,7 +80,7 @@ void EditKernelsService::shallowUpdateSelectedObjects(CudaSettings const& gpuSet
         KERNEL_CALL(cudaUpdateAngleAndAngularVelForSelection, updateData, data, copyToHost(_cudaCenter));
     }
 
-    //connect selection in case of reconnection
+    // Connect selection in case of reconnection
     if (reconnectionRequired) {
         cudaDeviceSynchronize();
 
@@ -99,7 +99,7 @@ void EditKernelsService::shallowUpdateSelectedObjects(CudaSettings const& gpuSet
             KERNEL_CALL(cudaCleanupMaps, data);
             cudaDeviceSynchronize();
 
-        } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  //due to locking not all necessary connections may be established at first => repeat
+        } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  // Due to locking not all necessary connections may be established at first => repeat
 
         SelectionKernelsService::get().updateSelection(gpuSettings, data);
     }
@@ -161,7 +161,7 @@ void EditKernelsService::reconnect(CudaSettings const& gpuSettings, SimulationDa
         KERNEL_CALL(cudaProcessDeleteConnectionChanges, data);
         KERNEL_CALL(cudaProcessAddConnectionChanges, data);
         cudaDeviceSynchronize();
-    } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  //due to locking not all affecting connections may be removed at first => repeat
+    } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  // Due to locking not all affecting connections may be removed at first => repeat
 
     cudaDeviceSynchronize();
 
@@ -180,7 +180,7 @@ void EditKernelsService::reconnect(CudaSettings const& gpuSettings, SimulationDa
         KERNEL_CALL(cudaCleanupMaps, data);
         cudaDeviceSynchronize();
 
-    } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  //due to locking not all necessary connections may be established at first => repeat
+    } while (1 == copyToHost(_cudaUpdateResult) && --counter > 0);  // Due to locking not all necessary connections may be established at first => repeat
 
     SelectionKernelsService::get().updateSelection(gpuSettings, data);
 }

--- a/source/EngineImpl/EngineWorker.h
+++ b/source/EngineImpl/EngineWorker.h
@@ -74,7 +74,7 @@ public:
     void calcTimesteps(uint64_t timesteps);
     void applyCataclysm(int power);
 
-    void beginShutdown();  //caller should wait for termination of thread
+    void beginShutdown();  // Caller should wait for termination of thread
     void endShutdown();
 
     int getTpsRestriction() const;
@@ -147,7 +147,7 @@ private:
     // Sync
     std::atomic<bool> _syncSimulationWithRendering{false};
     std::atomic<int> _syncSimulationWithRenderingRatio{2};
-    std::atomic<int> _accessState{0};  //0 = worker thread has access, 1 = require access from other thread, 2 = access granted to other thread
+    std::atomic<int> _accessState{0};  // 0 = worker thread has access, 1 = require access from other thread, 2 = access granted to other thread
     std::atomic<bool> _isSimulationRunning{false};
     std::atomic<bool> _isPreviewRunning{false};
     std::atomic<bool> _isShutdown{false};
@@ -168,7 +168,7 @@ private:
     std::vector<ApplyForceJob> _applyForceJobs;
 
     // Time step measurements
-    std::atomic<int> _tpsRestriction{0};  //0 = no restriction
+    std::atomic<int> _tpsRestriction{0};  // 0 = no restriction
     std::atomic<float> _tps;
     int _timestepsSinceMeasurement = 0;
     std::optional<std::chrono::steady_clock::time_point> _measureTimepoint;

--- a/source/EngineImpl/GarbageCollectorKernelsService.cuh
+++ b/source/EngineImpl/GarbageCollectorKernelsService.cuh
@@ -27,6 +27,6 @@ public:
 private:
     GarbageCollectorKernelsService() = default;
 
-    //gpu memory
+    // GPU memory
     bool* _cudaBool = nullptr;
 };

--- a/source/EngineImpl/SimulationCudaFacade.cu
+++ b/source/EngineImpl/SimulationCudaFacade.cu
@@ -671,7 +671,7 @@ void _SimulationCudaFacade::initCuda()
         throw std::runtime_error("CUDA device could not be initialized.");
     }
 
-    cudaGetLastError();  //reset error code
+    cudaGetLastError();  // Reset error code
     CudaContextState::get().reset();
 
     log(Priority::Important, "device " + std::to_string(_gpuInfo.deviceNumber) + " selected");
@@ -800,7 +800,7 @@ void _SimulationCudaFacade::calcTimestepsInternal(uint64_t timesteps, bool force
         }
         syncAndCheck();
 
-        //make check after every 10th call
+        // Make check after every 10th call
         if (++counter % 10 == 0) {
             counter = 0;
             resizeArraysIfNecessary();

--- a/source/EngineImpl/SimulationCudaFacade.cuh
+++ b/source/EngineImpl/SimulationCudaFacade.cuh
@@ -26,7 +26,7 @@
 #include <vector_types.h>
 
 #if !defined(USE_HIP)
-struct cudaGraphicsResource;  // on HIP, hipGraphicsResource is declared by the HIP runtime
+struct cudaGraphicsResource;  // On HIP, hipGraphicsResource is declared by the HIP runtime
 #endif
 
 class _SimulationCudaFacade

--- a/source/EngineImpl/SimulationFacadeImpl.h
+++ b/source/EngineImpl/SimulationFacadeImpl.h
@@ -105,7 +105,7 @@ public:
     uint64_t getCurrentTimestepForPreview() override;
     void setCurrentTimestepForPreview(uint64_t timestep) override;
 
-    // for tests only
+    // For tests only
     void testOnly_mutate(uint64_t objectId) override;
     void testOnly_removeUnusedGenes(uint64_t objectId) override;
     void testOnly_createConnection(uint64_t objectId1, uint64_t objectId2) override;

--- a/source/EngineImpl/SimulationParametersUpdateService.cuh
+++ b/source/EngineImpl/SimulationParametersUpdateService.cuh
@@ -20,5 +20,5 @@ public:
     bool updateSimulationParametersAfterTimestep(
         SettingsForSimulation& settings,
         SimulationData const& simulationData,
-        uint64_t timestep);  //returns true if parameters have been changed
+        uint64_t timestep);  // Returns true if parameters have been changed
 };

--- a/source/EngineInterface/Colors.h
+++ b/source/EngineInterface/Colors.h
@@ -9,7 +9,7 @@
 
 namespace Const
 {
-    uint32_t constexpr CustomizationColor1 = 0x2020FF;  //for device code
+    uint32_t constexpr CustomizationColor1 = 0x2020FF;  // For device code
     uint32_t constexpr CustomizationColor2 = 0xB520FF;
     uint32_t constexpr CustomizationColor3 = 0xFF20B5;
     uint32_t constexpr CustomizationColor4 = 0xFF2020;
@@ -20,7 +20,7 @@ namespace Const
     uint32_t constexpr CustomizationColor9 = 0x20FFB5;
     uint32_t constexpr CustomizationColor10 = 0xFFFFFF;
 
-    uint32_t constexpr DefaultCustomizationColors[MAX_COLORS] = {  //array for convenience
+    uint32_t constexpr DefaultCustomizationColors[MAX_COLORS] = {  // Array for convenience
         CustomizationColor1,
         CustomizationColor2,
         CustomizationColor3,

--- a/source/EngineInterface/Desc.cpp
+++ b/source/EngineInterface/Desc.cpp
@@ -674,7 +674,7 @@ Desc& Desc::addConnection(uint64_t const& objectId1, uint64_t const& objectId2, 
         }
         auto angleDiff2 = connectionIt->_angleFromPrevious;
         if (connectionIt == object._connections.begin()) {
-            connectionIt = object._connections.end();  // connection at index 0 should be an invariant
+            connectionIt = object._connections.end();  // Connection at index 0 should be an invariant
         }
 
         auto factor = (angleDiff2 != 0) ? angleDiff1 / angleDiff2 : 0.5f;

--- a/source/EngineInterface/DescEditService.cpp
+++ b/source/EngineInterface/DescEditService.cpp
@@ -44,7 +44,7 @@ Desc DescEditService::createHex(CreateHexParameters const& parameters) const
     for (int j = 0; j < parameters._layers; ++j) {
         for (int i = -(parameters._layers - 1); i < parameters._layers - j; ++i) {
 
-            //create cell: upper layer
+            // Create cell: upper layer
             result._objects.emplace_back(ObjectDesc()
                                              .stiffness(parameters._stiffness)
                                              .pos({toFloat(i * parameters._cellDistance + j * parameters._cellDistance / 2.0), toFloat(-j * incY)})
@@ -53,7 +53,7 @@ Desc DescEditService::createHex(CreateHexParameters const& parameters) const
                                              .sticky(parameters._sticky)
                                              .type(parameters._objectType));
 
-            //create cell: under layer (except for 0-layer)
+            // Create cell: under layer (except for 0-layer)
             if (j > 0) {
                 result._objects.emplace_back(ObjectDesc()
                                                  .stiffness(parameters._stiffness)
@@ -292,7 +292,7 @@ Desc DescEditService::randomMultiply(
                  toFloat(numberGen.getRandomDouble(parameters._minVelY, parameters._maxVelY))},
                 toFloat(numberGen.getRandomDouble(parameters._minAngularVel, parameters._maxAngularVel)));
 
-            //overlapping check
+            // Overlapping check
             overlapping = false;
             if (parameters._overlappingCheck) {
                 for (auto const& object : copy._objects) {

--- a/source/EngineInterface/GenomeDescEditService.cpp
+++ b/source/EngineInterface/GenomeDescEditService.cpp
@@ -372,7 +372,7 @@ auto GenomeDescEditService::createSeedCollectionForPreview(
             CHECK(cachedPhenotype._creatures.size() <= 2);
             auto seedFirst = false;
             if (cachedPhenotype._creatures.front()._generation == 0) {
-                seedFirst = true;  // first Creature is seed
+                seedFirst = true;  // First Creature is seed
             }
 
             result.description.add(std::move(cachedPhenotype), false);  // Try keeping ids stable for preview selection

--- a/source/EngineInterface/GeometryBuffers.h
+++ b/source/EngineInterface/GeometryBuffers.h
@@ -26,14 +26,14 @@ struct ObjectVertexData
     int state;            // Bit 0..7 = cell type
                           // Bit 8..15 = object type (ObjectType_Solid, ObjectType_FreeCell, ObjectType_Cell)
                           // Bit 16 = is isolated (zero connections)
-    float signalChanges;  // signal changes in [0, 1]
+    float signalChanges;  // Signal changes in [0, 1]
 };
 
 struct FluidParticleVertexData
 {
     float pos[3];    // x, y, z position
     float color[3];  // r, g, b color
-    float glow;      // glow intensity (0.0 = no glow, 1.0 = full glow)
+    float glow;      // Glow intensity (0.0 = no glow, 1.0 = full glow)
 };
 
 struct LocationVertexData
@@ -41,10 +41,10 @@ struct LocationVertexData
     float pos[2];         // x, y position
     float color[3];       // r, g, b color
     int shapeType;        // 0 = circular, 1 = rectangular
-    float dimension1;     // radius for circular, width for rectangular
-    float dimension2;     // unused for circular, height for rectangular
-    float fadeoutRadius;  // fadeout radius for the location
-    float opacity;        // opacity/transparency of the location
+    float dimension1;     // Radius for circular, width for rectangular
+    float dimension2;     // Unused for circular, height for rectangular
+    float fadeoutRadius;  // Fadeout radius for the location
+    float opacity;        // Opacity/transparency of the location
 };
 
 struct SelectedObjectVertexData
@@ -56,8 +56,8 @@ struct ConnectionArrowVertexData
 {
     float pos[2];                     // x, y position
     float color[3];                   // r, g, b color
-    float connectionWeightToObject1;  // connection weight for arrow toward first vertex
-    float connectionWeightToObject2;  // connection weight for arrow toward second vertex
+    float connectionWeightToObject1;  // Connection weight for arrow toward first vertex
+    float connectionWeightToObject2;  // Connection weight for arrow toward second vertex
 };
 
 struct AttackEventVertexData
@@ -69,7 +69,7 @@ struct AttackEventVertexData
 struct DetonationEventVertexData
 {
     float pos[2];  // x, y position
-    float radius;  // circle radius
+    float radius;  // Circle radius
 };
 
 class _GeometryBuffers

--- a/source/EngineInterface/Ids.h
+++ b/source/EngineInterface/Ids.h
@@ -4,6 +4,6 @@
 
 struct Ids
 {
-    uint64_t entityId = 0;  // unified counter for cells, particles, creatures and genomes
+    uint64_t entityId = 0;  // Unified counter for cells, particles, creatures and genomes
     uint32_t lineageId = 0;
 };

--- a/source/EngineInterface/LocationHelper.h
+++ b/source/EngineInterface/LocationHelper.h
@@ -17,7 +17,7 @@ public:
     static void decreaseOrderNumber(SimulationParameters& parameters, int orderNumber);
     static void increaseOrderNumber(SimulationParameters& parameters, int orderNumber);
 
-    // returns new by old location index
+    // Returns new by old location index
     static std::map<int, int> adaptLocationIndices(SimulationParameters& parameters, int fromOrderNumber, int offset);
 
     static std::string generateLayerName(SimulationParameters const& parameters);

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -65,9 +65,9 @@ struct SimulationParameters
 
     // Physics: Motion
     BaseParameter<float> timestepSize = {1.0f};
-    BaseParameter<float> smoothingLength = {0.8f};    // for MotionType_Fluid
-    BaseParameter<float> viscosityStrength = {0.1f};  // for MotionType_Fluid
-    BaseParameter<float> pressureStrength = {0.1f};   // for MotionType_Fluid
+    BaseParameter<float> smoothingLength = {0.8f};    // For MotionType_Fluid
+    BaseParameter<float> viscosityStrength = {0.1f};  // For MotionType_Fluid
+    BaseParameter<float> pressureStrength = {0.1f};   // For MotionType_Fluid
     BaseLayerParameter<float> friction = {.baseValue = 0.001f};
     BaseParameter<float> innerFriction = {0.6f};
     BaseLayerParameter<float> rigidity = {.baseValue = 0.0f};

--- a/source/EngineInterface/StatisticsConverterService.cpp
+++ b/source/EngineInterface/StatisticsConverterService.cpp
@@ -32,8 +32,8 @@ DataPointCollection StatisticsConverterService::convert(
         point.totalMutations = entry.totalMutations;
         result.lineages[entry.lineageId] = point;
 
-        //aggregate the lineage into the overall bucket of its colorBitset; the object counts are not per-color
-        //(they also cover non-creature objects) and are read live from the engine instead
+        // Aggregate the lineage into the overall bucket of its colorBitset; the object counts are not per-color
+        // (they also cover non-creature objects) and are read live from the engine instead
         auto& colorPoint = result.overall[entry.colorBitset];
         colorPoint.numCreatures += point.numCreatures;
         colorPoint.numGenomes += point.numGenomes;

--- a/source/EngineInterfaceTests/GenomeDescEditServiceTests.cpp
+++ b/source/EngineInterfaceTests/GenomeDescEditServiceTests.cpp
@@ -312,7 +312,7 @@ TEST_F(GenomeDescEditServiceTests, createSubGenomesForPreview_onlyBaseAndConstru
     nodes.emplace_back(NodeDesc().constructor(ConstructorGenomeDesc().separation(false)).neuralNetwork(NeuralNetGenomeDesc().weight(2, 3, 0.4f)));
 
     std::set<CellType> addedTypes;
-    addedTypes.insert(CellType_Base);  // first node is Base
+    addedTypes.insert(CellType_Base);  // First node is Base
     for (auto const& param : allParams) {
         if (addedTypes.find(param.cellTypeGenome) == addedTypes.end()) {
             addedTypes.insert(param.cellTypeGenome);

--- a/source/EngineKernels/Array.cuh
+++ b/source/EngineKernels/Array.cuh
@@ -218,7 +218,7 @@ public:
 
     UnmanagedArray() {}
 
-    //methods for host
+    // Methods for host
     __host__ __inline__ void init()
     {
         CudaMemoryManager::getInstance().acquireMemory<int>(1, _numEntries);
@@ -239,7 +239,7 @@ public:
         CudaMemoryManager::getInstance().freeMemory(_data);
     }
 
-    //methods for device
+    // Methods for device
     __device__ __inline__ void setMemory(T* data, int size) const
     {
         *_data = data;
@@ -255,7 +255,7 @@ public:
     __device__ __inline__ T& at(int index) { return (*_data)[index]; }
     __device__ __inline__ T const& at(int index) const { return (*_data)[index]; }
 
-    //returns index if successful, otherwise -1
+    // Returns index if successful, otherwise -1
     __device__ __inline__ int tryAddEntry(T const& entry)
     {
         auto index = atomicAdd(_numEntries, 1);

--- a/source/EngineKernels/AttackerProcessor.cuh
+++ b/source/EngineKernels/AttackerProcessor.cuh
@@ -184,14 +184,14 @@ __device__ __inline__ void AttackerProcessor::processCell(SimulationData& data, 
                         return;
                     }
 
+                    // Calculate energy gain
+                    auto energyToTransfer = calcAttackableEnergy(otherCell) * cudaSimulationParameters.attackerStrength.value * TIMESTEPS_PER_CELL_FUNCTION;
+
                     // Check if target creature is in the list of sensor-detected targets (including color restriction)
                     auto otherCreatureId = otherCell->creature->id;
                     if (!isContainedInSensorMatches(sensorTargetCreatureIds, sensorRestrictToColors, numSensorTargets, otherCreatureId, otherObject->color)) {
                         return;
                     }
-
-                    // Calculate energy gain
-                    auto energyToTransfer = calcAttackableEnergy(otherCell) * cudaSimulationParameters.attackerStrength.value * TIMESTEPS_PER_CELL_FUNCTION;
 
                     auto color = calcMod(object->color, MAX_COLORS);
                     auto otherColor = calcMod(otherObject->color, MAX_COLORS);

--- a/source/EngineKernels/Base.cuh
+++ b/source/EngineKernels/Base.cuh
@@ -232,7 +232,7 @@ public:
     __device__ __inline__ void releaseLock() { atomicExch(&lock, 0); }
 
 private:
-    int lock;  //0 = unlocked, 1 = locked
+    int lock;  // 0 = unlocked, 1 = locked
 };
 
 class SystemDoubleLock

--- a/source/EngineKernels/ClusterProcessor.cuh
+++ b/source/EngineKernels/ClusterProcessor.cuh
@@ -51,7 +51,7 @@ __device__ __inline__ void ClusterProcessor::findClusterIteration(SimulationData
             continue;
         }
 
-        //heuristics to cover connected cells
+        // Heuristics to cover connected cells
         for (int i = 0; i < 30; ++i) {
             bool found = false;
             for (int j = 0; j < currentObject->numConnections; ++j) {
@@ -108,7 +108,7 @@ __device__ __inline__ void ClusterProcessor::accumulateClusterPosAndVel(Simulati
         atomicAdd(&cluster->typeData.solid.clusterVel.x, object->vel.x);
         atomicAdd(&cluster->typeData.solid.clusterVel.y, object->vel.y);
 
-        //topology correction
+        // Topology correction
         auto cellPos = object->pos;
         if ((cluster->typeData.solid.clusterBoundaries & 1) == 1 && cellPos.x > data.worldSize.x * 2 / 3) {
             cellPos.x -= data.worldSize.x;
@@ -138,7 +138,7 @@ __device__ __inline__ void ClusterProcessor::accumulateClusterAngularProp(Simula
         auto clusterVel = cluster->typeData.solid.clusterVel / cluster->typeData.solid.numCellsInCluster;
         auto clusterPos = cluster->typeData.solid.clusterPos / cluster->typeData.solid.numCellsInCluster;
 
-        //topology correction
+        // Topology correction
         auto cellPos = object->pos;
         if ((cluster->typeData.solid.clusterBoundaries & 1) == 1 && cellPos.x > data.worldSize.x * 2 / 3) {
             cellPos.x -= data.worldSize.x;

--- a/source/EngineKernels/DataAccessKernels.cu
+++ b/source/EngineKernels/DataAccessKernels.cu
@@ -233,7 +233,7 @@ namespace
                             nodeTO.cellTypeData.memory.modeData.signalIntegrator.newSignalWeight =
                                 node.cellTypeData.memory.modeData.signalIntegrator.newSignalWeight;
                         }
-                        int targetSize;  // not used
+                        int targetSize;  // Not used
                         copyDataToHeap<int>(
                             sizeof(SignalEntryGenome) * node.cellTypeData.memory.numSignalEntries,
                             reinterpret_cast<uint8_t*>(node.cellTypeData.memory.signalEntries),
@@ -533,7 +533,7 @@ namespace
                 } else if (cell.cellTypeData.memory.mode == MemoryMode_SignalIntegrator) {
                     cellTO.cellTypeData.memory.modeData.signalIntegrator.newSignalWeight = cell.cellTypeData.memory.modeData.signalIntegrator.newSignalWeight;
                 }
-                int targetSize;  // not used
+                int targetSize;  // Not used
                 copyDataToHeap<int>(
                     sizeof(SignalEntry) * cell.cellTypeData.memory.numSignalEntries,
                     reinterpret_cast<uint8_t*>(cell.cellTypeData.memory.signalEntries),
@@ -916,7 +916,7 @@ __global__ void cudaGetCreatureData(InspectedEntityIds ids, SimulationData data,
     }
 }
 
-// tags cell with objectTO index and tags objectTO connections with cell index
+// Tags cell with objectTO index and tags objectTO connections with cell index
 __global__ void cudaGetObjectDataWithoutConnections(int2 rectUpperLeft, int2 rectLowerRight, SimulationData data, TOs to)
 {
     auto const& objects = data.entities.objects;

--- a/source/EngineKernels/EditKernels.cu
+++ b/source/EngineKernels/EditKernels.cu
@@ -19,7 +19,7 @@ __global__ void cudaColorSelectedObjects(SimulationData data, unsigned char colo
     }
 }
 
-//assumes that *changeTO.numObjects == 1
+// Assumes that *changeTO.numObjects == 1
 __global__ void cudaChangeObject(SimulationData data, TOs changeTO)
 {
     auto const partition = calcSystemThreadPartition(data.entities.objects.getNumEntries());
@@ -38,7 +38,7 @@ __global__ void cudaChangeObject(SimulationData data, TOs changeTO)
     }
 }
 
-//assumes that *changeTO.numEnergyParticles == 1
+// Assumes that *changeTO.numEnergyParticles == 1
 __global__ void cudaChangeParticle(SimulationData data, TOs changeTO)
 {
     auto const partition = calcSystemThreadPartition(data.entities.energies.getNumEntries());

--- a/source/EngineKernels/EnergyProcessor.cuh
+++ b/source/EngineKernels/EnergyProcessor.cuh
@@ -230,7 +230,7 @@ __inline__ __device__ void EnergyProcessor::radiate(SimulationData& data, Object
     auto const radiationEnergy = min(cellEnergy, energy);
     auto origEnergy = atomicAdd(&cell->typeData.cell.usableEnergy, -radiationEnergy);
     if (origEnergy < 1.0f) {
-        atomicAdd(&cell->typeData.cell.usableEnergy, radiationEnergy);  //revert
+        atomicAdd(&cell->typeData.cell.usableEnergy, radiationEnergy);  // Revert
         return;
     }
 

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -18,13 +18,13 @@ struct Energy
     float2 vel;
     uint8_t color;
     float energy;
-    Object* lastAbsorbedObject;  //could be invalid
+    Object* lastAbsorbedObject;  // Could be invalid
 
     // Editing data
-    uint8_t selected;  //0 = no, 1 = selected
+    uint8_t selected;  // 0 = no, 1 = selected
 
     // Auxiliary data
-    int locked;  //0 = unlocked, 1 = locked
+    int locked;  // 0 = unlocked, 1 = locked
 
     __device__ __inline__ bool tryLock()
     {
@@ -107,14 +107,14 @@ struct DetectSolid
 struct DetectFreeCell
 {
     float minDensity;
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct DetectCreature
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -178,7 +178,7 @@ struct Generator
 
 struct AttackFreeCell
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct AttackCreature
@@ -296,14 +296,14 @@ struct ReconnectSolid
 
 struct ReconnectFreeCell
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct ReconnectCreature
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -387,7 +387,7 @@ struct Sender
 
 struct Receiver
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -699,8 +699,8 @@ struct __align__(8) LightObject
     float density;
     ObjectType type;
 
-    Object* self;         // self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
-    int nextObjectIndex;  // next object in the same cell, -1 = end of chain
+    Object* self;         // Self before nextObjectIndex keeps the pointer 8-aligned (40 bytes)
+    int nextObjectIndex;  // Next object in the same cell, -1 = end of chain
     uint8_t numConnections;
     uint8_t flags;  // bit0 = isStatic, bit1 = detached, bit2 = sticky
 

--- a/source/EngineKernels/Genome.cuh
+++ b/source/EngineKernels/Genome.cuh
@@ -43,14 +43,14 @@ struct DetectSolidGenome
 struct DetectFreeCellGenome
 {
     float minDensity;
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct DetectCreatureGenome
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -114,7 +114,7 @@ struct GeneratorGenome
 
 struct AttackFreeCellGenome
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct AttackCreatureGenome
@@ -196,14 +196,14 @@ struct ReconnectSolidGenome
 
 struct ReconnectFreeCellGenome
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct ReconnectCreatureGenome
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -282,7 +282,7 @@ struct SenderGenome
 
 struct ReceiverGenome
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 

--- a/source/EngineKernels/GenomeTO.cuh
+++ b/source/EngineKernels/GenomeTO.cuh
@@ -43,14 +43,14 @@ struct DetectSolidGenomeTO
 struct DetectFreeCellGenomeTO
 {
     float minDensity;
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct DetectCreatureGenomeTO
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -114,7 +114,7 @@ struct GeneratorGenomeTO
 
 struct AttackFreeCellGenomeTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct AttackCreatureGenomeTO
@@ -201,14 +201,14 @@ struct ReconnectSolidGenomeTO
 
 struct ReconnectFreeCellGenomeTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct ReconnectCreatureGenomeTO
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -287,7 +287,7 @@ struct SenderGenomeTO
 
 struct ReceiverGenomeTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 

--- a/source/EngineKernels/HashMap.cuh
+++ b/source/EngineKernels/HashMap.cuh
@@ -28,7 +28,7 @@ public:
         __syncthreads();
     }
 
-    //return true if key was present
+    // Return true if key was present
     __device__ __inline__ bool insertOrAssign(Key const& key, Value const& value)
     {
         int index = _hash(key) % _size;
@@ -58,7 +58,7 @@ public:
     __device__ __inline__ bool contains(Key const& key) const
     {
         int index = _hash(key) % _size;
-        for (int i = 0; i < 10; ++i, index = (++index) % _size) {  //workaround: 10 is set to avoid too long runtime
+        for (int i = 0; i < 10; ++i, index = (++index) % _size) {  // Workaround: 10 is set to avoid too long runtime
             auto& entry = _entries[index];
             entry.getLock(2);
             if (0 == entry.getFree()) {
@@ -76,7 +76,7 @@ public:
 
     __device__ __inline__ Value at(Key const& key)
     {
-        for (int i = 0; i < 10; ++i) {  //workaround: 10 is set to avoid too long runtime
+        for (int i = 0; i < 10; ++i) {  // Workaround: 10 is set to avoid too long runtime
             int index = _hash(key) % _size;
             auto& entry = _entries[index];
             entry.getLock(3);
@@ -133,8 +133,8 @@ private:
         }
 
     private:
-        int _free;    //0 = free, 1 = used
-        int _locked;  //0 = unlocked, 1 = locked
+        int _free;    // 0 = free, 1 = used
+        int _locked;  // 0 = unlocked, 1 = locked
         Value _value;
         Key _key;
     };

--- a/source/EngineKernels/Math.cuh
+++ b/source/EngineKernels/Math.cuh
@@ -37,7 +37,7 @@ public:
     __inline__ __device__ static bool isAngleStrictInBetween(float angle1, float angle2, float angleBetweenCandidate);
     __inline__ __device__ static void rotateQuarterClockwise(float2& v);
     __inline__ __device__ static void rotateQuarterCounterClockwise(float2& v);
-    __inline__ __device__ static float angleOfVector(float2 const& v);  //0 DEG corresponds to (0,-1)
+    __inline__ __device__ static float angleOfVector(float2 const& v);  // 0 DEG corresponds to (0,-1)
     __inline__ __device__ static float2 unitVectorOfAngle(float angle);
     __inline__ __device__ static void normalize(float2& vec);
     __inline__ __device__ static float2 getNormalized(float2 vec);

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -93,7 +93,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
     applyMutations_void(data, genome, accumulatedMutations);
     applyMutations_constructor(data, genome, accumulatedMutations);
 
-    // sync since following mutations may change entire genes
+    // Sync since following mutations may change entire genes
     block.sync();
     auto const& nodeRates = genome->mutationRates;
     bool anyNodeMutation = nodeRates.extendGeneMutation.geneProbability > 0 || nodeRates.addNodeMutation.nodeProbability > 0
@@ -107,7 +107,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
         correctGenome(data, genome);
     }
 
-    // sync since the copy-node-section mutation reads whole genes and rebuilds target genes (changing gene->nodes and numNodes)
+    // Sync since the copy-node-section mutation reads whole genes and rebuilds target genes (changing gene->nodes and numNodes)
     block.sync();
     if (nodeRates.copyNodeSectionMutation.geneProbability > 0) {
         applyMutations_copyNodeSection(data, genome, accumulatedMutations);
@@ -115,7 +115,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
         correctGenome(data, genome);
     }
 
-    // sync since the move-node-section mutation reads whole genes and rebuilds them (changing gene->nodes and numNodes)
+    // Sync since the move-node-section mutation reads whole genes and rebuilds them (changing gene->nodes and numNodes)
     block.sync();
     if (nodeRates.moveNodeSectionMutation.geneProbability > 0) {
         applyMutations_moveNodeSection(data, genome, accumulatedMutations);
@@ -123,7 +123,7 @@ __inline__ __device__ void MutationProcessor::applyMutations(SimulationData& dat
         correctGenome(data, genome);
     }
 
-    // sync since the following mutations may add or remove whole genes (changing genome->genes and numGenes)
+    // Sync since the following mutations may add or remove whole genes (changing genome->genes and numGenes)
     block.sync();
     bool anyGeneMutation = nodeRates.duplicateGeneMutation.geneProbability > 0 || nodeRates.deleteGeneMutation.geneProbability > 0;
     if (anyGeneMutation) {
@@ -975,7 +975,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_extendGene(Simulati
         if (gene.numNodes >= MaxNodesPerGene || data.primaryNumberGen.random() >= rate.geneProbability) {
             continue;
         }
-        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes;  // start or end
+        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes;  // Start or end
         insertNode(data, genome, gene, position);
         atomicAdd_block(&accumulatedMutations, 1.0f);
     }
@@ -1016,10 +1016,10 @@ __inline__ __device__ void MutationProcessor::applyMutations_trimGene(Simulation
 
     for (int geneIndex = laneId; geneIndex < genome->numGenes; geneIndex += blockDim.x) {
         auto& gene = genome->genes[geneIndex];
-        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // keep at least one node
+        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // Keep at least one node
             continue;
         }
-        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes - 1;  // start or end
+        auto position = data.primaryNumberGen.random() < 0.5f ? 0 : gene.numNodes - 1;  // Start or end
         removeNode(data, gene, position);
         atomicAdd_block(&accumulatedMutations, 1.0f);
     }
@@ -1040,7 +1040,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_deleteNode(Simulati
         // low so a deletion does not shift nodes that have not been visited yet.
         auto const oldNumNodes = gene.numNodes;
         for (int position = oldNumNodes - 1; position >= 0; --position) {
-            if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.nodeProbability) {  // keep at least one node
+            if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.nodeProbability) {  // Keep at least one node
                 continue;
             }
             removeNode(data, gene, position);
@@ -1126,7 +1126,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_duplicateGene(Simul
     auto block = cg_mutation::this_thread_block();
     auto laneId = block.thread_rank();
     auto const& rate = genome->mutationRates.duplicateGeneMutation;
-    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+    if (rate.geneProbability <= 0) {  // Uniform across the block, so the early return does not desync the cooperative group
         return;
     }
 
@@ -1183,7 +1183,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_duplicateGene(Simul
             for (int nodeIndex = 0; nodeIndex < source.numNodes; ++nodeIndex) {
                 newNodes[nodeIndex] = source.nodes[nodeIndex];
             }
-            newGenes[newIndex] = source;  // shallow copy of the gene-level attributes
+            newGenes[newIndex] = source;  // Shallow copy of the gene-level attributes
             newGenes[newIndex].nodes = newNodes;
             atomicAdd_block(&accumulatedMutations, toFloat(source.numNodes));
         }
@@ -1217,7 +1217,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_deleteGene(Simulati
     auto block = cg_mutation::this_thread_block();
     auto laneId = block.thread_rank();
     auto const& rate = genome->mutationRates.deleteGeneMutation;
-    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+    if (rate.geneProbability <= 0) {  // Uniform across the block, so the early return does not desync the cooperative group
         return;
     }
 
@@ -1308,7 +1308,7 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
 
     __shared__ int numGenes;
     __shared__ int newNumGenes;
-    __shared__ int* newGeneIndices;  // during marking: -1 = unreachable, 1 = reachable but not scanned yet, 2 = scanned
+    __shared__ int* newGeneIndices;  // During marking: -1 = unreachable, 1 = reachable but not scanned yet, 2 = scanned
     __shared__ bool anyGeneScanned;
 
     if (laneId == 0) {
@@ -1394,7 +1394,7 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
             if (geneIndex < numGenes) {
                 targetIndex = newGeneIndices[geneIndex];
                 if (targetIndex == geneIndex) {
-                    targetIndex = -1;  // already in place
+                    targetIndex = -1;  // Already in place
                 } else if (targetIndex >= 0) {
                     movedGene = genome->genes[geneIndex];
                 }
@@ -1423,13 +1423,13 @@ __inline__ __device__ void MutationProcessor::applyMutations_copyNodeSection(Sim
     auto block = cg_mutation::this_thread_block();
     auto laneId = block.thread_rank();
     auto const& rate = genome->mutationRates.copyNodeSectionMutation;
-    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+    if (rate.geneProbability <= 0) {  // Uniform across the block, so the early return does not desync the cooperative group
         return;
     }
 
     __shared__ int numGenes;
     __shared__ int numOps;
-    __shared__ Node** opSourceNodes;  // captured pre-mutation node array of the source gene (never overwritten in place)
+    __shared__ Node** opSourceNodes;  // Captured pre-mutation node array of the source gene (never overwritten in place)
     __shared__ int* opSectionStart;
     __shared__ int* opSectionLength;
     __shared__ int* opTargetGene;
@@ -1532,14 +1532,14 @@ __inline__ __device__ void MutationProcessor::applyMutations_moveNodeSection(Sim
     auto block = cg_mutation::this_thread_block();
     auto laneId = block.thread_rank();
     auto const& rate = genome->mutationRates.moveNodeSectionMutation;
-    if (rate.geneProbability <= 0) {  // uniform across the block, so the early return does not desync the cooperative group
+    if (rate.geneProbability <= 0) {  // Uniform across the block, so the early return does not desync the cooperative group
         return;
     }
 
     __shared__ int numGenes;
     __shared__ int numOps;
     __shared__ int* opSourceGene;
-    __shared__ Node** opSourceNodes;  // captured pre-mutation node array of the source gene (never overwritten in place)
+    __shared__ Node** opSourceNodes;  // Captured pre-mutation node array of the source gene (never overwritten in place)
     __shared__ int* opSectionStart;
     __shared__ int* opSectionLength;
     __shared__ int* opTargetGene;
@@ -1564,7 +1564,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_moveNodeSection(Sim
     // the genome is not modified yet and every gene still has its original node count.
     for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
         auto& gene = genome->genes[geneIndex];
-        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // need >= 2 nodes to keep one behind
+        if (gene.numNodes <= 1 || data.primaryNumberGen.random() >= rate.geneProbability) {  // Need >= 2 nodes to keep one behind
             continue;
         }
         int sectionLength = data.primaryNumberGen.random(gene.numNodes - 2) + 1;           // [1, numNodes - 1]
@@ -1618,7 +1618,7 @@ __inline__ __device__ void MutationProcessor::applyMutations_moveNodeSection(Sim
             if (opSourceGene[op] == geneIndex && opAccepted[op]) {
                 removeStart = opSectionStart[op];
                 removeLength = opSectionLength[op];
-                break;  // at most one op per source gene
+                break;  // At most one op per source gene
             }
         }
 

--- a/source/EngineKernels/NeuronProcessor.cuh
+++ b/source/EngineKernels/NeuronProcessor.cuh
@@ -162,7 +162,7 @@ __inline__ __device__ void NeuronProcessor::processCell(Object* object, bool ini
     }
     block.sync();
 
-    // matrix-vector multiplication (16x16 weights * 16 input vector)
+    // Matrix-vector multiplication (16x16 weights * 16 input vector)
     // Each thread computes one output channel
     if (laneId < NEURONS_PER_CELL) {
         int row = laneId;

--- a/source/EngineKernels/ObjectConnectionProcessor.cuh
+++ b/source/EngineKernels/ObjectConnectionProcessor.cuh
@@ -17,14 +17,14 @@ public:
 
     __inline__ __device__ static void processDeleteObjectOperations(SimulationData& data);
 
-    // angle of object1 is given by desiredRelAngle with respect to the inserted connection and between [0, +360)
+    // Angle of object1 is given by desiredRelAngle with respect to the inserted connection and between [0, +360)
     // angle of object2 will be automatically determined by current geometry
     // if desiredRelAngle=0: angle of object1 will be automatically determined by current geometry
     // if desiredDistance=0: distance will be automatically determined by current geometry
     __inline__ __device__ static bool
     tryAddConnectionWithRelAngle(SimulationData& data, Object* object1, Object* object2, float desiredDistance = 0, float desiredRelAngle = 0);
 
-    // angle of object1 and object2 are given by desiredRelAngle with respect to connections[0] and between [0, +360)
+    // Angle of object1 and object2 are given by desiredRelAngle with respect to connections[0] and between [0, +360)
     __inline__ __device__ static bool
     tryAddConnectionWithAbsAngle(SimulationData& data, Object* object1, Object* object2, float desiredDistance, float desiredAbsAngle1, float desiredAbsAngle2);
 
@@ -55,7 +55,7 @@ private:
     __inline__ __device__ static void lockAndTryAddConnections(SimulationData& data, Object* object1, Object* object2);
     __inline__ __device__ static void markConnectionsForDeletion(Object* object, Object* connectedObject);
 
-    // angle of object1 is given by desiredRelAngle with respect to the inserted connection and between [0, +360)
+    // Angle of object1 is given by desiredRelAngle with respect to the inserted connection and between [0, +360)
     __inline__ __device__ static bool tryAddConnectionWithRelAngle_oneWay(
         SimulationData& data,
         Object* object1,
@@ -64,7 +64,7 @@ private:
         float desiredDistance,
         float desiredRelAngle = 0);
 
-    // angle of object1 is given by desiredRelAngle with respect to connections[0] and between [0, +360)
+    // Angle of object1 is given by desiredRelAngle with respect to connections[0] and between [0, +360)
     __inline__ __device__ static bool tryAddConnectionWithAbsAngle_oneWay(Object* object1, Object* object2, float desiredDistance, float desiredAbsAngle);
 };
 
@@ -368,7 +368,7 @@ __inline__ __device__ bool ObjectConnectionProcessor::tryAddConnectionWithRelAng
     // process general case
     // *****
 
-    // find appropriate index for new connection
+    // Find appropriate index for new connection
     int index = 0;
     float prevAngle = 0;
     float nextAngle = 0;
@@ -405,7 +405,7 @@ __inline__ __device__ bool ObjectConnectionProcessor::tryAddConnectionWithRelAng
 
     // Insert new connection
     if (index == 0) {
-        index = object1->numConnections;  // connection at index 0 should be an invariant
+        index = object1->numConnections;  // Connection at index 0 should be an invariant
     }
     for (int j = object1->numConnections; j > index; --j) {
         object1->connections[j] = object1->connections[j - 1];

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -24,7 +24,7 @@ public:
     __inline__ __device__ static void calcFluidForces_reconnectCells_correctOverlap(SimulationData& data);
     __inline__ __device__ static void calcFluidBoundaryForces(SimulationData& data);
     __inline__ __device__ static void checkForces(SimulationData& data);
-    __inline__ __device__ static void applyForces(SimulationData& data);  //prerequisite: data from calcCollisions_reconnectCells_correctOverlap
+    __inline__ __device__ static void applyForces(SimulationData& data);  // Prerequisite: data from calcCollisions_reconnectCells_correctOverlap
 
     __inline__ __device__ static void calcConnectionForces(SimulationData& data, bool calcAngularForces);
     __inline__ __device__ static void checkConnections(SimulationData& data);
@@ -573,7 +573,7 @@ __inline__ __device__ void ObjectProcessor::verletPositionUpdate(SimulationData&
             object->pos += object->vel * cudaSimulationParameters.timestepSize.value
                 + object->tempValue1.as_float2 * cudaSimulationParameters.timestepSize.value * cudaSimulationParameters.timestepSize.value / 2;
             data.objectMap.correctPosition(object->pos);
-            object->tempValue2.as_float2 = object->tempValue1.as_float2;  // save forces from first step for averaging
+            object->tempValue2.as_float2 = object->tempValue1.as_float2;  // Save forces from first step for averaging
             object->tempValue1.as_float2 = {0, 0};
         }
     }
@@ -695,7 +695,7 @@ __inline__ __device__ void ObjectProcessor::radiation(SimulationData& data)
                 float2 particleVel = object->vel * cudaSimulationParameters.radiationVelocityMultiplier
                     + Math::unitVectorOfAngle(data.primaryNumberGen.random() * 360) * cudaSimulationParameters.radiationVelocityPerturbation;
                 float2 particlePos = object->pos + Math::getNormalized(particleVel) * 1.5f
-                    - particleVel;  // minus particleVel because particle will still be moved in current time step
+                    - particleVel;  // Minus particleVel because particle will still be moved in current time step
                 data.objectMap.correctPosition(particlePos);
 
                 EnergyProcessor::createEnergyParticle(data, particlePos, particleVel, object->color, radiation1 + radiation2);

--- a/source/EngineKernels/ParameterCalculator.cuh
+++ b/source/EngineKernels/ParameterCalculator.cuh
@@ -18,7 +18,7 @@ public:
     __device__ __inline__ static float2
     calcParameter(float2 const& baseValue, float2 (&layerValues)[MAX_LAYERS], bool (&enabled)[MAX_LAYERS], SimulationData const& data, float2 const& worldPos);
 
-    //return -1 for base
+    // Return -1 for base
     template <typename T>
     __device__ __inline__ static int getFirstMatchingLayerOrBase(SimulationData const& data, float2 const& worldPos, BaseLayerParameter<T> const& parameter);
 

--- a/source/EngineKernels/Physics.cuh
+++ b/source/EngineKernels/Physics.cuh
@@ -52,12 +52,12 @@ __device__ __inline__ float2 Physics::calcNormalToCell(Object* cell, float2 outw
     Object* maxCell = nullptr;
     float2 minVector;
     float2 maxVector;
-    float min_h = 0.0;  //h = angular distance from outward vector
+    float min_h = 0.0;  // h = angular distance from outward vector
     float max_h = 0.0;
 
     for (int i = 0; i < cell->numConnections; ++i) {
 
-        //calculate h (angular distance from outward vector)
+        // Calculate h (angular distance from outward vector)
         float2 u = cell->connections[i].object->pos - cell->pos;
         Math::normalize(u);
         float h = Math::dot(outward, u);
@@ -77,17 +77,17 @@ __device__ __inline__ float2 Physics::calcNormalToCell(Object* cell, float2 outw
         }
     }
 
-    //no adjacent cells?
+    // No adjacent cells?
     if (!minCell && !maxCell) {
         return outward;
     }
 
-    //one adjacent cells?
+    // One adjacent cells?
     if (minCell == maxCell) {
         return cell->pos - minCell->pos;
     }
 
-    //calc normal vectors
+    // Calc normal vectors
     float temp = maxVector.x;
     maxVector.x = maxVector.y;
     maxVector.y = -temp;

--- a/source/EngineKernels/SelectionKernels.cu
+++ b/source/EngineKernels/SelectionKernels.cu
@@ -126,7 +126,7 @@ __global__ void cudaRolloutSelectionStep(SimulationData data, int* result)
         if (0 != object->selected) {
             auto currentObject = object;
 
-            //heuristics to cover connected cells
+            // Heuristics to cover connected cells
             for (int i = 0; i < 30; ++i) {
                 bool found = false;
                 for (int j = 0; j < currentObject->numConnections; ++j) {

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -508,8 +508,8 @@ __inline__ __device__ uint16_t SensorProcessor::convertAngleToUint16(float angle
 
 __inline__ __device__ float SensorProcessor::convertUint16ToAngle(uint16_t b)
 {
-    //0 to 32767 => 0 to 179 degree
-    //32768 to 65535 => -179 to 0 degree
+    // 0 to 32767 => 0 to 179 degree
+    // 32768 to 65535 => -179 to 0 degree
     if (b < 32768) {
         return (0.5f + static_cast<float>(b)) * (180.0f / 32768.0f);
     } else {

--- a/source/EngineKernels/SimulationData.cu
+++ b/source/EngineKernels/SimulationData.cu
@@ -21,8 +21,8 @@ void SimulationData::init(int2 const& worldSize_, uint64_t timestep_)
     CHECK_FOR_DEVICE_ERRORS(cudaMemset(externalEnergyInflowPerConstructorByColor, 0, sizeof(float) * MAX_COLORS));
 
     processMemory.init();
-    primaryNumberGen.init(40312357);   //some array size for random numbers (~ 160 MB)
-    secondaryNumberGen.init(1536941);  //some array size for random numbers (~ 6 MB)
+    primaryNumberGen.init(40312357);   // Some array size for random numbers (~ 160 MB)
+    secondaryNumberGen.init(1536941);  // Some array size for random numbers (~ 6 MB)
 
     structuralOperations.init();
     for (int i = 0; i < CellType_Count; ++i) {

--- a/source/EngineKernels/SimulationKernels.cu
+++ b/source/EngineKernels/SimulationKernels.cu
@@ -49,7 +49,7 @@ __global__ void cudaNextTimestep_physics_init(SimulationData data)
 __global__ void cudaNextTimestep_physics_fillMaps(SimulationData data)
 {
     ObjectProcessor::updateMap(data);
-    ObjectProcessor::radiation(data);  //do not use EnergyParticleProcessor in this calcKernel
+    ObjectProcessor::radiation(data);  // Do not use EnergyParticleProcessor in this calcKernel
     ObjectProcessor::clearDensityMap(data);
 }
 

--- a/source/EngineKernels/SimulationKernels.cuh
+++ b/source/EngineKernels/SimulationKernels.cuh
@@ -5,9 +5,9 @@
 __global__ void cudaNextTimestep_prepare(SimulationData data);
 __global__ void cudaNextTimestep_physics_init(SimulationData data);
 __global__ void cudaNextTimestep_physics_fillMaps(SimulationData data);
-__global__ void cudaNextTimestep_physics_calcFluidForces(SimulationData data);  //requires threads/block = (ceilf(smoothingLength * 2) * 2 + 1)^2
+__global__ void cudaNextTimestep_physics_calcFluidForces(SimulationData data);  // Requires threads/block = (ceilf(smoothingLength * 2) * 2 + 1)^2
 __global__ void cudaNextTimestep_physics_calcFluidBoundaryForces(
-    SimulationData data);  //requires threads/block = (ceilf(smoothingLength * 2 * 2) * 2 + 1)^2, fluid uses 2x smoothingLength
+    SimulationData data);  // Requires threads/block = (ceilf(smoothingLength * 2 * 2) * 2 + 1)^2, fluid uses 2x smoothingLength
 __global__ void cudaNextTimestep_physics_applyForces(SimulationData data);
 __global__ void cudaNextTimestep_physics_verletPositionUpdate(SimulationData data);
 __global__ void cudaNextTimestep_physics_calcConnectionForces(SimulationData data, bool considerAngles);

--- a/source/EngineKernels/TOs.cuh
+++ b/source/EngineKernels/TOs.cuh
@@ -83,14 +83,14 @@ struct DetectSolidTO
 struct DetectFreeCellTO
 {
     float minDensity;
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct DetectCreatureTO
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -154,7 +154,7 @@ struct GeneratorTO
 
 struct AttackFreeCellTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct AttackCreatureTO
@@ -267,14 +267,14 @@ struct ReconnectSolidTO
 
 struct ReconnectFreeCellTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
 };
 
 struct ReconnectCreatureTO
 {
     uint32_t minNumCells;       // 0 = no restriction
     uint32_t maxNumCells;       // 0 = no restriction
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 
@@ -358,7 +358,7 @@ struct SenderTO
 
 struct ReceiverTO
 {
-    uint16_t restrictToColors;  // bitset: bit i set = color i allowed, 0x3ff = all colors
+    uint16_t restrictToColors;  // Bitset: bit i set = color i allowed, 0x3ff = all colors
     LineageRestriction restrictToLineage;
 };
 

--- a/source/EngineTests/CellTypeMutationTests.cpp
+++ b/source/EngineTests/CellTypeMutationTests.cpp
@@ -16,9 +16,9 @@ protected:
     {
         auto reset = [](GenomeDesc& genome) {
             for (auto& gene : genome._genes) {
-                gene._homogeneousCellType = false;  // canonicalize: the cell type mutation may also flip this flag
+                gene._homogeneousCellType = false;  // Canonicalize: the cell type mutation may also flip this flag
                 for (auto& node : gene._nodes) {
-                    node._cellType = BaseGenomeDesc{};  // canonicalize so everything except the cell type is compared
+                    node._cellType = BaseGenomeDesc{};  // Canonicalize so everything except the cell type is compared
                 }
             }
         };

--- a/source/EngineTests/CommunicatorTests.cpp
+++ b/source/EngineTests/CommunicatorTests.cpp
@@ -301,8 +301,8 @@ TEST_F(CommunicatorTests, sender_frontAngleFlipsDirection)
     // Rotating the sender's front by 180 degrees flips the facing direction to north, so now a southern receiver
     // (in the opposite half-plane) receives, while a northern receiver is blocked.
     auto data = createSenderCreature(1, {100.0f, 100.0f}, 50.0f, 0, 180.0f);
-    data.add(createReceiverCreature(2, {100.0f, 110.0f}), false);  // south -> should receive
-    data.add(createReceiverCreature(3, {100.0f, 90.0f}), false);   // north -> should be blocked
+    data.add(createReceiverCreature(2, {100.0f, 110.0f}), false);  // South -> should receive
+    data.add(createReceiverCreature(3, {100.0f, 90.0f}), false);   // North -> should be blocked
 
     _simulationFacade->setSimulationData(data);
     _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);
@@ -318,8 +318,8 @@ TEST_F(CommunicatorTests, sender_encodedAngleChangesDirection)
     // With an encoded angle of 0, the facing direction equals the absolute front (east). A western receiver is then
     // in the opposite half-plane and receives, while an eastern receiver is blocked.
     auto data = createSenderCreature(1, {100.0f, 100.0f}, 50.0f, 0, 0.0f, 0.0f);
-    data.add(createReceiverCreature(2, {90.0f, 100.0f}), false);   // west -> should receive
-    data.add(createReceiverCreature(3, {110.0f, 100.0f}), false);  // east -> should be blocked
+    data.add(createReceiverCreature(2, {90.0f, 100.0f}), false);   // West -> should receive
+    data.add(createReceiverCreature(3, {110.0f, 100.0f}), false);  // East -> should be blocked
 
     _simulationFacade->setSimulationData(data);
     _simulationFacade->calcTimesteps(TIMESTEPS_PER_CELL_FUNCTION);

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -42,7 +42,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttribute
     _simulationFacade->testOnly_mutate(1);
     auto const actualGenome = getMutatedGenome();
     auto const& constructor = actualGenome._genes.at(0)._nodes.at(0)._constructor;
-    ASSERT_TRUE(constructor.has_value());  // without constructorToggleProbability the constructor must never be removed
+    ASSERT_TRUE(constructor.has_value());  // Without constructorToggleProbability the constructor must never be removed
     auto const& mutated = constructor.value();
 
     EXPECT_TRUE(mutated._autoTriggerInterval != original._autoTriggerInterval);
@@ -58,7 +58,7 @@ TEST_F(ConstructorMutationTests, constructorMutation_changesConstructorAttribute
 TEST_F(ConstructorMutationTests, constructorMutation_addsConstructorWithDefaultValues)
 {
     auto genome = createTestGenome();
-    genome._genes.at(0)._nodes.at(0)._constructor.reset();  // node without a constructor
+    genome._genes.at(0)._nodes.at(0)._constructor.reset();  // Node without a constructor
     genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
@@ -93,7 +93,7 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 
     _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 1000.0f;
-    _parameters.newLineageThreshold.value = 100.0f;  // keep accumulatedMutationsInLineage from resetting
+    _parameters.newLineageThreshold.value = 100.0f;  // Keep accumulatedMutationsInLineage from resetting
     _simulationFacade->setSimulationParameters(_parameters);
 
     _simulationFacade->setSimulationData(data);
@@ -103,7 +103,7 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
 
     auto actualData = _simulationFacade->getSimulationData();
 
-    ASSERT_EQ(2, actualData.getNumObjects());  // offspring cell was constructed
+    ASSERT_EQ(2, actualData.getNumObjects());  // Offspring cell was constructed
     auto hostCreatureId = actualData.getObjectRef(1).getCellRef()._creatureId;
     EXPECT_GT(actualData.getCreatureRef(hostCreatureId)._accumulatedMutations, 0.0f);
 
@@ -151,17 +151,17 @@ TEST_F(ConstructorMutationTests, constructorMutation_keepOtherAttributesUnchange
 TEST_F(ConstructorMutationTests, constructorMutation_existProbabilityTogglesConstructorPresence)
 {
     auto genome = createTestGenome();
-    genome._genes.at(0)._nodes.at(0)._constructor.reset();  // one node without a constructor
+    genome._genes.at(0)._nodes.at(0)._constructor.reset();  // One node without a constructor
     genome._mutationRates._constructorMutations[0] = ConstructorMutationDesc().nodeProbability(1.0f).constructorToggleProbability(1.0f);
 
     auto data = Desc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
 
     _simulationFacade->setSimulationData(data);
-    _simulationFacade->testOnly_mutate(1);  // a single step flips the presence of every node exactly once
+    _simulationFacade->testOnly_mutate(1);  // A single step flips the presence of every node exactly once
 
     auto actualGenome = getMutatedGenome();
 
     // constructorToggleProbability alone must toggle whether a node has a constructor.
-    EXPECT_TRUE(actualGenome._genes.at(0)._nodes.at(0)._constructor.has_value());   // had none -> gained one
-    EXPECT_FALSE(actualGenome._genes.at(0)._nodes.at(1)._constructor.has_value());  // had one -> lost it
+    EXPECT_TRUE(actualGenome._genes.at(0)._nodes.at(0)._constructor.has_value());   // Had none -> gained one
+    EXPECT_FALSE(actualGenome._genes.at(0)._nodes.at(1)._constructor.has_value());  // Had one -> lost it
 }

--- a/source/EngineTests/DuplicateGeneMutationTests.cpp
+++ b/source/EngineTests/DuplicateGeneMutationTests.cpp
@@ -50,8 +50,8 @@ TEST_F(DuplicateGeneMutationTests, duplicateGeneMutation_duplicatesGeneReference
 
     auto actualGenome = getMutatedGenome();
     ASSERT_EQ(3, actualGenome._genes.size());
-    EXPECT_EQ(genome._genes.at(1)._nodes, actualGenome._genes.at(2)._nodes);  // copy has the same nodes as gene 1
-    EXPECT_EQ(1, countReferencesToGene(actualGenome, 2));                     // exactly one reference moved to the copy
+    EXPECT_EQ(genome._genes.at(1)._nodes, actualGenome._genes.at(2)._nodes);  // Copy has the same nodes as gene 1
+    EXPECT_EQ(1, countReferencesToGene(actualGenome, 2));                     // Exactly one reference moved to the copy
 }
 
 TEST_F(DuplicateGeneMutationTests, duplicateGeneMutation_injectorReferencesCount)

--- a/source/EngineTests/StatisticsTests.cpp
+++ b/source/EngineTests/StatisticsTests.cpp
@@ -39,7 +39,7 @@ TEST_F(StatisticsTests, basicCounts)
     EXPECT_EQ(2u, entry42->sumCreatureCells);
     EXPECT_EQ(3u, entry42->sumCreatureGenerations);
     EXPECT_GT(entry42->sumCreatureEnergy, 0.0);
-    EXPECT_EQ((1u << 2) | (1u << 5), entry42->colorBitset);  //derived from genome node colors, not cell colors
+    EXPECT_EQ((1u << 2) | (1u << 5), entry42->colorBitset);  // Derived from genome node colors, not cell colors
 
     auto const* entry43 = findEntry(43);
     ASSERT_TRUE(entry43 != nullptr);
@@ -67,7 +67,7 @@ TEST_F(StatisticsTests, objectStatistics)
     EXPECT_EQ(1u, entries.objectStatistics.numSolidObjects);
     EXPECT_EQ(1u, entries.objectStatistics.numEnergyParticles);
 
-    //the total energy covers free cells, solids and energy particles, not just the cells belonging to creatures
+    // The total energy covers free cells, solids and energy particles, not just the cells belonging to creatures
     ASSERT_EQ(1, entries.lineageEntries.size());
     auto creatureEnergy = entries.lineageEntries.front().sumCreatureEnergy;
     EXPECT_GT(creatureEnergy, 0.0);
@@ -84,7 +84,7 @@ TEST_F(StatisticsTests, representativeCell)
 
     auto entries = _simulationFacade->getStatisticsEntry();
     ASSERT_EQ(1, entries.lineageEntries.size());
-    EXPECT_EQ(3u, entries.lineageEntries.front().representativeCellId);  //cell of the creature with the highest generation
+    EXPECT_EQ(3u, entries.lineageEntries.front().representativeCellId);  // Cell of the creature with the highest generation
 }
 
 TEST_F(StatisticsTests, genomeNodesAndMutationRates)
@@ -104,7 +104,7 @@ TEST_F(StatisticsTests, genomeNodesAndMutationRates)
     auto const& entry = entries.lineageEntries.front();
     EXPECT_EQ(1u, entry.numGenomes);
     EXPECT_EQ(numNodes, entry.sumGenomeNodes);
-    EXPECT_NEAR(0.01, entry.sumMutationRates, 1e-6);  //mean over 21 probability values: 0.21 / 21
+    EXPECT_NEAR(0.01, entry.sumMutationRates, 1e-6);  // Mean over 21 probability values: 0.21 / 21
 }
 
 TEST_F(StatisticsTests, accumulatedMutations)

--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -154,7 +154,7 @@ bool AlienGui::SliderFloat2(SliderFloat2Parameters const& parameters, float& val
         AlienGui::Text(TextParameters().text(parameters._name.c_str()).highlightedSubString(parameters._highlightedSubString));
     }
 
-    //tooltip
+    // Tooltip
     if (parameters._tooltip) {
         AlienGui::HelpMarker(*parameters._tooltip);
     }
@@ -681,14 +681,14 @@ bool AlienGui::Switcher(SwitcherParameters& parameters, int* value, bool* enable
         ImGui::BeginDisabled();
     }
 
-    //enable button
+    // Enable button
     if (enabled) {
         ImGui::Checkbox("##checkbox", enabled);
         ImGui::BeginDisabled(!(*enabled));
         ImGui::SameLine();
     }
 
-    //color dependent button
+    // Color dependent button
     auto toggleButtonId = ImGui::GetID("expanded");
     auto isExpanded = parameters._colorDependence && _expandedColorControlIds.contains(toggleButtonId);
     if (parameters._colorDependence) {
@@ -1010,7 +1010,7 @@ namespace
             auto startPos = ImGui::GetCursorScreenPos();
             auto height = ImGui::GetFrameHeight();
             ImVec4 frameBgColor = ImGui::GetStyle().Colors[ImGuiCol_FrameBg];
-            frameBgColor.w *= 0.6f;  // make it half-transparent
+            frameBgColor.w *= 0.6f;  // Make it half-transparent
 
             ImDrawList* drawList = ImGui::GetWindowDrawList();
             ImU32 bgCol = ImGui::GetColorU32(frameBgColor);
@@ -2300,7 +2300,7 @@ namespace
                 // Only use formatted separators for large values
                 if (std::abs(value) >= 1000.0f) {
                     // Extract decimal places from format string like "%.3f"
-                    int decimalPlaces = 3;  // default
+                    int decimalPlaces = 3;  // Default
                     auto dotPos = format.find('.');
                     if (dotPos != std::string::npos) {
                         auto fPos = format.find('f', dotPos);
@@ -2315,7 +2315,7 @@ namespace
                 return format;
             }
             // When not maintaining format (e.g., for display in ranges), use formatted output
-            int decimalPlaces = 3;  // default
+            int decimalPlaces = 3;  // Default
             auto dotPos = format.find('.');
             if (dotPos != std::string::npos) {
                 auto fPos = format.find('f', dotPos);
@@ -2356,7 +2356,7 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
         style.GrabMinSize = scale(4.0f);
     }
 
-    //enable button
+    // Enable button
     if (enabled) {
         ImGui::Checkbox("##checkbox", enabled);
         if (!(*enabled)) {
@@ -2369,7 +2369,7 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
         ImGui::SameLine();
     }
 
-    //color dependent button
+    // Color dependent button
     auto toggleButtonId = ImGui::GetID("expanded");
     auto isExpanded = _expandedColorControlIds.contains(toggleButtonId);
     if (parameters._colorDependence) {
@@ -2401,7 +2401,7 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
             ImGui::SetCursorPosX(sliderPosX);
         }
 
-        //color field
+        // Color field
         ImGui::PushID(color);
         auto pinnedButtonWidth = pinned ? scale(PinnedButtonWidth) + ImGui::GetStyle().FramePadding.x : 0.0f;
 
@@ -2413,7 +2413,7 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
         auto sliderOffset = ImGui::GetCursorPosX() - sliderPosX;
         ImGui::SetNextItemWidth(width - sliderOffset - scale(parameters._textWidth) - pinnedButtonWidth);
 
-        //slider
+        // Slider
         T sliderValue;
         T minValue = value[0], maxValue = value[0];
         int sliderValueColor = 0;
@@ -2469,14 +2469,14 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
 
         if (color == 0) {
 
-            //pin button
+            // Pin button
             if (pinned) {
                 ImGui::SameLine();
                 ImGui::SetCursorPosX(ImGui::GetCursorPosX() - ImGui::GetStyle().FramePadding.x);
                 AlienGui::SelectableButton(AlienGui::SelectableButtonParameters().name(ICON_FA_THUMBTACK).width(PinnedButtonWidth), *pinned);
             }
 
-            //revert button
+            // Revert button
             if (parameters._defaultValue) {
                 ImGui::SameLine();
 
@@ -2602,7 +2602,7 @@ void AlienGui::BasicInputColorMatrix(BasicInputColorMatrixParameters<T> const& p
 
         ImGui::SetCursorPos(startPos);
 
-        //color matrix
+        // Color matrix
         if (ImGui::BeginTable(("##" + parameters._name).c_str(), MAX_COLORS + 1, 0, ImVec2(ImGui::GetContentRegionAvail().x - textWidth, 0))) {
             for (int row = 0; row < MAX_COLORS + 1; ++row) {
                 ImGui::PushID(row);
@@ -2650,7 +2650,7 @@ void AlienGui::BasicInputColorMatrix(BasicInputColorMatrixParameters<T> const& p
         ImGui::EndGroup();
     } else {
 
-        //collapsed view
+        // Collapsed view
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - textWidth);
         if constexpr (std::is_same<T, bool>()) {
             static bool test = false;
@@ -2735,7 +2735,7 @@ void AlienGui::BasicInputColorMatrix(BasicInputColorMatrixParameters<T> const& p
     ImGui::PopID();
 }
 
-//RotateStart, RotationCenter, etc. are taken from https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
+// RotateStart, RotationCenter, etc. are taken from https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
 //>>>>>>>>>>
 void AlienGui::RotateStart(ImDrawList* drawList)
 {
@@ -2744,13 +2744,13 @@ void AlienGui::RotateStart(ImDrawList* drawList)
 
 ImVec2 AlienGui::RotationCenter(ImDrawList* drawList)
 {
-    ImVec2 l(FLT_MAX, FLT_MAX), u(-FLT_MAX, -FLT_MAX);  // bounds
+    ImVec2 l(FLT_MAX, FLT_MAX), u(-FLT_MAX, -FLT_MAX);  // Bounds
 
     const auto& buf = drawList->VtxBuffer;
     for (int i = _rotationStartIndex; i < buf.Size; i++)
         l = ImMin(l, buf[i].pos), u = ImMax(u, buf[i].pos);
 
-    return ImVec2((l.x + u.x) / 2, (l.y + u.y) / 2);  // or use _ClipRectStack?
+    return ImVec2((l.x + u.x) / 2, (l.y + u.y) / 2);  // Or use _ClipRectStack?
 }
 
 bool AlienGui::RevertButton(std::string const& id)
@@ -2777,8 +2777,8 @@ void AlienGui::drawTextWithInfoLabel(
         ImVec2 labelSize = ImGui::CalcTextSize(infoLabel->c_str());
         auto const& style = ImGui::GetStyle();
         labelPos.y += scale(1.0f);
-        labelSize.x += style.FramePadding.x * 2;  // padding left+right
-        labelSize.y += style.FramePadding.y * 2;  // padding top+bottom
+        labelSize.x += style.FramePadding.x * 2;  // Padding left+right
+        labelSize.y += style.FramePadding.y * 2;  // Padding top+bottom
         ImDrawList* drawList = ImGui::GetWindowDrawList();
         ImU32 borderColor = ImGui::GetColorU32(ImGuiCol_Border);
         drawList->AddRect(
@@ -2787,7 +2787,7 @@ void AlienGui::drawTextWithInfoLabel(
             borderColor,
             4.0f,
             0,
-            2.0f  // thickness
+            2.0f  // Thickness
         );
         ImGui::SetCursorScreenPos(ImVec2(labelPos.x + style.FramePadding.x, labelPos.y));
         ImGui::TextDisabled("%s", infoLabel->c_str());

--- a/source/Gui/AutosaveWindow.cpp
+++ b/source/Gui/AutosaveWindow.cpp
@@ -25,7 +25,7 @@ namespace
 {
     auto constexpr RightColumnWidth = 200.0f;
     auto constexpr AutosaveSenderId = "Autosave";
-    auto constexpr PeakDetectionInterval = 30;  //in seconds
+    auto constexpr PeakDetectionInterval = 30;  // In seconds
 }
 
 AutosaveWindow::AutosaveWindow()
@@ -166,7 +166,7 @@ void AutosaveWindow::processTable()
                 ImGui::PushID(row);
                 ImGui::TableNextRow(0, scale(23.0f));
 
-                // project name
+                // Project name
                 ImGui::TableNextColumn();
                 if (entry->state == SavepointState_InQueue) {
                     ImGui::PushStyleColor(ImGuiCol_Text, Const::TextDecentColor.Value);
@@ -201,19 +201,19 @@ void AutosaveWindow::processTable()
                     _selectedEntry = selected ? entry : nullptr;
                 }
 
-                // timestamp
+                // Timestamp
                 ImGui::TableNextColumn();
                 if (entry->state == SavepointState_Persisted) {
                     AlienGui::Text(entry->timestamp);
                 }
 
-                // timestep
+                // Timestep
                 ImGui::TableNextColumn();
                 if (entry->state == SavepointState_Persisted) {
                     AlienGui::Text(AlienGui::TextParameters().text(StringHelper::format(entry->timestep)).rightAligned(true));
                 }
 
-                // peak
+                // Peak
                 //ImGui::TableNextColumn();
                 //AlienGui::Text(entry->peak);
 
@@ -436,7 +436,7 @@ void AutosaveWindow::processDeleteNonPersistentSavepoint()
                     SerializerService::get().deleteSimulation(saveResult->getData().filename);
                 }
             } else if (requestState.value() == PersisterRequestState::Error) {
-                // do nothing
+                // Do nothing
             } else {
                 newRequestsToDelete.emplace_back(entry);
             }

--- a/source/Gui/BrowserWindow.cpp
+++ b/source/Gui/BrowserWindow.cpp
@@ -47,7 +47,7 @@
 
 namespace
 {
-    auto constexpr RefreshInterval = 20;  //in minutes
+    auto constexpr RefreshInterval = 20;  // In minutes
 
     auto constexpr UserTableWidth = 300.0f;
     auto constexpr BrowserBottomSpace = 41.0f;
@@ -169,7 +169,7 @@ void BrowserWindow::refreshIntern(bool withRetry)
                 auto userName = NetworkService::get().getLoggedInUserName().value_or("");
                 for (auto const& rawTO : data.resourceTOs) {
                     if (rawTO->resourceType == workspaceId.resourceType) {
-                        //public user items should also be visible in private workspace
+                        // Public user items should also be visible in private workspace
                         if ((workspaceId.workspaceType == WorkspaceType_Private && rawTO->userName == userName
                              && (rawTO->workspaceType == WorkspaceType_Private || rawTO->workspaceType == WorkspaceType_Public))
                             || ((workspaceId.workspaceType == WorkspaceType_Public || workspaceId.workspaceType == WorkspaceType_AlienProject)
@@ -228,7 +228,7 @@ void BrowserWindow::processToolbar()
     std::string resourceTypeString = _currentWorkspace.resourceType == NetworkResourceType_Simulation ? "simulation" : "genome";
     auto isOwnerForSelectedItem = isOwner(_selectedTreeTO);
 
-    //refresh button
+    // Refresh button
     ImGui::BeginDisabled(_refreshProcessor->pendingTasks());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SYNC))) {
         onRefresh();
@@ -236,7 +236,7 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Refresh");
 
-    //login button
+    // Login button
     ImGui::SameLine();
     ImGui::BeginDisabled(NetworkService::get().getLoggedInUserName().has_value());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SIGN_IN_ALT))) {
@@ -245,7 +245,7 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Login or register");
 
-    //logout button
+    // Logout button
     ImGui::SameLine();
     ImGui::BeginDisabled(!NetworkService::get().getLoggedInUserName());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SIGN_OUT_ALT))) {
@@ -255,11 +255,11 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Logout");
 
-    //separator
+    // Separator
     ImGui::SameLine();
     AlienGui::ToolbarSeparator();
 
-    //upload button
+    // Upload button
     ImGui::SameLine();
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_UPLOAD))) {
         std::string prefix = [&] {
@@ -276,7 +276,7 @@ void BrowserWindow::processToolbar()
           "in your private workspace.\nIf you have already selected a folder, your "
         + resourceTypeString + " will be uploaded there.");
 
-    //edit button
+    // Edit button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isOwnerForSelectedItem);
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EDIT))) {
@@ -285,7 +285,7 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Change name or description");
 
-    //replace button
+    // Replace button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isOwnerForSelectedItem || !_selectedTreeTO->isLeaf());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EXCHANGE_ALT))) {
@@ -295,7 +295,7 @@ void BrowserWindow::processToolbar()
     AlienGui::Tooltip(
         "Replace the selected " + resourceTypeString + " with the one that is currently open. The name, description and reactions will be preserved.");
 
-    //move to other workspace button
+    // Move to other workspace button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isOwnerForSelectedItem);
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SHARE_ALT))) {
@@ -304,7 +304,7 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Change visibility: public " ICON_FA_LONG_ARROW_ALT_RIGHT " private and private " ICON_FA_LONG_ARROW_ALT_RIGHT " public");
 
-    //delete button
+    // Delete button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isOwnerForSelectedItem);
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_TRASH))) {
@@ -313,18 +313,18 @@ void BrowserWindow::processToolbar()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Delete selected " + resourceTypeString);
 
-    //separator
+    // Separator
     ImGui::SameLine();
     AlienGui::ToolbarSeparator();
 
-    //expand button
+    // Expand button
     ImGui::SameLine();
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EXPAND_ARROWS_ALT))) {
         onExpandFolders();
     }
     AlienGui::Tooltip("Expand all folders");
 
-    //collapse button
+    // Collapse button
     ImGui::SameLine();
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COMPRESS_ARROWS_ALT))) {
         onCollapseFolders();
@@ -332,11 +332,11 @@ void BrowserWindow::processToolbar()
     AlienGui::Tooltip("Collapse all folders");
 
 #ifdef _WIN32
-    //separator
+    // Separator
     ImGui::SameLine();
     AlienGui::ToolbarSeparator();
 
-    //Discord button
+    // Discord button
     ImGui::SameLine();
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COMMENTS))) {
         openWeblink(Const::DiscordURL);
@@ -390,7 +390,7 @@ void BrowserWindow::processWorkspaceSelectionAndFilter()
         ImGui::TableSetColumnIndex(0);
         auto userName = NetworkService::get().getLoggedInUserName();
         auto privateWorkspaceString = userName.has_value() ? *userName + "'s private workspace" : "Private workspace (need to login)";
-        auto workspaceType_reordered = 2 - _currentWorkspace.workspaceType;  //change the order for display
+        auto workspaceType_reordered = 2 - _currentWorkspace.workspaceType;  // Change the order for display
         if (AlienGui::Switcher(
                 AlienGui::SwitcherParameters()
                     .textWidth(48.0f)
@@ -595,7 +595,7 @@ void BrowserWindow::processSimulationList()
         ImGui::TableHeadersRow();
         ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, Const::TableHeaderColor);
 
-        //create treeTOs if sorting changed
+        // Create treeTOs if sorting changed
         if (auto sortSpecs = ImGui::TableGetSortSpecs()) {
             if (sortSpecs->SpecsDirty) {
                 for (WorkspaceType workspaceType = 0; workspaceType < WorkspaceType_Count; ++workspaceType) {
@@ -610,7 +610,7 @@ void BrowserWindow::processSimulationList()
             }
         }
 
-        //process treeTOs
+        // Process treeTOs
         auto& workspace = _workspaces.at(_currentWorkspace);
         auto scheduleRecreateTreeTOs = false;
 
@@ -701,7 +701,7 @@ void BrowserWindow::processGenomeList()
         ImGui::TableHeadersRow();
         ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, Const::TableHeaderColor);
 
-        //create treeTOs if sorting changed
+        // Create treeTOs if sorting changed
         if (auto sortSpecs = ImGui::TableGetSortSpecs()) {
             if (sortSpecs->SpecsDirty) {
                 for (WorkspaceType workspaceType = 0; workspaceType < WorkspaceType_Count; ++workspaceType) {
@@ -716,7 +716,7 @@ void BrowserWindow::processGenomeList()
             }
         }
 
-        //process treeTOs
+        // Process treeTOs
         auto& workspace = _workspaces.at(_currentWorkspace);
         auto scheduleRecreateTreeTOs = false;
         ImGuiListClipper clipper;
@@ -849,7 +849,7 @@ void BrowserWindow::processReactionList(NetworkResourceTreeTO const& treeTO)
             _emojiPopupTO = treeTO;
         }
 
-        //calc remap which allows to show most frequent like type first
+        // Calc remap which allows to show most frequent like type first
         std::map<int, int> remap;
         std::set<int> processedEmojiTypes;
 
@@ -868,7 +868,7 @@ void BrowserWindow::processReactionList(NetworkResourceTreeTO const& treeTO)
             ++index;
         }
 
-        //show like types with count
+        // Show like types with count
         int counter = 0;
         std::optional<int> toggleEmojiType;
         for (auto const& emojiType : remap | std::views::values) {
@@ -904,7 +904,7 @@ void BrowserWindow::processReactionList(NetworkResourceTreeTO const& treeTO)
                 AlienGui::Tooltip([=, this] { return getUserNamesToEmojiType(leaf.rawTO->id, emojiType); }, false);
             }
 
-            //separator except for last element
+            // Separator except for last element
             if (++counter < leaf.rawTO->numLikesByEmojiType.size()) {
                 ImGui::SetCursorPosX(ImGui::GetCursorPosX() - scale(4.0f));
             }
@@ -1240,14 +1240,14 @@ void BrowserWindow::processPendingRequestIds()
 
 void BrowserWindow::createTreeTOs(Workspace& workspace)
 {
-    //sorting
+    // Sorting
     if (workspace.rawTOs.size() > 1) {
         std::sort(workspace.rawTOs.begin(), workspace.rawTOs.end(), [&](auto const& left, auto const& right) {
             return _NetworkResourceRawTO::compare(left, right, workspace.sortSpecs) < 0;
         });
     }
 
-    //filtering
+    // Filtering
     std::vector<NetworkResourceRawTO> filteredRawTOs;
     for (auto const& rawTO : workspace.rawTOs) {
         if (rawTO->matchWithFilter(_filter)) {
@@ -1255,7 +1255,7 @@ void BrowserWindow::createTreeTOs(Workspace& workspace)
         }
     }
 
-    //create treeTOs
+    // Create treeTOs
     workspace.treeTOs = NetworkResourceService::get().createTreeTOs(filteredRawTOs, workspace.collapsedFolderNames);
     _selectedTreeTO = nullptr;
 }
@@ -1332,7 +1332,7 @@ void BrowserWindow::onMoveResource(NetworkResourceTreeTO const& treeTO)
         createTreeTOs(_workspaces.at(WorkspaceId{_currentWorkspace.resourceType, workspaceType}));
     }
 
-    //apply changes to server
+    // Apply changes to server
     MoveNetworkResourceRequestData requestData;
     for (auto const& rawTO : rawTOs) {
         requestData.entries.emplace_back(rawTO->id, rawTO->workspaceType);
@@ -1347,7 +1347,7 @@ void BrowserWindow::onDeleteResource(NetworkResourceTreeTO const& treeTO)
 
     auto message = treeTO->isLeaf() ? "Do you really want to delete the selected item?" : "Do you really want to delete the selected folder?";
     GenericMessageDialog::get().yesNo("Delete", message, [rawTOs = rawTOs, this]() {
-        //remove resources form workspace
+        // Remove resources form workspace
         for (WorkspaceType workspaceType = 0; workspaceType < WorkspaceType_Count; ++workspaceType) {
             auto& workspace = _workspaces.at(WorkspaceId{_currentWorkspace.resourceType, workspaceType});
             for (auto const& rawTO : rawTOs) {
@@ -1359,7 +1359,7 @@ void BrowserWindow::onDeleteResource(NetworkResourceTreeTO const& treeTO)
             createTreeTOs(workspace);
         }
 
-        //apply changes to server
+        // Apply changes to server
         DeleteNetworkResourceRequestData requestData;
         for (auto const& rawTO : rawTOs) {
             requestData.entries.emplace_back(rawTO->id);
@@ -1374,7 +1374,7 @@ void BrowserWindow::onToggleLike(NetworkResourceTreeTO const& to, int emojiType)
     auto& leaf = to->getLeaf();
     if (NetworkService::get().getLoggedInUserName()) {
 
-        //remove existing like
+        // Remove existing like
         auto findResult = _ownEmojiTypeBySimId.find(leaf.rawTO->id);
         auto onlyRemoveLike = false;
         if (findResult != _ownEmojiTypeBySimId.end()) {
@@ -1383,11 +1383,11 @@ void BrowserWindow::onToggleLike(NetworkResourceTreeTO const& to, int emojiType)
                 leaf.rawTO->numLikesByEmojiType.erase(origEmojiType);
             }
             _ownEmojiTypeBySimId.erase(findResult);
-            _userNamesByEmojiTypeBySimIdCache.erase(std::make_pair(leaf.rawTO->id, origEmojiType));  //invalidate cache entry
-            onlyRemoveLike = origEmojiType == emojiType;                                             //remove like if same like icon has been clicked
+            _userNamesByEmojiTypeBySimIdCache.erase(std::make_pair(leaf.rawTO->id, origEmojiType));  // Invalidate cache entry
+            onlyRemoveLike = origEmojiType == emojiType;                                             // Remove like if same like icon has been clicked
         }
 
-        //create new like
+        // Create new like
         if (!onlyRemoveLike) {
             _ownEmojiTypeBySimId[leaf.rawTO->id] = emojiType;
             if (leaf.rawTO->numLikesByEmojiType.contains(emojiType)) {
@@ -1397,7 +1397,7 @@ void BrowserWindow::onToggleLike(NetworkResourceTreeTO const& to, int emojiType)
             }
         }
 
-        _userNamesByEmojiTypeBySimIdCache.erase(std::make_pair(leaf.rawTO->id, emojiType));  //invalidate cache entry
+        _userNamesByEmojiTypeBySimIdCache.erase(std::make_pair(leaf.rawTO->id, emojiType));  // Invalidate cache entry
 
         _reactionProcessor->executeTask(
             [&](auto const& senderId) {

--- a/source/Gui/BrowserWindow.h
+++ b/source/Gui/BrowserWindow.h
@@ -45,8 +45,8 @@ private:
     struct Workspace
     {
         std::vector<ImGuiTableColumnSortSpecs> sortSpecs;
-        std::vector<NetworkResourceRawTO> rawTOs;    //unfiltered, sorted
-        std::vector<NetworkResourceTreeTO> treeTOs;  //filtered, sorted
+        std::vector<NetworkResourceRawTO> rawTOs;    // Unfiltered, sorted
+        std::vector<NetworkResourceTreeTO> treeTOs;  // Filtered, sorted
         std::set<std::vector<std::string>> collapsedFolderNames;
     };
 
@@ -66,7 +66,7 @@ private:
 
     bool processResourceNameField(
         NetworkResourceTreeTO const& treeTO,
-        std::set<std::vector<std::string>>& collapsedFolderNames);  //return true if folder symbol clicked
+        std::set<std::vector<std::string>>& collapsedFolderNames);  // Return true if folder symbol clicked
     void processDescriptionField(NetworkResourceTreeTO const& treeTO);
     void processReactionList(NetworkResourceTreeTO const& treeTO);
     void processTimestampField(NetworkResourceTreeTO const& treeTO);
@@ -80,7 +80,7 @@ private:
 
     bool processFolderTreeSymbols(
         NetworkResourceTreeTO const& treeTO,
-        std::set<std::vector<std::string>>& collapsedFolderNames);  //return true if folder symbol clicked
+        std::set<std::vector<std::string>>& collapsedFolderNames);  // Return true if folder symbol clicked
     void processEmojiWindow();
     void processEmojiButton(int emojiType);
 

--- a/source/Gui/EditorController.cpp
+++ b/source/Gui/EditorController.cpp
@@ -283,12 +283,12 @@ void EditorController::onDelete()
 
 void EditorController::processInspectorWindows()
 {
-    //process inspector windows
+    // Process inspector windows
     for (auto const& inspectorWindow : _inspectorWindows) {
         inspectorWindow->process();
     }
 
-    //inspector windows closed?
+    // Inspector windows closed?
     std::vector<InspectionWindow> inspectorWindows;
     std::vector<ExtendedObjectOrEnergyDesc> inspectedEntities;
     for (auto const& inspectorWindow : _inspectorWindows) {

--- a/source/Gui/EvolutionDashboardWindow.cpp
+++ b/source/Gui/EvolutionDashboardWindow.cpp
@@ -30,7 +30,7 @@
 
 namespace
 {
-    auto constexpr LiveStatisticsDeltaTime = 50;  //in millisec
+    auto constexpr LiveStatisticsDeltaTime = 50;  // In millisec
     auto constexpr RateAveragingTimesteps = LiveStatisticsService::RateAveragingTimesteps;
 
     auto constexpr ColorChipSize = 22.0f;
@@ -58,7 +58,7 @@ namespace
         float tableColumnWidth;
     };
 
-    //the last two metrics are rates per 1K time steps, both in the table and in the timeline plots
+    // The last two metrics are rates per 1K time steps, both in the table and in the timeline plots
     MetricDef const Metrics[EvolutionDashboardWindow::NumMetrics] = {
         {"Creatures", "Creatures", 0, 0, 82.0f},
         {"Avg cells", "Avg cells", 1, 1, 82.0f},
@@ -79,19 +79,19 @@ namespace
             toInt(alpha * 255.0f));
     }
 
-    auto constexpr LineageHueShift = 0.03f;    //hue offset between consecutive plot rows of a lineage
-    auto constexpr LineageBrightening = 1.5f;  //the identifying colors of the renderer are too dark on the dark GUI background
+    auto constexpr LineageHueShift = 0.03f;    // Hue offset between consecutive plot rows of a lineage
+    auto constexpr LineageBrightening = 1.5f;  // The identifying colors of the renderer are too dark on the dark GUI background
     auto constexpr LineageSaturationFactor = 0.85f;
 
-    //palette as used by the former statistics window; one colormap color per plot row;
-    //stepping through the colormap with an alternating stride of 1 and 2 makes adjacent rows distinct
+    // Palette as used by the former statistics window; one colormap color per plot row;
+    // stepping through the colormap with an alternating stride of 1 and 2 makes adjacent rows distinct
     ImColor getOverallPlotColor(int metricIndex)
     {
         return ImColor(ImPlot::GetColormapColor((metricIndex / 2 * 3 + metricIndex % 2) % 11, ImPlotColormap_Cool));
     }
 
-    //identifying color of a lineage as used by the renderer, brightened for the dark GUI background;
-    //hueShiftSteps shifts the hue slightly so that consecutive plot rows of a lineage remain distinguishable
+    // Identifying color of a lineage as used by the renderer, brightened for the dark GUI background;
+    // hueShiftSteps shifts the hue slightly so that consecutive plot rows of a lineage remain distinguishable
     ImColor getLineageColor(int64_t lineageId, int hueShiftSteps = 0)
     {
         auto rgb = ObjectColoring::getColorFromId(toUInt32(lineageId));
@@ -101,7 +101,7 @@ namespace
         return toImColor(ObjectColoring::hsvToRgb(h, s * LineageSaturationFactor, std::min(1.0f, v * LineageBrightening)));
     }
 
-    //the "all filtered" row keeps the colormap palette, single lineages are colored by their identity
+    // The "all filtered" row keeps the colormap palette, single lineages are colored by their identity
     ImColor getPlotColor(int64_t lineageId, int metricIndex)
     {
         return lineageId < 0 ? getOverallPlotColor(metricIndex) : getLineageColor(lineageId, metricIndex);
@@ -112,7 +112,7 @@ namespace
         if (std::isnan(value)) {
             return "-";
         }
-        if (value >= toDouble(Infinity<float>::value)) {  //parameters use FLT_MAX to represent infinity
+        if (value >= toDouble(Infinity<float>::value)) {  // Parameters use FLT_MAX to represent infinity
             return "infinity";
         }
         return StringHelper::format(value, decimals);
@@ -164,8 +164,8 @@ namespace
         return x - startX;
     }
 
-    //the accumulated statistics restart at zero when a saved simulation is loaded, which makes the rate incomputable
-    //for the samples whose reference still lies before the loading; NaN lets the callers hold the last known rate
+    // The accumulated statistics restart at zero when a saved simulation is loaded, which makes the rate incomputable
+    // for the samples whose reference still lies before the loading; NaN lets the callers hold the last known rate
     double calcRate(double accumValue, double lastAccumValue, double delta)
     {
         if (delta <= 0 || accumValue < lastAccumValue) {
@@ -174,7 +174,7 @@ namespace
         return (accumValue - lastAccumValue) / delta;
     }
 
-    //holds the last known value as long as the metric is not computable; a leading gap remains unset
+    // Holds the last known value as long as the metric is not computable; a leading gap remains unset
     void appendMetricValue(std::vector<double>& series, double value)
     {
         series.emplace_back(std::isnan(value) && !series.empty() ? series.back() : value);
@@ -190,9 +190,9 @@ namespace
         return sample.data;
     }
 
-    //works on any data point that carries the aggregatable creature fields (LineageDataPoint or the
-    //summed per-color ColorOverallDataPoint), so the same metric derivation serves single lineages and
-    //color-filtered overall statistics
+    // Works on any data point that carries the aggregatable creature fields (LineageDataPoint or the
+    // summed per-color ColorOverallDataPoint), so the same metric derivation serves single lineages and
+    // color-filtered overall statistics
     template <typename DataPoint>
     double getAggregatableMetricValue(DataPoint const& entry, DataPoint const* lastEntry, double rateDelta, int metricIndex)
     {
@@ -224,8 +224,8 @@ namespace
         return getAggregatableMetricValue(sample.data, referenceSample ? &referenceSample->data : nullptr, deltaKSteps, metricIndex);
     }
 
-    //sum of the per-color buckets whose colorBitset intersects the filter; a lineage falls into exactly one
-    //bucket (its full colorBitset), so this matches the "colorBitset & filter" row filter without double counting
+    // Sum of the per-color buckets whose colorBitset intersects the filter; a lineage falls into exactly one
+    // bucket (its full colorBitset), so this matches the "colorBitset & filter" row filter without double counting
     ColorOverallDataPoint aggregateFilteredColors(std::unordered_map<uint32_t, ColorOverallDataPoint> const& data, int colorFilter)
     {
         ColorOverallDataPoint result;
@@ -268,7 +268,7 @@ namespace
         return snprintf(buff, size, "%s s", StringHelper::format(value, 0).c_str());
     }
 
-    //most recent sample that is at least RateAveragingTimesteps older; falls back to the oldest sample
+    // Most recent sample that is at least RateAveragingTimesteps older; falls back to the oldest sample
     size_t findRateReferenceIndex(std::vector<DataPointCollection> const& history, double timestep)
     {
         size_t result = 0;
@@ -281,12 +281,12 @@ namespace
         return result;
     }
 
-    //builds the x points and metric series of one timeline; reference samples for the rate metrics are selected
-    //via a trailing window of RateAveragingTimesteps time steps
+    // Builds the x points and metric series of one timeline; reference samples for the rate metrics are selected
+    // via a trailing window of RateAveragingTimesteps time steps
     template <typename Target, typename Sample, typename MetricEvaluator>
     void buildPlotSeries(Target& target, std::vector<Sample> const& source, size_t firstIndex, bool useTimeAsX, MetricEvaluator const& evaluateMetric)
     {
-        //only the live DataPointCollection carries a real-time axis; the long-term history is always plotted over time steps
+        // Only the live DataPointCollection carries a real-time axis; the long-term history is always plotted over time steps
         auto getX = [&](Sample const& sample) {
             if constexpr (requires { sample.time; }) {
                 return useTimeAsX ? sample.time : sample.timestep;
@@ -299,13 +299,13 @@ namespace
         target.timePoints.clear();
         target.systemClockPoints.clear();
 
-        size_t referenceIndex = 0;  //reference samples may also lie before the visible range
+        size_t referenceIndex = 0;  // Reference samples may also lie before the visible range
         for (auto sampleIndex = firstIndex; sampleIndex < source.size(); ++sampleIndex) {
             auto const& sample = source.at(sampleIndex);
             while (referenceIndex + 1 < sampleIndex && source.at(referenceIndex + 1).timestep + RateAveragingTimesteps <= sample.timestep) {
                 ++referenceIndex;
             }
-            //rates over references younger than the averaging window would produce spikes at the left plot border; NaN suppresses those samples
+            // Rates over references younger than the averaging window would produce spikes at the left plot border; NaN suppresses those samples
             auto const& referenceSample = source.at(referenceIndex);
             auto referenceIsOldEnough = referenceIndex < sampleIndex && referenceSample.timestep + RateAveragingTimesteps <= sample.timestep;
             auto const* reference = referenceIsOldEnough ? &referenceSample : nullptr;
@@ -372,7 +372,7 @@ void EvolutionDashboardWindow::processBackground()
 
 void EvolutionDashboardWindow::processIntern()
 {
-    //scale the plot section proportionally when the window is resized
+    // Scale the plot section proportionally when the window is resized
     auto windowHeight = ImGui::GetWindowSize().y;
     if (_lastWindowHeight.has_value() && *_lastWindowHeight > 0 && *_lastWindowHeight != windowHeight) {
         _timelinesHeight *= windowHeight / *_lastWindowHeight;
@@ -392,7 +392,7 @@ void EvolutionDashboardWindow::processIntern()
 
     AlienGui::MovableHorizontalSeparator(AlienGui::MovableHorizontalSeparatorParameters().additive(false), _timelinesHeight);
 
-    //apply selection changes from the table immediately; otherwise the plots are empty for one frame
+    // Apply selection changes from the table immediately; otherwise the plots are empty for one frame
     updateDisplayData();
 
     if (ImGui::BeginChild("##timelineSection", {0, 0})) {
@@ -425,7 +425,7 @@ void EvolutionDashboardWindow::updateTableData()
     _lastTableBackTime = liveBackTime;
     _lastTableColorFilter = _colorFilter;
 
-    //table rows from the latest live sample (rates per 1K time steps)
+    // Table rows from the latest live sample (rates per 1K time steps)
     _lineages.clear();
     if (liveHistory.empty()) {
         return;
@@ -439,7 +439,7 @@ void EvolutionDashboardWindow::updateTableData()
         lineage.representativeCellId = entry.representativeCellId;
         LineageDataPoint const* referenceEntry = nullptr;
         auto referenceTimestep = 0.0;
-        for (auto sampleIndex = referenceIndex; sampleIndex + 1 < liveHistory.size(); ++sampleIndex) {  //young lineages: use their oldest sample
+        for (auto sampleIndex = referenceIndex; sampleIndex + 1 < liveHistory.size(); ++sampleIndex) {  // Young lineages: use their oldest sample
             if (auto const* candidate = findLineageEntry(liveHistory.at(sampleIndex), lineageId)) {
                 referenceEntry = candidate;
                 referenceTimestep = liveHistory.at(sampleIndex).timestep;
@@ -453,13 +453,13 @@ void EvolutionDashboardWindow::updateTableData()
     }
     sortLineages();
 
-    //current values for the table summary row
+    // Current values for the table summary row
     DataPointCollection const* referenceDataPoints = liveHistory.size() >= 2 ? &liveHistory.at(referenceIndex) : nullptr;
     for (int i = 0; i < NumMetrics; ++i) {
         _allLineages.currentValues.at(i) = getFilteredOverallMetricValue(lastSample, referenceDataPoints, _colorFilter, i);
     }
 
-    //union of colors over all lineages matching the current filter, shown as swatches on the summary row
+    // Union of colors over all lineages matching the current filter, shown as swatches on the summary row
     _allLineages.colorBitset = 0;
     for (auto const& lineage : _lineages) {
         if ((_colorFilter & lineage.colorBitset) != 0) {
@@ -486,7 +486,7 @@ void EvolutionDashboardWindow::sortLineages()
         auto rhsIsNan = std::isnan(rhsValue);
         if (lhsIsNan || rhsIsNan) {
             if (lhsIsNan != rhsIsNan) {
-                return rhsIsNan;  //rows without a value are sorted to the bottom
+                return rhsIsNan;  // Rows without a value are sorted to the bottom
             }
             return lhs.id < rhs.id;
         }
@@ -499,7 +499,7 @@ void EvolutionDashboardWindow::sortLineages()
 
 void EvolutionDashboardWindow::updatePlotData()
 {
-    //the long-term history carries per-lineage data and is therefore expensive to copy; process it under its mutex instead
+    // The long-term history carries per-lineage data and is therefore expensive to copy; process it under its mutex instead
     if (_timelineMode == TimelineMode_EntireHistory) {
         auto const& statisticsHistory = _SimulationFacade::get()->getStatisticsHistory();
         std::lock_guard lock(statisticsHistory.getMutex());
@@ -511,7 +511,7 @@ void EvolutionDashboardWindow::updatePlotData()
 
 void EvolutionDashboardWindow::rebuildPlotSeries(std::vector<DataPointCollection> const& source)
 {
-    //rebuild only when the underlying data or view settings have changed
+    // Rebuild only when the underlying data or view settings have changed
     auto sourceBackTime = !source.empty() ? source.back().time : -1.0;
     RebuildKey key{_timelineMode, _lastSteps, _timeHorizon, _colorFilter, sourceBackTime, _selectedLineageIds};
     if (_lastRebuildKey && *_lastRebuildKey == key) {
@@ -533,20 +533,20 @@ void EvolutionDashboardWindow::rebuildPlotSeries(std::vector<DataPointCollection
         while (firstIndex < source.size() && getX(source.at(firstIndex)) < startX) {
             ++firstIndex;
         }
-        //keep one sample left of the visible range so the lines extend beyond the left plot border
-        //(they are clipped there); otherwise a flickering gap remains between border and first sample
+        // Keep one sample left of the visible range so the lines extend beyond the left plot border
+        // (they are clipped there); otherwise a flickering gap remains between border and first sample
         if (firstIndex > 0) {
             --firstIndex;
         }
     }
 
-    //"all lineages" series honoring the color filter (the current values are maintained by updateTableData)
+    // "all lineages" series honoring the color filter (the current values are maintained by updateTableData)
     _allLineages.id = -1;
     buildPlotSeries(_allLineages, source, firstIndex, useTimeAsX, [colorFilter = _colorFilter](auto const& sample, auto const* reference, int metricIndex) {
         return getFilteredOverallMetricValue(sample, reference, colorFilter, metricIndex);
     });
 
-    //per-lineage series for the selected lineages
+    // Per-lineage series for the selected lineages
     _plottedLineages.clear();
     for (auto const& selectedId : _selectedLineageIds) {
         LineageDisplayData lineage;
@@ -556,7 +556,7 @@ void EvolutionDashboardWindow::rebuildPlotSeries(std::vector<DataPointCollection
             double timestep = 0;
             LineageDataPoint const* entry = nullptr;
         };
-        std::vector<RateReference> rateReferences;  //already visited samples containing the lineage; may also lie before the visible range
+        std::vector<RateReference> rateReferences;  // Already visited samples containing the lineage; may also lie before the visible range
         size_t rateReferenceIndex = 0;
         for (size_t sampleIndex = 0; sampleIndex < source.size(); ++sampleIndex) {
             auto const& sample = source.at(sampleIndex);
@@ -574,7 +574,7 @@ void EvolutionDashboardWindow::rebuildPlotSeries(std::vector<DataPointCollection
                 if (!useTimeAsX) {
                     lineage.systemClockPoints.emplace_back(sample.systemClock);
                 }
-                //rates over references younger than the averaging window would produce spikes at the left plot border; NaN suppresses those samples
+                // Rates over references younger than the averaging window would produce spikes at the left plot border; NaN suppresses those samples
                 auto referenceIsOldEnough =
                     !rateReferences.empty() && rateReferences.at(rateReferenceIndex).timestep + RateAveragingTimesteps <= sample.timestep;
                 auto const* lastEntry = referenceIsOldEnough ? rateReferences.at(rateReferenceIndex).entry : nullptr;
@@ -598,8 +598,8 @@ void EvolutionDashboardWindow::rebuildPlotSeries(std::vector<DataPointCollection
 
 void EvolutionDashboardWindow::rebuildPlotSeries(StatisticsHistoryData const& source)
 {
-    //rebuild only when the underlying data or view settings have changed; the lineage timelines are
-    //sampled independently of the overall timeline and therefore contribute their own back times
+    // Rebuild only when the underlying data or view settings have changed; the lineage timelines are
+    // sampled independently of the overall timeline and therefore contribute their own back times
     auto sourceBackTime = !source.colors.empty() ? source.colors.back().timestep : -1.0;
     std::vector<double> lineageBackTimes;
     lineageBackTimes.reserve(_selectedLineageIds.size());
@@ -613,13 +613,13 @@ void EvolutionDashboardWindow::rebuildPlotSeries(StatisticsHistoryData const& so
     }
     _lastRebuildKey = std::move(key);
 
-    //"all lineages" series honoring the color filter (the current values are maintained by updateTableData)
+    // "all lineages" series honoring the color filter (the current values are maintained by updateTableData)
     _allLineages.id = -1;
     buildPlotSeries(_allLineages, source.colors, 0, false, [colorFilter = _colorFilter](auto const& sample, auto const* reference, int metricIndex) {
         return getFilteredOverallMetricValue(sample, reference, colorFilter, metricIndex);
     });
 
-    //per-lineage series for the selected lineages
+    // Per-lineage series for the selected lineages
     _plottedLineages.clear();
     for (auto const& selectedId : _selectedLineageIds) {
         LineageDisplayData lineage;
@@ -646,8 +646,8 @@ void EvolutionDashboardWindow::processHeader()
     auto cardHeight =
         style.WindowPadding.y * 2 + ImGui::GetTextLineHeight() * 3 + StyleRepository::get().getLargeFont()->FontSize + style.ItemSpacing.y * 3 + scale(6.0f);
 
-    //the header shows the current global state; object counts and the total energy cover all objects and thus come
-    //from the raw engine snapshot, while the creature counts are accumulated over the lineages of that same snapshot
+    // The header shows the current global state; object counts and the total energy cover all objects and thus come
+    // from the raw engine snapshot, while the creature counts are accumulated over the lineages of that same snapshot
     auto const& objectStatistics = _lastStatisticsEntry.objectStatistics;
 
     auto numCreatures = 0.0;
@@ -731,7 +731,7 @@ void EvolutionDashboardWindow::processCard(
             }
             firstSubValue = false;
 
-            //draw an ellipsis instead of sub-values that do not fit into the card
+            // Draw an ellipsis instead of sub-values that do not fit into the card
             auto groupWidth = std::max(ImGui::CalcTextSize(subLabel.c_str()).x, ImGui::CalcTextSize(subValue.c_str()).x);
             if (ImGui::GetContentRegionAvail().x < groupWidth) {
                 ImGui::PushStyleColor(ImGuiCol_Text, (ImU32)Const::TextDecentColor);
@@ -803,8 +803,8 @@ void EvolutionDashboardWindow::processLineageTable()
 
         auto drawList = ImGui::GetWindowDrawList();
 
-        //header row: all labels are left-aligned and clamped to the visible part of each column, which can be
-        //partially hidden behind the frozen lineage column or cut off at the right window border
+        // Header row: all labels are left-aligned and clamped to the visible part of each column, which can be
+        // partially hidden behind the frozen lineage column or cut off at the right window border
         ImGui::TableNextRow(ImGuiTableRowFlags_Headers);
         ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, Const::TableHeaderColor);
         for (int column = 0; column < NumMetrics + FirstMetricColumn; ++column) {
@@ -822,7 +822,7 @@ void EvolutionDashboardWindow::processLineageTable()
                     _sortAscending = !_sortAscending;
                 } else {
                     _sortColumnIndex = column;
-                    _sortAscending = column < FirstMetricColumn;  //metric columns show the largest values on top by default
+                    _sortAscending = column < FirstMetricColumn;  // Metric columns show the largest values on top by default
                 }
                 sortLineages();
             }
@@ -833,7 +833,7 @@ void EvolutionDashboardWindow::processLineageTable()
             ImGui::PopID();
         }
 
-        //summary row
+        // Summary row
         ImGui::TableNextRow();
         ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, ImColor(0.13f, 0.16f, 0.23f, 1.0f));
         ImGui::TableSetColumnIndex(LineageColumn);
@@ -843,7 +843,7 @@ void EvolutionDashboardWindow::processLineageTable()
         }
         ImGui::SameLine(0, 0);
 
-        //draw the pin icon slightly smaller and shifted so it aligns nicely with the row text
+        // Draw the pin icon slightly smaller and shifted so it aligns nicely with the row text
         auto iconSize = ImGui::GetFontSize() * 0.75f;
         auto iconPos = ImGui::GetCursorScreenPos();
         drawList->AddText(
@@ -867,7 +867,7 @@ void EvolutionDashboardWindow::processLineageTable()
             rightAlignedText(formatMetricValue(_allLineages.currentValues.at(i), Metrics[i].tableDecimals));
         }
 
-        //lineage rows
+        // Lineage rows
         for (auto const& lineage : _lineages) {
             if ((_colorFilter & lineage.colorBitset) == 0) {
                 continue;
@@ -875,8 +875,8 @@ void EvolutionDashboardWindow::processLineageTable()
             ImGui::PushID(toInt(lineage.id));
             ImGui::TableNextRow();
 
-            //genome button on the left of the creatures column, shrunk like the pin icon and bottom-aligned within the row;
-            //submitted before the row selectable, otherwise the selectable resets the hover timer and the tooltip never shows
+            // Genome button on the left of the creatures column, shrunk like the pin icon and bottom-aligned within the row;
+            // submitted before the row selectable, otherwise the selectable resets the hover timer and the tooltip never shows
             ImGui::TableSetColumnIndex(FirstMetricColumn);
             auto lineHeight = ImGui::GetTextLineHeight();
             ImGui::SetWindowFontScale(0.75f);
@@ -944,8 +944,8 @@ void EvolutionDashboardWindow::processTimelineSection()
 {
     processTimelineHeader();
 
-    //rebuild the plot series right after the header widgets changed the horizon; otherwise the widened
-    //x-axis shows a gap on the left for one frame because the series are still trimmed to the old horizon
+    // Rebuild the plot series right after the header widgets changed the horizon; otherwise the widened
+    // x-axis shows a gap on the left for one frame because the series are still trimmed to the old horizon
     updatePlotData();
 
     std::vector<LineageDisplayData const*> plottedLineages;
@@ -957,8 +957,8 @@ void EvolutionDashboardWindow::processTimelineSection()
         }
     }
 
-    //the time axis is pinned below the scrolling plot area so it stays visible in every mode; reserve its full
-    //height (axis plot + table cell padding + item spacing), otherwise the section gets its own scrollbar
+    // The time axis is pinned below the scrolling plot area so it stays visible in every mode; reserve its full
+    // height (axis plot + table cell padding + item spacing), otherwise the section gets its own scrollbar
     auto const& style = ImGui::GetStyle();
     auto timeAxisHeight = scale(TimeAxisExtraHeight) + style.CellPadding.y * 2.0f + style.ItemSpacing.y;
     auto scrollbarWidth = 0.0f;
@@ -979,7 +979,7 @@ void EvolutionDashboardWindow::processTimelineHeader()
     std::vector<std::string> modeValues{"Real-time", "Last time steps", "Entire history"};
     AlienGui::Switcher(AlienGui::SwitcherParameters().name("Mode").width(260.0f).textWidth(45.0f).values(modeValues), &_timelineMode);
 
-    //sliders keep their default width and only shrink when the window gets too narrow
+    // Sliders keep their default width and only shrink when the window gets too narrow
     auto numSliders = _timelineMode == TimelineMode_EntireHistory ? 1.0f : 2.0f;
     ImGui::SameLine(0, scale(20.0f));
     AlienGui::VerticalSeparator();
@@ -1020,7 +1020,7 @@ void EvolutionDashboardWindow::processTimelineHeader()
 
 void EvolutionDashboardWindow::processTimelinePlots(std::vector<LineageDisplayData const*> const& plottedLineages)
 {
-    //labels and current values are placed to the right of the widgets, matching the general ALIEN layout
+    // Labels and current values are placed to the right of the widgets, matching the general ALIEN layout
     if (ImGui::BeginTable("##plots", 2, ImGuiTableFlags_None)) {
         ImGui::TableSetupColumn("##plot");
         ImGui::TableSetupColumn("##label", ImGuiTableColumnFlags_WidthFixed, scale(PlotLabelColumnWidth));
@@ -1076,7 +1076,7 @@ void EvolutionDashboardWindow::processTimelinePlot(std::vector<LineageDisplayDat
             auto count = toInt(lineage->timePoints.size());
             auto const& series = lineage->series.at(metricIndex);
 
-            //rate series start with NaN samples until a sufficiently old rate reference exists; skip them
+            // Rate series start with NaN samples until a sufficiently old rate reference exists; skip them
             auto offset = 0;
             while (offset < count && std::isnan(series.at(offset))) {
                 ++offset;
@@ -1152,7 +1152,7 @@ void EvolutionDashboardWindow::processTimeAxis(std::vector<LineageDisplayData co
 {
     auto [minTime, maxTime] = computePlotTimeRange(plottedLineages);
 
-    //the label column mirrors the plot table above (widened by the scrollbar if present) so the axis stays aligned with the plots
+    // The label column mirrors the plot table above (widened by the scrollbar if present) so the axis stays aligned with the plots
     if (ImGui::BeginTable("##timeAxis", 2, ImGuiTableFlags_None)) {
         ImGui::TableSetupColumn("##axis");
         ImGui::TableSetupColumn("##label", ImGuiTableColumnFlags_WidthFixed, scale(PlotLabelColumnWidth) + rightMargin);
@@ -1167,7 +1167,7 @@ void EvolutionDashboardWindow::processTimeAxis(std::vector<LineageDisplayData co
         ImPlot::SetNextAxesLimits(minTime, maxTime, 0, 1.0, ImGuiCond_Always);
         if (ImPlot::BeginPlot("##timeAxis", ImVec2(-1, scale(TimeAxisExtraHeight)), ImPlotFlags_CanvasOnly | ImPlotFlags_NoInputs)) {
             ImPlot::SetupAxis(ImAxis_X1, "", ImPlotAxisFlags_NoHighlight);
-            //the real-time axis is in seconds; the step-based modes label their x-axis in thousands of time steps
+            // The real-time axis is in seconds; the step-based modes label their x-axis in thousands of time steps
             ImPlot::SetupAxisFormat(ImAxis_X1, _timelineMode == TimelineMode_RealTime ? formatRealTimeSeconds : formatTimestepsInThousands, nullptr);
             ImPlot::SetupAxis(ImAxis_Y1, "", ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoHighlight);
             ImPlot::EndPlot();
@@ -1203,7 +1203,7 @@ void EvolutionDashboardWindow::drawValuesAtMouseCursor(
             break;
         }
     }
-    auto valueAtCursor = mousePos.y;  //may be NaN for rate series without a sufficiently old rate reference
+    auto valueAtCursor = mousePos.y;  // May be NaN for rate series without a sufficiently old rate reference
     mousePos.y = std::isnan(mousePos.y) ? 0.0 : std::max(0.0, std::min(upperBound, mousePos.y));
 
     ImPlot::PushStyleColor(ImPlotCol_InlayText, ImColor::HSV(0.0f, 0.0f, 1.0f).Value);
@@ -1244,5 +1244,5 @@ void EvolutionDashboardWindow::validateAndCorrect()
     _timeHorizon = std::clamp(_timeHorizon, 1.0f, LiveStatisticsService::MaxLiveHistory);
     _plotHeight = std::clamp(_plotHeight, MinPlotHeight, MaxPlotHeight);
     _sortColumnIndex = std::clamp(_sortColumnIndex, 0, NumMetrics + FirstMetricColumn - 1);
-    _colorFilter &= (1 << MAX_COLORS) - 1;  //an empty filter is allowed and simply shows no lineages
+    _colorFilter &= (1 << MAX_COLORS) - 1;  // An empty filter is allowed and simply shows no lineages
 }

--- a/source/Gui/EvolutionDashboardWindow.h
+++ b/source/Gui/EvolutionDashboardWindow.h
@@ -71,25 +71,25 @@ private:
 
     struct LineageDisplayData
     {
-        int64_t id = 0;  //-1 = "all lineages"
+        int64_t id = 0;  // -1 = "all lineages"
         int colorBitset = 0;
-        uint64_t representativeCellId = 0;  //cell of a creature with the highest generation; 0 = not available
+        uint64_t representativeCellId = 0;  // Cell of a creature with the highest generation; 0 = not available
         std::array<double, NumMetrics> currentValues = {};
-        std::array<std::vector<double>, NumMetrics> series = {};  //only filled for plotted lineages
-        std::vector<double> timePoints;                           //only filled for plotted lineages
-        std::vector<double> systemClockPoints;                    //only filled when the x-axis represents time steps
+        std::array<std::vector<double>, NumMetrics> series = {};  // Only filled for plotted lineages
+        std::vector<double> timePoints;                           // Only filled for plotted lineages
+        std::vector<double> systemClockPoints;                    // Only filled when the x-axis represents time steps
     };
 
-    std::vector<LineageDisplayData> _lineages;  //table rows from the latest sample, sorted by the selected table column
+    std::vector<LineageDisplayData> _lineages;  // Table rows from the latest sample, sorted by the selected table column
     std::vector<LineageDisplayData> _plottedLineages;
     LineageDisplayData _allLineages;
 
     std::array<uint32_t, MAX_COLORS> _cellColors = {};
 
     std::set<int64_t> _selectedLineageIds;
-    int _colorFilter = 0x3ff;  //bitset for MAX_COLORS cell colors
+    int _colorFilter = 0x3ff;  // Bitset for MAX_COLORS cell colors
 
-    int _sortColumnIndex = 1;  //0 = lineage column, 1..NumMetrics = metric columns
+    int _sortColumnIndex = 1;  // 0 = lineage column, 1..NumMetrics = metric columns
     bool _sortAscending = false;
 
     using TimelineMode = int;
@@ -102,7 +102,7 @@ private:
     TimelineMode _timelineMode = TimelineMode_EntireHistory;
 
     int _lastSteps = 100000;
-    float _timeHorizon = 10.0f;  //in seconds
+    float _timeHorizon = 10.0f;  // In seconds
     float _timelinesHeight = 0;
     float _plotHeight = 60.0f;
     std::optional<float> _lastWindowHeight;
@@ -115,7 +115,7 @@ private:
         int colorFilter = 0;
         double sourceBackTime = 0;
         std::set<int64_t> selectedLineageIds;
-        std::vector<double> lineageBackTimes;  //only used for the long-term history where each lineage has its own timeline
+        std::vector<double> lineageBackTimes;  // Only used for the long-term history where each lineage has its own timeline
 
         bool operator==(RebuildKey const&) const = default;
     };

--- a/source/Gui/ImageToPatternDialog.cpp
+++ b/source/Gui/ImageToPatternDialog.cpp
@@ -111,6 +111,6 @@ void ImageToPatternDialog::show()
         DescEditService::get().setCenter(dataDesc, Viewport::get().getCenterInWorldPos());
 
         _SimulationFacade::get()->addAndSelectSimulationData(std::move(dataDesc));
-        //TODO: update pattern editor
+        // TODO: update pattern editor
     });
 }

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -282,7 +282,7 @@ void MainLoopController::processExiting()
 
 void MainLoopController::drawLoadingScreen()
 {
-    //background color
+    // Background color
     glClearColor(0, 0, 0.1f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
 
@@ -585,7 +585,7 @@ void MainLoopController::processMenubar()
     AlienGui::EndMenu();
     AlienGui::EndMenuBar();
 
-    //further hotkeys
+    // Further hotkeys
     if (!io.WantCaptureKeyboard) {
         if (ImGui::IsKeyPressed(ImGuiKey_F7)) {
             if (WindowController::get().isDesktopMode()) {

--- a/source/Gui/MainWindow.cpp
+++ b/source/Gui/MainWindow.cpp
@@ -232,7 +232,7 @@ void _MainWindow::initGlfwAndOpenGL()
     //glfwSwapInterval(1);  //enable vsync
     ImGui::CreateContext();
     ImPlot::CreateContext();
-    ImGui_ImplGlfw_InitForOpenGL(windowData.window, true);  //setup Platform/Renderer back-ends
+    ImGui_ImplGlfw_InitForOpenGL(windowData.window, true);  // Setup Platform/Renderer back-ends
     ImGui_ImplOpenGL3_Init(glslVersion);
 }
 

--- a/source/Gui/OpenGLHelper.h
+++ b/source/Gui/OpenGLHelper.h
@@ -7,6 +7,6 @@
 class OpenGLHelper
 {
 public:
-    //returns id
+    // Returns id
     static TextureData loadTexture(std::filesystem::path const& filename);
 };

--- a/source/Gui/PatternEditorWindow.cpp
+++ b/source/Gui/PatternEditorWindow.cpp
@@ -49,13 +49,13 @@ void PatternEditorWindow::processIntern()
         _angularVel = 0;
     }
 
-    //load button
+    // Load button
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_FOLDER_OPEN))) {
         onOpenPattern();
     }
     AlienGui::Tooltip("Open pattern");
 
-    //save button
+    // Save button
     ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
     ImGui::SameLine();
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SAVE))) {
@@ -67,7 +67,7 @@ void PatternEditorWindow::processIntern()
     ImGui::SameLine();
     AlienGui::ToolbarSeparator();
 
-    //copy button
+    // Copy button
     ImGui::SameLine();
     ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COPY))) {
@@ -76,7 +76,7 @@ void PatternEditorWindow::processIntern()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Copy pattern");
 
-    //paste button
+    // Paste button
     ImGui::SameLine();
     ImGui::BeginDisabled(!_copiedSelection.has_value());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PASTE))) {
@@ -85,7 +85,7 @@ void PatternEditorWindow::processIntern()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Paste pattern");
 
-    //delete button
+    // Delete button
     ImGui::SameLine();
     ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_TRASH))) {
@@ -97,7 +97,7 @@ void PatternEditorWindow::processIntern()
     ImGui::SameLine();
     AlienGui::ToolbarSeparator();
 
-    //inspect objects button
+    // Inspect objects button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isObjectInspectionPossible());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_MICROSCOPE))) {
@@ -106,7 +106,7 @@ void PatternEditorWindow::processIntern()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Inspect Objects");
 
-    //inspect genomes button
+    // Inspect genomes button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isGenomeInspectionPossible());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_DNA))) {
@@ -115,7 +115,7 @@ void PatternEditorWindow::processIntern()
     ImGui::EndDisabled();
     AlienGui::Tooltip("Inspect genomes");
 
-    //inspect creatures button
+    // Inspect creatures button
     ImGui::SameLine();
     ImGui::BeginDisabled(!isCreatureInspectionPossible());
     if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PAW))) {

--- a/source/Gui/RenderStep.cpp
+++ b/source/Gui/RenderStep.cpp
@@ -245,18 +245,18 @@ _PostProcessingRenderStep::_PostProcessingRenderStep(StepParameters const& param
 
     // Setup full-screen quad
     float vertices[] = {
-        1.0f,  1.0f,  0.0f, 1.0f, 1.0f,  // top right
-        1.0f,  -1.0f, 0.0f, 1.0f, 0.0f,  // bottom right
-        -1.0f, -1.0f, 0.0f, 0.0f, 0.0f,  // bottom left
-        -1.0f, 1.0f,  0.0f, 0.0f, 1.0f   // top left
+        1.0f,  1.0f,  0.0f, 1.0f, 1.0f,  // Top right
+        1.0f,  -1.0f, 0.0f, 1.0f, 0.0f,  // Bottom right
+        -1.0f, -1.0f, 0.0f, 0.0f, 0.0f,  // Bottom left
+        -1.0f, 1.0f,  0.0f, 0.0f, 1.0f   // Top left
     };
     unsigned int indices[] = {
         0,
         1,
-        3,  // first triangle
+        3,  // First triangle
         1,
         2,
-        3  // second triangle
+        3  // Second triangle
     };
 
     glBindVertexArray(_vao);

--- a/source/Gui/ResizeWorldDialog.cpp
+++ b/source/Gui/ResizeWorldDialog.cpp
@@ -32,7 +32,7 @@ void ResizeWorldDialog::processIntern()
 {
     if (ImGui::BeginTable("##", 2, ImGuiTableFlags_SizingStretchProp)) {
 
-        //width
+        // Width
         ImGui::TableNextRow();
 
         ImGui::TableSetColumnIndex(0);
@@ -43,7 +43,7 @@ void ResizeWorldDialog::processIntern()
         ImGui::TableSetColumnIndex(1);
         ImGui::Text("Width");
 
-        //height
+        // Height
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
         ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);

--- a/source/Gui/Shader.cpp
+++ b/source/Gui/Shader.cpp
@@ -77,25 +77,25 @@ _Shader::_Shader(
     std::ifstream vShaderFile;
     std::ifstream fShaderFile;
     std::ifstream gShaderFile;
-    // ensure ifstream objects can throw exceptions:
+    // Ensure ifstream objects can throw exceptions:
     vShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
     fShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
     gShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
     try {
-        // open files
+        // Open files
         vShaderFile.open(vertexPath);
         fShaderFile.open(fragmentPath);
         std::stringstream vShaderStream, fShaderStream;
-        // read file's buffer contents into streams
+        // Read file's buffer contents into streams
         vShaderStream << vShaderFile.rdbuf();
         fShaderStream << fShaderFile.rdbuf();
-        // close file handlers
+        // Close file handlers
         vShaderFile.close();
         fShaderFile.close();
-        // convert stream into string
+        // Convert stream into string
         vertexCode = vShaderStream.str();
         fragmentCode = fShaderStream.str();
-        // if geometry shader path is present, also load a geometry shader
+        // If geometry shader path is present, also load a geometry shader
         if (!geometryPath.empty()) {
             gShaderFile.open(geometryPath);
             std::stringstream gShaderStream;

--- a/source/Gui/SimulationInteractionController.cpp
+++ b/source/Gui/SimulationInteractionController.cpp
@@ -341,11 +341,11 @@ void SimulationInteractionController::drawCursor()
         ImGui::SetMouseCursor(ImGuiMouseCursor_None);
     }
 
-    // position selection cursor
+    // Position selection cursor
     if (_modes.positionSelectionMode) {
         auto cursorSize = scale(CursorRadius);
 
-        // shadow
+        // Shadow
         drawList->AddRectFilled(
             {mousePos.x - scale(2.0f), mousePos.y - cursorSize}, {mousePos.x + scale(2.0f), mousePos.y - cursorSize / 2}, Const::CursorShadowColor);
         drawList->AddRectFilled(
@@ -355,7 +355,7 @@ void SimulationInteractionController::drawCursor()
         drawList->AddRectFilled(
             {mousePos.x + cursorSize / 2, mousePos.y - scale(2.0f)}, {mousePos.x + cursorSize, mousePos.y + scale(2.0f)}, Const::CursorShadowColor);
 
-        // foreground
+        // Foreground
         drawList->AddRectFilled(
             {mousePos.x - scale(1.0f), mousePos.y - cursorSize}, {mousePos.x + scale(1.0f), mousePos.y - cursorSize / 2}, Const::CursorColor);
         drawList->AddRectFilled(
@@ -367,12 +367,12 @@ void SimulationInteractionController::drawCursor()
         return;
     }
 
-    // editing cursors
+    // Editing cursors
     if (_modes.editMode) {
         if (!_modes.drawMode) {
             auto cursorSize = scale(CursorRadius);
 
-            // shadow
+            // Shadow
             drawList->AddRectFilled(
                 {mousePos.x - scale(2.0f), mousePos.y - cursorSize}, {mousePos.x + scale(2.0f), mousePos.y - cursorSize / 2}, Const::CursorShadowColor);
             drawList->AddRectFilled(
@@ -382,7 +382,7 @@ void SimulationInteractionController::drawCursor()
             drawList->AddRectFilled(
                 {mousePos.x + cursorSize / 2, mousePos.y - scale(2.0f)}, {mousePos.x + cursorSize, mousePos.y + scale(2.0f)}, Const::CursorShadowColor);
 
-            // foreground
+            // Foreground
             drawList->AddRectFilled(
                 {mousePos.x - scale(1.0f), mousePos.y - cursorSize}, {mousePos.x + scale(1.0f), mousePos.y - cursorSize / 2}, Const::CursorColor);
             drawList->AddRectFilled(
@@ -403,11 +403,11 @@ void SimulationInteractionController::drawCursor()
         return;
     }
 
-    // navigation cursor
+    // Navigation cursor
     if (!_modes.editMode) {
         auto cursorSize = scale(CursorRadius);
 
-        // shadow
+        // Shadow
         drawList->AddCircle(mousePos, cursorSize / 2, Const::CursorShadowColor, 0, scale(4.0f));
         drawList->AddLine(
             {mousePos.x + sqrtf(2.0f) / 2.0f * cursorSize / 2, mousePos.y + sqrtf(2.0f) / 2.0f * cursorSize / 2},
@@ -415,7 +415,7 @@ void SimulationInteractionController::drawCursor()
             Const::CursorShadowColor,
             scale(4.0f));
 
-        // foreground
+        // Foreground
         drawList->AddCircle(mousePos, cursorSize / 2, Const::CursorColor, 0, scale(2.0f));
         drawList->AddLine(
             {mousePos.x + sqrtf(2.0f) / 2.0f * cursorSize / 2, mousePos.y + sqrtf(2.0f) / 2.0f * cursorSize / 2},

--- a/source/Gui/SimulationInteractionController.h
+++ b/source/Gui/SimulationInteractionController.h
@@ -66,7 +66,7 @@ private:
     Modes _modes;
     Modes _modesAtClick;
 
-    //navigation
+    // Navigation
     std::optional<RealVector2D> _worldPosForPanning;
     std::optional<RealVector2D> _worldPosOnClick;
     std::optional<IntVector2D> _prevMousePosInt;
@@ -77,7 +77,7 @@ private:
 
     struct MouseWheelAction
     {
-        bool up;  //false=down
+        bool up;  // false=down
         float strongness;
         std::chrono::steady_clock::time_point start;
         std::chrono::steady_clock::time_point lastTime;

--- a/source/Gui/SimulationParametersBaseWidget.cpp
+++ b/source/Gui/SimulationParametersBaseWidget.cpp
@@ -39,5 +39,5 @@ int _SimulationParametersBaseWidget::getOrderNumber() const
 
 void _SimulationParametersBaseWidget::setOrderNumber(int orderNumber)
 {
-    // do nothing
+    // Do nothing
 }

--- a/source/Gui/StyleRepository.cpp
+++ b/source/Gui/StyleRepository.cpp
@@ -37,7 +37,7 @@ void StyleRepository::setup()
 
     ImGuiIO& io = ImGui::GetIO();
 
-    //default font (small with icons)
+    // Default font (small with icons)
     io.Fonts->AddFontFromMemoryCompressedTTF(DroidSans_compressed_data, DroidSans_compressed_size, 16.0f * scaleFactor);
     {
         static const ImWchar rangesIcons[] = {ICON_MIN_FA, ICON_MAX_FA, 0};
@@ -45,19 +45,19 @@ void StyleRepository::setup()
             FontAwesomeSolid_compressed_data, FontAwesomeSolid_compressed_size, 16.0f * scaleFactor, &configMerge, rangesIcons);
     }
 
-    //small bold font
+    // Small bold font
     _smallBoldFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSansBold_compressed_data, DroidSansBold_compressed_size, 16.0f * scaleFactor);
 
-    //medium bold font
+    // Medium bold font
     _mediumBoldFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSansBold_compressed_data, DroidSansBold_compressed_size, 24.0f * scaleFactor);
 
-    //medium font
+    // Medium font
     _mediumFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSans_compressed_data, DroidSans_compressed_size, 24.0f * scaleFactor);
 
-    //large font
+    // Large font
     _largeFont = io.Fonts->AddFontFromMemoryCompressedTTF(DroidSans_compressed_data, DroidSans_compressed_size, 48.0f * scaleFactor);
 
-    //icon font
+    // Icon font
     _iconFont = io.Fonts->AddFontFromMemoryCompressedTTF(AlienIconFont_compressed_data, AlienIconFont_compressed_size, 24.0f * scaleFactor);
     {
         static const ImWchar rangesIcons[] = {ICON_MIN_FA, ICON_MAX_FA, 0};
@@ -66,10 +66,10 @@ void StyleRepository::setup()
         io.Fonts->Build();
     }
 
-    //monospace medium font
+    // Monospace medium font
     _monospaceMediumFont = io.Fonts->AddFontFromMemoryCompressedTTF(Cousine_Regular_compressed_data, Cousine_Regular_compressed_size, 14.0f * scaleFactor);
 
-    //monospace large font
+    // Monospace large font
     _monospaceLargeFont = io.Fonts->AddFontFromMemoryCompressedTTF(Cousine_Regular_compressed_data, Cousine_Regular_compressed_size, 128.0f * scaleFactor);
 
     _reefMediumFont = io.Fonts->AddFontFromMemoryCompressedTTF(Reef_compressed_data, Reef_compressed_size, 24.0f * scaleFactor);

--- a/source/Gui/StyleRepository.h
+++ b/source/Gui/StyleRepository.h
@@ -42,7 +42,7 @@ namespace Const
     ImColor const TreeNodeHighColor = ImColor::HSV(0.6f, 0.6f, 0.40f);
     ImColor const TreeNodeHighHoveredColor = ImColor::HSV(0.6f, 0.6f, 0.55f);
     ImColor const TreeNodeHighActiveColor = ImColor::HSV(0.6f, 0.6f, 0.65f);
-    ImColor const TreeNodeDefaultColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  //same dark gray as TableHeaderColor
+    ImColor const TreeNodeDefaultColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  // Same dark gray as TableHeaderColor
     ImColor const TreeNodeDefaultHoveredColor = ImColor::HSV(0.6f, 0.6f, 0.55f);
     ImColor const TreeNodeDefaultActiveColor = ImColor::HSV(0.6f, 0.6f, 0.65f);
     ImColor const TreeNodeLowColor = ImColor::HSV(0.0, 0.0f, 0.20f);
@@ -52,14 +52,14 @@ namespace Const
     ImColor const DisabledOverlayColor1 = ImColor::HSV(0.0f, 0.0f, 0.35f, 0.5f);
     ImColor const DisabledOverlayColor2 = ImColor::HSV(0.0f, 0.0f, 0.06f, 0.2f);
 
-    ImColor const GroupDefaultColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  //same dark gray as TableHeaderColor
+    ImColor const GroupDefaultColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  // Same dark gray as TableHeaderColor
     ImColor const GroupHighColor = ImColor::HSV(0.6f, 0.6f, 0.40f);
 
     ImColor const MovableSeparatorColor = ImColor::HSV(0.5f, 0.6f, 0.6f);
     ImColor const MovableSeparatorHoveredColor = ImColor::HSV(0.5f, 0.6f, 0.7f);
     ImColor const MovableSeparatorActiveColor = ImColor::HSV(0.5f, 0.6f, 0.8f);
 
-    ImColor const TableHeaderColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  //matches the ImGui default ImGuiCol_TableHeaderBg
+    ImColor const TableHeaderColor = ImColor(0.19f, 0.19f, 0.20f, 1.00f);  // Matches the ImGui default ImGuiCol_TableHeaderBg
 
     ImColor const MonospaceColor = ImColor::HSV(0.3f, 1.0f, 1.0f);
 

--- a/source/Gui/WindowController.cpp
+++ b/source/Gui/WindowController.cpp
@@ -87,7 +87,7 @@ void WindowController::init()
     }
 
     float temp;
-    glfwGetMonitorContentScale(glfwGetPrimaryMonitor(), &_contentScaleFactor, &temp);  //consider only horizontal content scale
+    glfwGetMonitorContentScale(glfwGetPrimaryMonitor(), &_contentScaleFactor, &temp);  // Consider only horizontal content scale
 }
 
 void WindowController::shutdown()

--- a/source/Network/NetworkResourceService.cpp
+++ b/source/Network/NetworkResourceService.cpp
@@ -27,7 +27,7 @@ namespace
         return equalFolders;
     }
 
-    //returns true iff folderNames contains otherFolderNames
+    // Returns true iff folderNames contains otherFolderNames
     bool contains(std::vector<std::string> const& folderNames, std::vector<std::string> const& otherFolderNames)
     {
         if (folderNames.size() < otherFolderNames.size()) {
@@ -71,7 +71,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
     std::list<NetworkResourceTreeTO> treeTOlist;
     for (auto const& rawTO : rawTOs) {
 
-        //parse folder names
+        // Parse folder names
         std::string nameWithoutFolders;
         std::vector<std::string> folderNames = getNameParts(rawTO->resourceName);
         if (!folderNames.empty()) {
@@ -83,7 +83,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
         int bestMatchEqualFolders;
         if (!treeTOlist.empty()) {
 
-            //find matching node
+            // Find matching node
             auto searchIter = treeTOlist.end();
             bestMatchIter = searchIter;
             bestMatchEqualFolders = -1;
@@ -105,7 +105,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
             bestMatchEqualFolders = 0;
         }
 
-        //insert folders
+        // Insert folders
         for (int i = bestMatchEqualFolders; i < folderNames.size(); ++i) {
             auto treeTO = std::make_shared<_NetworkResourceTreeTO>();
             treeTO->folderNames = std::vector(folderNames.begin(), folderNames.begin() + i + 1);
@@ -115,7 +115,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
             ++bestMatchIter;
         }
 
-        //insert leaf
+        // Insert leaf
         auto treeTO = std::make_shared<_NetworkResourceTreeTO>();
         BrowserLeaf leaf{.leafName = nameWithoutFolders, .rawTO = rawTO};
         treeTO->type = rawTO->resourceType;
@@ -124,7 +124,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
         treeTOlist.insert(bestMatchIter, treeTO);
     }
 
-    //calc folder lines
+    // Calc folder lines
     std::vector treeTOs(treeTOlist.begin(), treeTOlist.end());
     for (int i = 0; i < treeTOs.size(); ++i) {
         auto& treeTO = treeTOs.at(i);
@@ -139,7 +139,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
 
             treeTO->treeSymbols.resize(treeTO->folderNames.size(), FolderTreeSymbols::None);
 
-            //calc symbols at position numEqualFolders - 1
+            // Calc symbols at position numEqualFolders - 1
             if (numEqualFolders > 0) {
                 int f = numEqualFolders - 1;
                 if (prevTreeTO->treeSymbols.at(f) == FolderTreeSymbols::Expanded) {
@@ -163,7 +163,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
                 }
             }
 
-            //calc symbols before position numEqualFolders - 1
+            // Calc symbols before position numEqualFolders - 1
             for (int f = 0; f < numEqualFolders - 1; ++f) {
                 if (prevTreeTO->treeSymbols.at(f) == FolderTreeSymbols::Branch) {
                     treeTO->treeSymbols.at(f) = FolderTreeSymbols::None;
@@ -196,7 +196,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
         }
     }
 
-    //calc numLeafs and numReactions for folders
+    // Calc numLeafs and numReactions for folders
     for (int i = toInt(treeTOs.size()) - 1; i > 0; --i) {
         auto& treeTO = treeTOs.at(i);
         if (treeTO->isLeaf()) {
@@ -219,7 +219,7 @@ std::vector<NetworkResourceTreeTO> NetworkResourceService::createTreeTOs(
         }
     }
 
-    //collapse items
+    // Collapse items
     std::unordered_set<std::string> collapsedFolderStrings;
     for (auto const& folderNames : collapsedFolderNames) {
         collapsedFolderStrings.insert(boost::join(folderNames, FolderSeparator));

--- a/source/Network/NetworkResourceService.h
+++ b/source/Network/NetworkResourceService.h
@@ -16,9 +16,9 @@ public:
         std::set<std::vector<std::string>> const& collapsedFolderNames);
 
     std::vector<NetworkResourceRawTO> getMatchingRawTOs(NetworkResourceTreeTO const& treeTO, std::vector<NetworkResourceRawTO> const& rawTOs);
-    void invalidateCache();  //invalidate cache for getMatchingRawTOs
+    void invalidateCache();  // Invalidate cache for getMatchingRawTOs
 
-    //folder names conversion methods
+    // Folder names conversion methods
     std::vector<std::string> getFolderNames(std::string const& resourceName);
     std::string removeFoldersFromName(std::string const& resourceName);
     std::set<std::vector<std::string>> getFolderNames(std::vector<NetworkResourceRawTO> const& browserData, int minNesting = 2);

--- a/source/Network/NetworkService.cpp
+++ b/source/Network/NetworkService.cpp
@@ -580,7 +580,7 @@ void NetworkService::incDownloadCounter(std::string const& simId)
         params.emplace("id", simId);
         executeRequest([&] { return client.Get("/incdownloadcount", params, {}); });
     } catch (...) {
-        //do nothing
+        // Do nothing
     }
 }
 

--- a/source/PersisterInterface/ParameterParser.h
+++ b/source/PersisterInterface/ParameterParser.h
@@ -10,7 +10,7 @@
 class ParameterParser
 {
 public:
-    //return true if value does not exist in tree
+    // Return true if value does not exist in tree
     template <typename T>
     static bool encodeDecode(boost::property_tree::ptree& tree, T& value, T const& defaultValue, std::string const& node, ParserTask task);
 };

--- a/source/PersisterInterface/PersisterFacade.h
+++ b/source/PersisterInterface/PersisterFacade.h
@@ -48,19 +48,19 @@ public:
 
     static PersisterFacade get();
 
-    //lifecycle control
+    // Lifecycle control
     virtual void setup() = 0;
     virtual void shutdown() = 0;
     virtual void restart() = 0;
 
-    //generic logic
+    // Generic logic
     virtual bool isBusy() const = 0;
     virtual std::optional<PersisterRequestState> getRequestState(PersisterRequestId const& id) const = 0;
     virtual PersisterRequestResult fetchPersisterRequestResult(PersisterRequestId const& id) = 0;
     virtual std::vector<PersisterErrorInfo> fetchAllErrorInfos(SenderId const& senderId) = 0;
     virtual PersisterErrorInfo fetchError(PersisterRequestId const& id) = 0;
 
-    //specific request
+    // Specific request
     virtual PersisterRequestId scheduleSaveSimulation(SenderInfo const& senderInfo, SaveSimulationRequestData const& data) = 0;
     virtual SaveSimulationResultData fetchSaveSimulationData(PersisterRequestId const& id) = 0;
 

--- a/source/PersisterInterface/SavepointTable.h
+++ b/source/PersisterInterface/SavepointTable.h
@@ -26,7 +26,7 @@ struct _SavepointEntry
     std::string peak;
     std::string peakType;
 
-    std::string requestId;  // transient
+    std::string requestId;  // Transient
 };
 using SavepointEntry = std::shared_ptr<_SavepointEntry>;
 

--- a/source/PersisterInterface/SavepointTableService.cpp
+++ b/source/PersisterInterface/SavepointTableService.cpp
@@ -31,17 +31,17 @@ auto SavepointTableService::loadFromFile(std::string const& filename) -> std::va
     try {
         auto directory = std::filesystem::path(filename).parent_path();
 
-        // directory does not exist
+        // Directory does not exist
         if (!std::filesystem::exists(directory)) {
             return Error{};
         }
 
-        // no write access
+        // No write access
         if (!hasWriteAccess(directory)) {
             return Error{};
         }
 
-        // savepoint file does not exist
+        // Savepoint file does not exist
         if (!std::filesystem::exists(filename)) {
             return SavepointTable(filename, {});
         }
@@ -111,7 +111,7 @@ void SavepointTableService::deleteEntry(SavepointTable& table, SavepointEntry co
 
 std::filesystem::path SavepointTableService::calcAbsolutePath(SavepointTable const& table, SavepointEntry const& entry) const
 {
-    //compatibility with v4.11
+    // Compatibility with v4.11
     if (entry->filename.is_absolute()) {
         return entry->filename;
     }

--- a/source/PersisterInterface/SavepointTableService.h
+++ b/source/PersisterInterface/SavepointTableService.h
@@ -22,7 +22,7 @@ public:
     {};
     std::variant<SavepointTable, Error> loadFromFile(std::string const& filename);
 
-    std::vector<SavepointEntry> truncate(SavepointTable& table, int newSize) const;  //returns non-persistent entries
+    std::vector<SavepointEntry> truncate(SavepointTable& table, int newSize) const;  // Returns non-persistent entries
     void insertEntryAtFront(SavepointTable& table, SavepointEntry const& entry) const;
     void updateEntry(SavepointTable& table, int row, SavepointEntry const& newEntry) const;
     void deleteEntry(SavepointTable& table, SavepointEntry const& entry) const;

--- a/source/PersisterInterface/SerializerService.cpp
+++ b/source/PersisterInterface/SerializerService.cpp
@@ -1978,7 +1978,7 @@ bool SerializerService::deleteSimulation(std::filesystem::path const& filename) 
             return false;
         }
 
-        //statistics files are optional
+        // Statistics files are optional
         std::filesystem::remove(statisticsFilename);
         std::filesystem::remove(legacyStatisticsFilename);
         return true;
@@ -2045,7 +2045,7 @@ bool SerializerService::serializeGenomeToFile(std::filesystem::path const& filen
 {
     try {
         log(Priority::Important, "save genome to " + filename.string());
-        //wrap constructor cell around genome
+        // Wrap constructor cell around genome
         Desc description;
         if (!wrapGenome(description, genome)) {
             return false;
@@ -2291,7 +2291,7 @@ namespace
     auto constexpr Id_LineageTimeline_NumCreatedCreatures = 12;
     auto constexpr Id_LineageTimeline_TotalMutations = 13;
 
-    //metric columns are plot statistics and are stored as float to halve the serialized size; the exact values stay double in memory
+    // Metric columns are plot statistics and are stored as float to halve the serialized size; the exact values stay double in memory
     struct ColorTimeline
     {
         std::vector<float> numCreatures;
@@ -2400,7 +2400,7 @@ namespace
     struct DeduplicatedColorTimelines
     {
         std::vector<ColorTimeline> uniqueTimelines;
-        std::vector<std::vector<uint32_t>> colorBitsetGroups;  // parallel to uniqueTimelines
+        std::vector<std::vector<uint32_t>> colorBitsetGroups;  // Parallel to uniqueTimelines
     };
 
     DeduplicatedColorTimelines deduplicateColorTimelines(std::unordered_map<uint32_t, ColorTimeline> const& colorTimelines)
@@ -2408,7 +2408,7 @@ namespace
         DeduplicatedColorTimelines result;
         std::unordered_map<size_t, std::vector<size_t>> hashToUniqueIndices;
 
-        //sort color combinations for deterministic output
+        // Sort color combinations for deterministic output
         std::vector<uint32_t> sortedColorBitsets;
         sortedColorBitsets.reserve(colorTimelines.size());
         for (auto const& [colorBitset, timeline] : colorTimelines) {
@@ -2681,7 +2681,7 @@ void SerializerService::serializeStatistics(StatisticsHistoryData const& statist
 
 void SerializerService::deserializeStatistics(StatisticsHistoryData& statistics, std::istream& stream) const
 {
-    //the statistics history is auxiliary data: an unreadable or outdated file yields an empty history instead of failing the simulation load
+    // The statistics history is auxiliary data: an unreadable or outdated file yields an empty history instead of failing the simulation load
     statistics = StatisticsHistoryData();
     try {
         zstd::istream decompressedStream(stream);

--- a/source/PersisterTests/SerializerServiceTest.cpp
+++ b/source/PersisterTests/SerializerServiceTest.cpp
@@ -35,7 +35,7 @@ protected:
         result.timestep = base + 1;
         result.systemClock = base + 2;
 
-        //the same set of color combinations in every sample, so the column-wise round-trip is exact
+        // The same set of color combinations in every sample, so the column-wise round-trip is exact
         for (auto&& [colorBitset, offset] : {std::pair{0x1u, 3.0}, std::pair{0x6u, 12.0}}) {
             ColorOverallDataPoint colorPoint;
             colorPoint.numCreatures = base + offset;
@@ -188,7 +188,7 @@ TEST_F(SerializerServiceTests, statisticsHistoryWithManyLineages)
 
 TEST_F(SerializerServiceTests, statisticsHistoryWithDeduplicatedColorTimelines)
 {
-    //many color combinations share the same timeline; a few carry distinct data
+    // Many color combinations share the same timeline; a few carry distinct data
     auto createSample = [](double base) {
         ColorSamples result;
         result.timestep = base + 1;


### PR DESCRIPTION
## Summary

Normalizes code comments in `source/` to the project convention `// Text` — a space after the slashes and a capital first letter — and includes one small unrelated refactor in the attacker processor.

| Commit | Scope |
|---|---|
| Normalize code comment style | 81 files, 385 comment lines |
| Move energy calculation before sensor match check | `AttackerProcessor.cuh` |

## Comment sweep

Applied via script plus a manual review pass. Every changed line differs from its previous version **only in whitespace and letter case** — no code was touched, and no edited `//` sits inside a string literal.

Deliberately left as they were:

- **Commented-out code** (`//return;`, `//if (x) {`, the disabled GLSL in `source/Shaders/`) — capitalizing it would break it if re-enabled.
- **Continuation lines** of multi-line comments — these got the missing space but keep their lowercase, since they continue a sentence.
- **`//*** Section ***` banners** — a space would misalign them against their `//***` border lines.
- **Comments whose first word is an identifier or literal** — `// to only contains 1 genome` (the `to` parameter), `// true means diff...`, `// x, y, z position`, `// r, g, b color`.

## Verification

- Full build: all translation units compile. `alien.exe` could not be linked locally because a running instance held the binary; `cli.exe`, `EngineTests.exe` and `PersisterTests.exe` link cleanly.
- `EngineInterfaceTests` 174, `NetworkTests` 4, `PersisterTests` 68 — all pass.
- `EngineTests`: 3082 tests, **3079 passed, 0 failed**, 3 skipped (pre-existing `GTEST_SKIP`s in `ConstructorTests_ProvideEnergy`, unrelated to this change).
- clang-format 19.1.5: of the 71 touched files that were format-clean on `develop`, none regressed. The remaining files were already not format-clean before this change and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)