### PR TITLE
Remove settings and statistics from server API and NetworkService

### DIFF
--- a/scripts/Server/main.py
+++ b/scripts/Server/main.py
@@ -115,7 +115,6 @@ class Simulation(Base):
     version: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
-    settings: Mapped[str] = mapped_column(Text, nullable=False)
     picture: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     num_downloads: Mapped[int] = mapped_column(Integer, nullable=False)
 
@@ -136,7 +135,6 @@ class Simulation(Base):
     )
 
     type: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    statistics: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class UserLike(Base):
@@ -1092,10 +1090,8 @@ async def upload_simulation(request: Request):
     height = _parse_int(_require_field(fields, "height"))
     particles = _parse_int(_require_field(fields, "particles"))
     version = _require_field(fields, "version")
-    settings = _require_field(fields, "settings")
     sim_type = _parse_int(fields.get("type", "0"))
     workspace = _parse_int(fields.get("workspace", "0"))
-    statistics = fields.get("statistics", "")
 
     with Session(engine) as session:
         with session.begin():
@@ -1120,13 +1116,11 @@ async def upload_simulation(request: Request):
                 version=version,
                 description=simDesc,
                 content=content_bytes,
-                settings=settings,
                 picture=b"",
                 num_downloads=0,
                 workspace=workspace,
                 size=len(content_bytes),
                 type=sim_type,
-                statistics=statistics,
             )
             session.add(sim)
             session.flush()
@@ -1150,8 +1144,6 @@ async def replace_simulation(request: Request):
     height = _parse_int(_require_field(fields, "height"))
     particles = _parse_int(_require_field(fields, "particles"))
     version = _require_field(fields, "version")
-    settings = _require_field(fields, "settings")
-    statistics = fields.get("statistics", "")
 
     sim_id = _parse_int(simId)
     notify_name: str | None = None
@@ -1186,9 +1178,7 @@ async def replace_simulation(request: Request):
             sim.content = content_bytes
             sim.width = width
             sim.height = height
-            sim.settings = settings
             sim.size = len(content_bytes)
-            sim.statistics = statistics
 
     if notify_workspace != _WORKSPACE_PRIVATE and notify_name is not None:
         _discord_notify_resource(
@@ -1224,23 +1214,6 @@ def download_content(id: str, chunkIndex: int = 0):
             )
             content = sim.content or b""
     return Response(content=bytes(content), media_type="application/octet-stream")
-
-
-@app.get("/downloadsettings")
-def download_settings(id: str):
-    sim_id = _parse_int(id)
-    with Session(engine) as session:
-        sim = session.get(Simulation, sim_id)
-        return Response(content=(sim.settings if sim is not None else "") or "", media_type="text/plain")
-
-
-@app.get("/downloadstatistics")
-def download_statistics(id: str):
-    sim_id = _parse_int(id)
-    with Session(engine) as session:
-        sim = session.get(Simulation, sim_id)
-        body = (sim.statistics if sim is not None else "") or ""
-    return Response(content=body, media_type="text/plain")
 
 
 @app.get("/incdownloadcount")

--- a/scripts/Server/tests/conftest.py
+++ b/scripts/Server/tests/conftest.py
@@ -141,8 +141,6 @@ def _upload_simulation(
     particles: int = 100,
     version: str = "1.0",
     content: bytes = b"\x00\x01\x02binary-payload",
-    settings: str = "{}",
-    statistics: str = "stats",
     sim_type: int = 0,
     workspace: int = 0,
 ):
@@ -156,10 +154,8 @@ def _upload_simulation(
         "particles": (None, str(particles)),
         "version": (None, version),
         "content": ("content.bin", content, "application/octet-stream"),
-        "settings": (None, settings),
         "type": (None, str(sim_type)),
         "workspace": (None, str(workspace)),
-        "statistics": (None, statistics),
     }
     return client.post("/uploadsimulation", files=files)
 

--- a/scripts/Server/tests/test_resources_api.py
+++ b/scripts/Server/tests/test_resources_api.py
@@ -24,8 +24,6 @@ def test_upload_simulation_persists_row_and_returns_sim_id(app_client, helpers):
         particles=200,
         version="2.0",
         content=b"\x00\x01\x02payload",
-        settings='{"k":1}',
-        statistics="stats-data",
         sim_type=0,
         workspace=0,
     )
@@ -46,8 +44,6 @@ def test_upload_simulation_persists_row_and_returns_sim_id(app_client, helpers):
         assert sim.version == "2.0"
         assert sim.description == "desc"
         assert bytes(sim.content) == b"\x00\x01\x02payload"
