### PR TITLE
Break gene cycles not running through the root gene after mutation

### DIFF
--- a/source/EngineImpl/EngineWorker.cpp
+++ b/source/EngineImpl/EngineWorker.cpp
@@ -471,6 +471,12 @@ void EngineWorker::testOnly_removeUnusedGenes(uint64_t objectId)
     _simulationCudaFacade->testOnly_removeUnusedGenes(objectId);
 }
 
+void EngineWorker::testOnly_removeGeneCycles(uint64_t objectId)
+{
+    EngineWorkerGuard access(this);
+    _simulationCudaFacade->testOnly_removeGeneCycles(objectId);
+}
+
 void EngineWorker::testOnly_createConnection(uint64_t objectId1, uint64_t objectId2)
 {
     EngineWorkerGuard access(this);

--- a/source/EngineImpl/EngineWorker.h
+++ b/source/EngineImpl/EngineWorker.h
@@ -120,6 +120,7 @@ public:
     // Only for tests
     void testOnly_mutate(uint64_t objectId);
     void testOnly_removeUnusedGenes(uint64_t objectId);
+    void testOnly_removeGeneCycles(uint64_t objectId);
     void testOnly_createConnection(uint64_t objectId1, uint64_t objectId2);
     void testOnly_createConnectionWithAbsAngle(uint64_t objectId1, uint64_t objectId2, float desiredDistance, float desiredAbsAngle1, float desiredAbsAngle2);
     void testOnly_cleanupAfterTimestep();

--- a/source/EngineImpl/SimulationCudaFacade.cu
+++ b/source/EngineImpl/SimulationCudaFacade.cu
@@ -590,6 +590,13 @@ void _SimulationCudaFacade::testOnly_removeUnusedGenes(uint64_t objectId)
     syncAndCheck();
 }
 
+void _SimulationCudaFacade::testOnly_removeGeneCycles(uint64_t objectId)
+{
+    checkAndProcessSimulationParameterChanges();
+    TestKernelsService::get().testOnly_removeGeneCycles(_settings.cudaSettings, getSimulationDataPtrCopy(), objectId);
+    syncAndCheck();
+}
+
 void _SimulationCudaFacade::testOnly_createConnection(uint64_t objectId1, uint64_t objectId2)
 {
     checkAndProcessSimulationParameterChanges();

--- a/source/EngineImpl/SimulationCudaFacade.cuh
+++ b/source/EngineImpl/SimulationCudaFacade.cuh
@@ -107,6 +107,7 @@ public:
     // Only for tests
     void testOnly_mutate(uint64_t objectId);
     void testOnly_removeUnusedGenes(uint64_t objectId);
+    void testOnly_removeGeneCycles(uint64_t objectId);
     void testOnly_createConnection(uint64_t objectId1, uint64_t objectId2);
     void testOnly_createConnectionWithAbsAngle(uint64_t objectId1, uint64_t objectId2, float desiredDistance, float desiredAbsAngle1, float desiredAbsAngle2);
     void testOnly_cleanupAfterTimestep();

--- a/source/EngineImpl/SimulationFacadeImpl.cpp
+++ b/source/EngineImpl/SimulationFacadeImpl.cpp
@@ -391,6 +391,11 @@ void _SimulationFacadeImpl::testOnly_removeUnusedGenes(uint64_t objectId)
     _worker.testOnly_removeUnusedGenes(objectId);
 }
 
