### PR TITLE
Fix dead zone when dragging the evolution dashboard separator back

### DIFF
--- a/source/Gui/EvolutionDashboardWindow.cpp
+++ b/source/Gui/EvolutionDashboardWindow.cpp
@@ -47,6 +47,9 @@ namespace
     auto constexpr MaxPlotHeight = 300.0f;
     auto constexpr TimeAxisExtraHeight = 20.0f;
     auto constexpr DefaultTimelinesHeight = 380.0f;
+    auto constexpr MinTimelinesHeight = 100.0f;
+    auto constexpr MinLineageTableHeight = 40.0f;
+    auto constexpr SeparatorHeight = 5.0f;  // Height of AlienGui::MovableHorizontalSeparator
 
     ImColor const CardBackgroundColor = ImColor(0.095f, 0.117f, 0.165f, 1.0f);
     ImColor const CardBorderColor = ImColor(0.165f, 0.196f, 0.270f, 1.0f);
@@ -394,6 +397,7 @@ void EvolutionDashboardWindow::processIntern()
     updateDisplayData();
     processHeader();
     processFilterBar();
+    limitTimelinesHeight();
 
     if (ImGui::BeginChild("##lineageTable", {0, -_timelinesHeight})) {
         processLineageTable();
@@ -795,6 +799,15 @@ void EvolutionDashboardWindow::processFilterBar()
     }
     ImGui::NewLine();
     ImGui::Spacing();
+}
+
+void EvolutionDashboardWindow::limitTimelinesHeight()
+{
+    // The separator can only be dragged as far as the sections can actually shrink. Without clamping here, the height would keep
+    // accumulating invisibly and the separator would not react until the same distance has been dragged back.
+    auto minHeight = scale(MinTimelinesHeight);
+    auto maxHeight = std::max(minHeight, ImGui::GetContentRegionAvail().y - scale(MinLineageTableHeight + SeparatorHeight));
+    _timelinesHeight = std::clamp(_timelinesHeight, minHeight, maxHeight);
 }
 
 void EvolutionDashboardWindow::processLineageTable()
@@ -1250,7 +1263,7 @@ void EvolutionDashboardWindow::drawValuesAtMouseCursor(
 
 void EvolutionDashboardWindow::validateAndCorrect()
 {
-    _timelinesHeight = std::max(scale(100.0f), _timelinesHeight);
+    _timelinesHeight = std::max(scale(MinTimelinesHeight), _timelinesHeight);
     _timelineMode = std::clamp(_timelineMode, static_cast<TimelineMode>(TimelineMode_RealTime), static_cast<TimelineMode>(TimelineMode_EntireHistory));
     _lastSteps = std::clamp(_lastSteps, 1000, LiveStatisticsService::MaxLiveSteps);
     _timeHorizon = std::clamp(_timeHorizon, 1.0f, LiveStatisticsService::MaxLiveHistory);

--- a/source/Gui/EvolutionDashboardWindow.h
+++ b/source/Gui/EvolutionDashboardWindow.h
@@ -50,6 +50,7 @@ private:
         float width,
         float height);
     void processFilterBar();
+    void limitTimelinesHeight();
     void processLineageTable();
     void onOpenRepresentativeGenome(uint64_t cellId);
     void processTimelineSection();


### PR DESCRIPTION
## Problem

Dragging the movable separator in the evolution dashboard far up stops the visible movement, but `_timelinesHeight` keeps growing: ImGui clamps the lineage table child to a 4 px minimum while the value accumulates. Dragging back down then does nothing until the same distance has been travelled again — it feels like the separator is stuck.

## Fix

`limitTimelinesHeight()` clamps `_timelinesHeight` every frame to what the layout can actually show: at least `MinTimelinesHeight` (100), at most `available height - (MinLineageTableHeight + SeparatorHeight)`. The value can no longer run past the visible limit, so the separator reacts immediately in both directions. The mirrored dead zone at the lower end is gone as well.

## Test

- Full Release build (`build-windows-ninja.bat 16`) succeeds.
- `EngineInterfaceTests` (174), `NetworkTests` (4), `PersisterTests` (70) pass. GUI-only change, so `EngineTests` was not run.
- clang-format 19.1.5 clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)