-        assert sim.settings == '{"k":1}'
-        assert sim.statistics == "stats-data"
         assert sim.size == len(b"\x00\x01\x02payload")
         assert sim.workspace == 0
         assert sim.type == 0
@@ -94,8 +90,6 @@ def test_replace_simulation_updates_owner_resource(app_client, helpers):
             "particles": (None, "1234"),
             "version": (None, "9.9"),
             "content": ("content.bin", b"NEW", "application/octet-stream"),
-            "settings": (None, "new-settings"),
-            "statistics": (None, "new-stats"),
         },
     )
     assert resp.json() == {"result": True}
@@ -108,8 +102,6 @@ def test_replace_simulation_updates_owner_resource(app_client, helpers):
         assert sim.height == 50
         assert sim.particles == 1234
         assert sim.version == "9.9"
-        assert sim.settings == "new-settings"
-        assert sim.statistics == "new-stats"
         assert sim.size == 3
 
 
@@ -130,14 +122,12 @@ def test_replace_simulation_rejects_non_owner(app_client, helpers):
             "particles": (None, "1"),
             "version": (None, "v"),
             "content": ("content.bin", b"X", "application/octet-stream"),
-            "settings": (None, "s"),
-            "statistics": (None, "x"),
         },
     )
     assert resp.json() == {"result": False}
 
 
-# --- /downloadcontent, /downloadsettings, /downloadstatistics ----------------
+# --- /downloadcontent --------------------------------------------------------
 def test_download_endpoints_return_content_and_increment_counter(
     app_client, helpers
 ):
@@ -148,8 +138,6 @@ def test_download_endpoints_return_content_and_increment_counter(
             "alice",
             "pw",
             content=b"raw-bytes",
-            settings="my-settings",
-            statistics="my-stats",
         ).json()["simId"]
     )
 
@@ -163,13 +151,6 @@ def test_download_endpoints_return_content_and_increment_counter(
     )
     assert resp.status_code == 200
     assert resp.content == b""
-
-    assert app_client.get(
-        "/downloadsettings", params={"id": str(sim_id)}
-    ).text == "my-settings"
-    assert app_client.get(
-        "/downloadstatistics", params={"id": str(sim_id)}
-    ).text == "my-stats"
 
     # Each call to /downloadcontent with chunkIndex==0 increments num_downloads.
     main = app_client.app_module

--- a/source/Network/NetworkService.cpp
+++ b/source/Network/NetworkService.cpp
@@ -463,10 +463,6 @@ bool NetworkService::uploadResource(
         {"content", mainData, "content.bin", "application/octet-stream"},
         {"type", std::to_string(resourceType), "", ""},
         {"workspace", std::to_string(workspaceType), "", ""},
-
-        // Obsolete fields, kept for server compatibility
-        {"settings", "", "", ""},
-        {"statistics", "", "", ""},
     };
 
     try {
@@ -500,10 +496,6 @@ bool NetworkService::replaceResource(std::string const& resourceId, IntVector2D 
         {"particles", std::to_string(numObjects), "", ""},
         {"version", Const::ProgramVersion, "", ""},
         {"content", mainData, "content.bin", "application/octet-stream"},
-
-        // Obsolete fields, kept for server compatibility
-        {"settings", "", "", ""},
-        {"statistics", "", "", ""},
     };
 
     try {


### PR DESCRIPTION
Since simulations are serialized into a single sim file, the separate settings and statistics payloads no longer exist. The client still sent empty strings for them and the server still stored them.

## Changes

**Server (`scripts/Server/main.py`)**
- Drop the `settings` and `statistics` columns from the `Simulation` model, so new databases no longer create them.
- `/uploadsimulation` and `/replacesimulation` no longer read or store those fields. `settings` was a required form field before; removing it keeps older clients working, since unknown form fields are ignored anyway.
- Remove the `/downloadsettings` and `/downloadstatistics` endpoints. They had no caller in the client.

**Client (`source/Network/NetworkService.cpp`)**
- Remove the empty placeholder fields from `uploadResource` and `replaceResource`.

**Tests**
- Adapt the upload helper and the resource API tests; the download test now covers `/downloadcontent` only.

## Notes

No database migration is included, as agreed. An existing production database keeps both columns physically, and `settings` is `NOT NULL` without a default there, so inserts from the new code would fail against it. If the live database is kept, it needs:

```sql
ALTER TABLE simulations DROP COLUMN settings, DROP COLUMN statistics;
```

## Testing

- `NetworkTests.exe` (4), `EngineInterfaceTests.exe` (174), `PersisterTests.exe` (70) all pass.
- The Python server tests were **not** run: no Python interpreter is available on the development machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)