+void _SimulationFacadeImpl::testOnly_removeGeneCycles(uint64_t objectId)
+{
+    _worker.testOnly_removeGeneCycles(objectId);
+}
+
 void _SimulationFacadeImpl::testOnly_createConnection(uint64_t objectId1, uint64_t objectId2)
 {
     _worker.testOnly_createConnection(objectId1, objectId2);

--- a/source/EngineImpl/SimulationFacadeImpl.h
+++ b/source/EngineImpl/SimulationFacadeImpl.h
@@ -108,6 +108,7 @@ public:
     // For tests only
     void testOnly_mutate(uint64_t objectId) override;
     void testOnly_removeUnusedGenes(uint64_t objectId) override;
+    void testOnly_removeGeneCycles(uint64_t objectId) override;
     void testOnly_createConnection(uint64_t objectId1, uint64_t objectId2) override;
     void testOnly_createConnectionWithAbsAngle(uint64_t objectId1, uint64_t objectId2, float desiredDistance, float desiredAbsAngle1, float desiredAbsAngle2)
         override;

--- a/source/EngineImpl/TestKernelsService.cu
+++ b/source/EngineImpl/TestKernelsService.cu
@@ -25,6 +25,11 @@ void TestKernelsService::testOnly_removeUnusedGenes(CudaSettings const& gpuSetti
     KERNEL_CALL_MOD(cudaTestRemoveUnreachableGenesFromRoot, NEURONS_PER_CELL, data, objectId);
 }
 
+void TestKernelsService::testOnly_removeGeneCycles(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId)
+{
+    KERNEL_CALL_MOD(cudaTestRemoveGeneCycles, NEURONS_PER_CELL, data, objectId);
+}
+
 void TestKernelsService::testOnly_createConnection(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId1, uint64_t objectId2)
 {
     KERNEL_CALL_1_1(cudaTestCreateConnection, data, objectId1, objectId2);

--- a/source/EngineImpl/TestKernelsService.cuh
+++ b/source/EngineImpl/TestKernelsService.cuh
@@ -16,6 +16,7 @@ public:
 
     void testOnly_mutate(CudaSettings const& gpuSettings, SimulationData const& data, SimulationStatistics const& statistics, uint64_t objectId);
     void testOnly_removeUnusedGenes(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId);
+    void testOnly_removeGeneCycles(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId);
     void testOnly_createConnection(CudaSettings const& gpuSettings, SimulationData const& data, uint64_t objectId1, uint64_t objectId2);
     void testOnly_createConnectionWithAbsAngle(
         CudaSettings const& gpuSettings,

--- a/source/EngineInterface/SimulationFacade.h
+++ b/source/EngineInterface/SimulationFacade.h
@@ -122,6 +122,7 @@ public:
     //****************
     virtual void testOnly_mutate(uint64_t objectId) = 0;
     virtual void testOnly_removeUnusedGenes(uint64_t objectId) = 0;
+    virtual void testOnly_removeGeneCycles(uint64_t objectId) = 0;
     virtual void testOnly_createConnection(uint64_t objectId1, uint64_t objectId2) = 0;
     virtual void
     testOnly_createConnectionWithAbsAngle(uint64_t objectId1, uint64_t objectId2, float desiredDistance, float desiredAbsAngle1, float desiredAbsAngle2) = 0;

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -239,6 +239,8 @@ __inline__ __device__ void ConstructorProcessor::mutateGenome(SimulationData& da
 
     if (clonedGenome != nullptr) {
         MutationProcessor::applyMutations(data, statistics, cell.creature, clonedGenome);
+        // Break cycles first: the constructors turned off there can render genes unreachable, which the following step removes.
+        MutationProcessor::removeCyclesNotThroughRoot(data, clonedGenome);
         MutationProcessor::removeUnreachableGenesFromRoot(data, clonedGenome);
         if (threadIdx.x == 0) {
             cell.creature->genome = clonedGenome;

--- a/source/EngineKernels/MutationProcessor.cuh
+++ b/source/EngineKernels/MutationProcessor.cuh
@@ -21,6 +21,7 @@ class MutationProcessor
 public:
     __inline__ __device__ static void applyMutations(SimulationData& data, SimulationStatistics& statistics, Creature* creature, Genome* genome);
     __inline__ __device__ static void removeUnreachableGenesFromRoot(SimulationData& data, Genome* genome);
+    __inline__ __device__ static void removeCyclesNotThroughRoot(SimulationData& data, Genome* genome);
 
 private:
     // Upper bound to avoid heap exhaustion.
@@ -1408,6 +1409,93 @@ __inline__ __device__ void MutationProcessor::removeUnreachableGenesFromRoot(Sim
 
         if (laneId == 0) {
             genome->numGenes = newNumGenes;
+        }
+    }
+    block.sync();
+}
+
+__inline__ __device__ void MutationProcessor::removeCyclesNotThroughRoot(SimulationData& data, Genome* genome)
+{
+    // The genes form a directed graph whose edges are the constructor references of their nodes. A cycle through the root gene is
+    // intended (constructing the root gene starts a new creature), while a cycle avoiding the root gene means unbounded
+    // construction within the same creature. Every cycle either contains the root gene or lies entirely within the remaining
+    // genes, so the requirement is exactly that the subgraph induced on the genes 1 .. numGenes - 1 is acyclic.
+    //
+    // A depth-first search over that subgraph detects and repairs this in one linear pass: a cycle exists if and only if the
+    // search finds a back edge, i.e. an edge onto a gene that is still on the DFS stack. Turning off the constructor of every
+    // back edge as it is found leaves an acyclic graph and only sacrifices the constructors that actually close a cycle.
+    auto block = cg_mutation::this_thread_block();
+    auto laneId = block.thread_rank();
+
+    __shared__ int numGenes;
+    if (laneId == 0) {
+        numGenes = genome->numGenes;
+    }
+    block.sync();
+    if (numGenes <= 1) {  // Uniform across the block, so the early return does not desync the cooperative group
+        return;
+    }
+
+    __shared__ int* state;  // 0 = not visited, 1 = on the DFS stack, 2 = finished
+    __shared__ int* stackGenes;
+    __shared__ int* stackNodeIndices;  // Next node of the gene on that stack level that still needs to be examined
+
+    if (laneId == 0) {
+        state = data.entities.heap.getTypedSubArray<int>(numGenes);
+        // A gene is pushed at most once because only genes in state 0 are pushed and they are marked immediately, so the DFS
+        // stack never holds more than numGenes entries.
+        stackGenes = data.entities.heap.getTypedSubArray<int>(numGenes);
+        stackNodeIndices = data.entities.heap.getTypedSubArray<int>(numGenes);
+    }
+    block.sync();
+
+    for (int geneIndex = laneId; geneIndex < numGenes; geneIndex += blockDim.x) {
+        state[geneIndex] = 0;
+    }
+    block.sync();
+
+    // The search is inherently sequential, but it visits every gene and every node only once, which is cheaper than the passes
+    // that already scan the genome per gene.
+    if (laneId == 0) {
+        // Marking the root gene as finished takes it out of the graph: edges into it are ignored and cycles through it are kept.
+        state[0] = 2;
+
+        for (int startGene = 1; startGene < numGenes; ++startGene) {
+            if (state[startGene] != 0) {
+                continue;
+            }
+            state[startGene] = 1;
+            stackGenes[0] = startGene;
+            stackNodeIndices[0] = 0;
+            int stackSize = 1;
+
+            while (stackSize > 0) {
+                auto& gene = genome->genes[stackGenes[stackSize - 1]];
+                auto nodeIndex = stackNodeIndices[stackSize - 1];
+                if (nodeIndex >= gene.numNodes) {
+                    state[stackGenes[stackSize - 1]] = 2;
+                    --stackSize;
+                    continue;
+                }
+                stackNodeIndices[stackSize - 1] = nodeIndex + 1;
+
+                auto& node = gene.nodes[nodeIndex];
+                if (!node.constructorAvailable) {
+                    continue;
+                }
+                auto targetGene = node.constructor.geneIndex;
+                if (state[targetGene] == 1) {
+                    // Back edge: the target is still on the stack, so this constructor closes a cycle avoiding the root gene.
+                    // A gene referencing itself is covered as well, since such a gene is on the stack while it is scanned.
+                    node.constructorAvailable = false;
+                } else if (state[targetGene] == 0) {
+                    state[targetGene] = 1;
+                    stackGenes[stackSize] = targetGene;
+                    stackNodeIndices[stackSize] = 0;
+                    ++stackSize;
+                }
+                // A finished target is a cross or forward edge and does not close a cycle.
+            }
         }
     }
     block.sync();

--- a/source/EngineKernels/TestKernels.cu
+++ b/source/EngineKernels/TestKernels.cu
@@ -58,6 +58,33 @@ __global__ void cudaTestRemoveUnreachableGenesFromRoot(SimulationData data, uint
     }
 }
 
+__global__ void cudaTestRemoveGeneCycles(SimulationData data, uint64_t objectId)
+{
+    DEVICE_CHECK(blockDim.x == NEURONS_PER_CELL);
+
+    auto block = cooperative_groups::this_thread_block();
+    auto laneId = block.thread_rank();
+
+    auto& objects = data.entities.objects;
+    auto partition = calcBlockPartition(objects.getNumEntries());
+
+    for (int index = partition.startIndex; index <= partition.endIndex; ++index) {
+        auto& object = objects.at(index);
+
+        __shared__ bool shouldProcess;
+        if (laneId == 0) {
+            DEVICE_CHECK(object->type == ObjectType_Cell);
+            shouldProcess = (object->id == objectId);
+        }
+        block.sync();
+
+        if (shouldProcess) {
+            MutationProcessor::removeCyclesNotThroughRoot(data, object->typeData.cell.creature->genome);
+        }
+        block.sync();
+    }
+}
+
 __global__ void cudaTestCreateConnection(SimulationData data, uint64_t objectId1, uint64_t objectId2)
 {
     DEVICE_CHECK(blockDim.x == 1 && gridDim.x == 1);

--- a/source/EngineKernels/TestKernels.cuh
+++ b/source/EngineKernels/TestKernels.cuh
@@ -8,6 +8,7 @@
 
 __global__ void cudaTestMutate(SimulationData data, SimulationStatistics statistics, uint64_t objectId);
 __global__ void cudaTestRemoveUnreachableGenesFromRoot(SimulationData data, uint64_t objectId);
+__global__ void cudaTestRemoveGeneCycles(SimulationData data, uint64_t objectId);
 __global__ void cudaTestCreateConnection(SimulationData data, uint64_t objectId1, uint64_t objectId2);
 __global__ void cudaTestCreateConnectionWithAbsAngle(
     SimulationData data,

--- a/source/EngineTests/CMakeLists.txt
+++ b/source/EngineTests/CMakeLists.txt
@@ -30,6 +30,7 @@ PUBLIC
     EnergyParticleTests.cpp
     HeadUpdateTests.cpp
     GarbageCollectorTests.cpp
+    GeneCycleRemovalTests.cpp
     GeneratorTests.cpp
     GeometryMutationTests.cpp
     GeometryTests.cpp

--- a/source/EngineTests/GeneCycleRemovalTests.cpp
+++ b/source/EngineTests/GeneCycleRemovalTests.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include <EngineInterface/Descs.h>
+#include <EngineInterface/SimulationFacade.h>
+
+#include "MutationTestsBase.h"
+
+class GeneCycleRemovalTests : public MutationTestsBase
+{
+protected:
+    // The constructor target of the node-th node of the given gene, or nullopt if that node has no constructor.
+    std::optional<int> getConstructorTarget(GenomeDesc const& genome, size_t geneIndex, size_t nodeIndex = 0) const
+    {
+        auto const& constructor = genome._genes.at(geneIndex)._nodes.at(nodeIndex)._constructor;
+        return constructor.has_value() ? std::make_optional(constructor->_geneIndex) : std::nullopt;
+    }
+};
+
+TEST_F(GeneCycleRemovalTests, breaksSelfReferencingGene)
+{
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(2, actualGenome._genes.size());
+    EXPECT_EQ(1, getConstructorTarget(actualGenome, 0));
+    EXPECT_EQ(std::nullopt, getConstructorTarget(actualGenome, 1));
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, breaksCycleBetweenTwoGenes)
+{
+    // Only the constructor closing the cycle (gene2 -> gene1) is removed, the chain gene0 -> gene1 -> gene2 stays intact.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(2))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(3, actualGenome._genes.size());
+    EXPECT_EQ(1, getConstructorTarget(actualGenome, 0));
+    EXPECT_EQ(2, getConstructorTarget(actualGenome, 1));
+    EXPECT_EQ(std::nullopt, getConstructorTarget(actualGenome, 2));
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, breaksSeveralIndependentCycles)
+{
+    // gene1 <-> gene2 and gene3 <-> gene4 are two cycles not reachable from the root gene; both must be broken.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc()}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(2))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(4))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(3))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    ASSERT_EQ(5, actualGenome._genes.size());
+    EXPECT_EQ(std::nullopt, getConstructorTarget(actualGenome, 0));
+    EXPECT_EQ(2, getConstructorTarget(actualGenome, 1));
+    EXPECT_EQ(std::nullopt, getConstructorTarget(actualGenome, 2));
+    EXPECT_EQ(4, getConstructorTarget(actualGenome, 3));
+    EXPECT_EQ(std::nullopt, getConstructorTarget(actualGenome, 4));
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, keepsCycleThroughRootGene)
+{
+    // Constructing the root gene starts a new creature, so a cycle running through it is intended.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(2))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(0))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, keepsSelfReferencingRootGene)
+{
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(0))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, keepsDiamondShapedReferences)
+{
+    // gene0 -> gene1 -> gene3 and gene0 -> gene2 -> gene3: gene3 is reached twice without any cycle, so nothing is removed.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({
+            NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1)),
+            NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(2)),
+        }),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(3))}),
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(3))}),
+        GeneDesc().nodes({NodeDesc()}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}
+
+TEST_F(GeneCycleRemovalTests, keepsCycleFormedByInjectorReference)
+{
+    // An injector's gene reference is a payload for a foreign creature, not part of this creature's own construction graph,
+    // so it cannot form a cycle.
+    auto genome = GenomeDesc().genes({
+        GeneDesc().nodes({NodeDesc().constructor(ConstructorGenomeDesc().geneIndex(1))}),
+        GeneDesc().nodes({NodeDesc().cellType(InjectorGenomeDesc().geneIndex(1))}),
+    });
+    auto data = ContentDesc().addCreature({ObjectDesc().id(1)}, CreatureDesc(), genome);
+
+    _simulationFacade->setSimulationData(data);
+    _simulationFacade->testOnly_removeGeneCycles(1);
+
+    auto actualGenome = getMutatedGenome();
+    EXPECT_EQ(genome, actualGenome);
+    EXPECT_TRUE(_simulationFacade->testOnly_isDataValid());
+}


### PR DESCRIPTION
## Problem

The genes of a genome form a directed graph: an edge A -> B means a node in gene A has a constructor referencing gene B. A cycle through the root gene (gene 0) is intended — constructing the root gene starts a new creature — but a cycle that avoids the root gene means unbounded construction within the same creature. Mutations could create such cycles.

## Solution

After every mutation, every cycle that does not run through the root gene is broken ("castration"): the constructor closing the cycle is turned off (`constructorAvailable = false`).

Every cycle either contains the root gene or lies entirely within genes `1 .. numGenes - 1`, so the requirement is exactly that the subgraph induced on those genes is acyclic. A depth-first search detects and repairs this in one pass in `O(numGenes + numNodes)` — cheaper than passes that already exist (e.g. `applyMutations_duplicateGene` calls `getNumGeneReferences()` per gene). No heuristic needed.

A cycle exists if and only if the search finds a back edge, i.e. an edge onto a gene that is still on the DFS stack. Turning off that constructor as the edge is found leaves an acyclic graph and only sacrifices the constructors that actually close a cycle — the rest of the reference chain is kept. A gene referencing itself is covered as well. The root gene is pre-marked as finished, which takes it out of the graph so cycles through it stay untouched. Injector references are not part of the construction graph and are ignored, consistent with `removeUnreachableGenesFromRoot()`.

## Changes

- `MutationProcessor::removeCyclesNotThroughRoot()`: iterative DFS on lane 0 with an explicit stack (three heap arrays of size `numGenes`), following the structure of `removeUnreachableGenesFromRoot()`
- Called from `ConstructorProcessor::mutateGenome()` between `applyMutations()` and `removeUnreachableGenesFromRoot()` — order matters, since the constructors turned off can render genes unreachable, which the following step removes
- New `testOnly_removeGeneCycles()` entry point mirroring `testOnly_removeUnusedGenes()`
- New `GeneCycleRemovalTests` with 7 cases: self-referencing gene, two-gene cycle, two independent cycles, cycle through the root gene, self-referencing root gene, diamond-shaped references (guards against cross/forward edges being mistaken for cycles), and an injector reference that would form a cycle

## Testing

- `EngineTests`: 3090 passed, 3 skipped (same pre-existing skips as on `develop`)
- `EngineInterfaceTests` 174, `NetworkTests` 4, `PersisterTests` 70 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)