### PR TITLE
Speed up the simulation kernels

### DIFF
--- a/source/Base/Resources.h
+++ b/source/Base/Resources.h
@@ -4,7 +4,7 @@
 
 namespace Const
 {
-    std::string const ProgramVersion = "5.0.0-alpha.24";
+    std::string const ProgramVersion = "5.0.0-alpha.25";
     std::string const DiscordURL = "https://discord.gg/7bjyZdXXQ2";
     std::string const AlienServerURL = "api.alien-project.org";
 

--- a/source/Cli/Main.cpp
+++ b/source/Cli/Main.cpp
@@ -84,7 +84,6 @@ int main(int argc, char** argv)
         std::cout << "Device: " << simulationFacade->getGpuName() << std::endl;
         std::cout << "Start simulation" << std::endl;
 
-        // Measure the simulation loop only: loading and uploading the data would otherwise distort the TPS
         auto startTimepoint = std::chrono::steady_clock::now();
         simulationFacade->calcTimesteps(timesteps);
 

--- a/source/Cli/Main.cpp
+++ b/source/Cli/Main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char** argv)
         std::cout << "Device: " << simulationFacade->getGpuName() << std::endl;
         std::cout << "Start simulation" << std::endl;
 
+        // Measure the simulation loop only: loading and uploading the data would otherwise distort the TPS
         auto startTimepoint = std::chrono::steady_clock::now();
         simulationFacade->calcTimesteps(timesteps);
 

--- a/source/Cli/Main.cpp
+++ b/source/Cli/Main.cpp
@@ -76,8 +76,6 @@ int main(int argc, char** argv)
         }
 
         // Run simulation
-        auto startTimepoint = std::chrono::steady_clock::now();
-
         auto simulationFacade = std::make_shared<_SimulationFacadeImpl>();
         simulationFacade->newSimulation(simData._timestep, simData._worldSize, simData._simulationParameters);
         simulationFacade->setSimulationData(simData._mainData);
@@ -86,6 +84,8 @@ int main(int argc, char** argv)
         std::cout << "Device: " << simulationFacade->getGpuName() << std::endl;
         std::cout << "Start simulation" << std::endl;
 
+        // Measure the simulation loop only: loading and uploading the data would otherwise distort the TPS
+        auto startTimepoint = std::chrono::steady_clock::now();
         simulationFacade->calcTimesteps(timesteps);
 
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTimepoint).count();

--- a/source/EngineKernels/CellProcessor.cuh
+++ b/source/EngineKernels/CellProcessor.cuh
@@ -262,11 +262,6 @@ __inline__ __device__ void CellProcessor::performEnergyFlow(SimulationData& data
     auto& objects = data.entities.objects;
     auto partition = calcSystemThreadPartition(objects.getNumEntries());
 
-    // Every possible connection count divides 60, so reducing the timestep modulo 60 up front yields the same
-    // connection index while replacing a 64 bit division per cell by a 32 bit one
-    static_assert(MAX_OBJECT_CONNECTIONS <= 6, "60 must stay a multiple of every possible connection count");
-    auto const timestepMod = toInt(*data.timestep % 60);
-
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
         if (object->type != ObjectType_Cell) {
@@ -278,7 +273,7 @@ __inline__ __device__ void CellProcessor::performEnergyFlow(SimulationData& data
         //if (object->typeData.cell.cellState == CellState_Constructing || object->typeData.cell.cellState == CellState_Activating) {
         //    continue;
         //}
-        auto i = timestepMod % object->numConnections;
+        auto i = *data.timestep % object->numConnections;
         auto& connectedObject = object->connections[i].object;
         // Skip if connected object is not a Cell
         if (connectedObject->type != ObjectType_Cell) {

--- a/source/EngineKernels/CellProcessor.cuh
+++ b/source/EngineKernels/CellProcessor.cuh
@@ -262,6 +262,11 @@ __inline__ __device__ void CellProcessor::performEnergyFlow(SimulationData& data
     auto& objects = data.entities.objects;
     auto partition = calcSystemThreadPartition(objects.getNumEntries());
 
+    // Every possible connection count divides 60, so reducing the timestep modulo 60 up front yields the same
+    // connection index while replacing a 64 bit division per cell by a 32 bit one
+    static_assert(MAX_OBJECT_CONNECTIONS <= 6, "60 must stay a multiple of every possible connection count");
+    auto const timestepMod = toInt(*data.timestep % 60);
+
     for (int index = partition.startIndex; index <= partition.endIndex; index += partition.step) {
         auto& object = objects.at(index);
         if (object->type != ObjectType_Cell) {
@@ -273,7 +278,7 @@ __inline__ __device__ void CellProcessor::performEnergyFlow(SimulationData& data
         //if (object->typeData.cell.cellState == CellState_Constructing || object->typeData.cell.cellState == CellState_Activating) {
         //    continue;
         //}
-        auto i = *data.timestep % object->numConnections;
+        auto i = timestepMod % object->numConnections;
         auto& connectedObject = object->connections[i].object;
         // Skip if connected object is not a Cell
         if (connectedObject->type != ObjectType_Cell) {

--- a/source/EngineKernels/DensityMap.cuh
+++ b/source/EngineKernels/DensityMap.cuh
@@ -5,14 +5,17 @@
 class DensityMap
 {
 public:
-    __host__ __inline__ void init(int2 const& worldSize, int slotSize)
+    // Compile-time constant so that the slot lookups below become shifts instead of integer divisions,
+    // which are emulated in software on the GPU and sit in the sensor's ray marching
+    static int constexpr SlotSize = 8;
+
+    __host__ __inline__ void init(int2 const& worldSize)
     {
-        _densityMapSize = {worldSize.x / slotSize, worldSize.y / slotSize};
+        _densityMapSize = {worldSize.x / SlotSize, worldSize.y / SlotSize};
         CudaMemoryManager::getInstance().acquireMemory<float>(_densityMapSize.x * _densityMapSize.y, _energyParticleDensityMap);
         CudaMemoryManager::getInstance().acquireMemory<uint64_t>(_densityMapSize.x * _densityMapSize.y, _freeCellDensityMap1);
         CudaMemoryManager::getInstance().acquireMemory<uint64_t>(_densityMapSize.x * _densityMapSize.y, _freeCellDensityMap2);
         CudaMemoryManager::getInstance().acquireMemory<uint32_t>(_densityMapSize.x * _densityMapSize.y, _solidDensityMap);
-        _slotSize = slotSize;
     }
 
     __host__ __inline__ void free()
@@ -36,9 +39,9 @@ public:
 
     __device__ __inline__ float getEnergyParticleDensity(float2 const& pos) const
     {
-        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
-            auto slotSizeAsFlot = toFloat(_slotSize);
+            auto slotSizeAsFlot = toFloat(SlotSize);
             return _energyParticleDensityMap[index] / (slotSizeAsFlot * slotSizeAsFlot);
         }
         return 0.0f;
@@ -46,9 +49,9 @@ public:
 
     __device__ __inline__ float getFreeCellDensity(float2 const& pos, uint16_t restrictToColors) const
     {
-        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
-            auto slotSizeAsFlot = toFloat(_slotSize);
+            auto slotSizeAsFlot = toFloat(SlotSize);
             if (restrictToColors == 0x3ff) {
                 auto totalCount = (_freeCellDensityMap2[index] >> 16) & 0xff;
                 return toFloat(totalCount) / (slotSizeAsFlot * slotSizeAsFlot);
@@ -71,7 +74,7 @@ public:
 
     __device__ __inline__ uint32_t getSolidDensity(float2 const& pos) const
     {
-        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             return _solidDensityMap[index];
         }
@@ -80,7 +83,7 @@ public:
 
     __device__ __inline__ void addParticle(Energy* particle)
     {
-        auto index = toInt(particle->pos.x) / _slotSize + toInt(particle->pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(particle->pos.x) / SlotSize + toInt(particle->pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             atomicAdd(&_energyParticleDensityMap[index], particle->energy);
         }
@@ -88,7 +91,7 @@ public:
 
     __device__ __inline__ void addFreeCell(Object* object)
     {
-        auto index = toInt(object->pos.x) / _slotSize + toInt(object->pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(object->pos.x) / SlotSize + toInt(object->pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             auto color = calcMod(object->color, MAX_COLORS);
             if (color < 8) {
@@ -102,14 +105,13 @@ public:
 
     __device__ __inline__ void addSolidObject(Object* object)
     {
-        auto index = toInt(object->pos.x) / _slotSize + toInt(object->pos.y) / _slotSize * _densityMapSize.x;
+        auto index = toInt(object->pos.x) / SlotSize + toInt(object->pos.y) / SlotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             atomicAdd(&_solidDensityMap[index], 1u);
         }
     }
 
 private:
-    int _slotSize;
     int2 _densityMapSize;
     float* _energyParticleDensityMap;
     uint64_t* _freeCellDensityMap1;

--- a/source/EngineKernels/DensityMap.cuh
+++ b/source/EngineKernels/DensityMap.cuh
@@ -5,17 +5,14 @@
 class DensityMap
 {
 public:
-    // Compile-time constant so that the slot lookups below become shifts instead of integer divisions,
-    // which are emulated in software on the GPU and sit in the sensor's ray marching
-    static int constexpr SlotSize = 8;
-
-    __host__ __inline__ void init(int2 const& worldSize)
+    __host__ __inline__ void init(int2 const& worldSize, int slotSize)
     {
-        _densityMapSize = {worldSize.x / SlotSize, worldSize.y / SlotSize};
+        _densityMapSize = {worldSize.x / slotSize, worldSize.y / slotSize};
         CudaMemoryManager::getInstance().acquireMemory<float>(_densityMapSize.x * _densityMapSize.y, _energyParticleDensityMap);
         CudaMemoryManager::getInstance().acquireMemory<uint64_t>(_densityMapSize.x * _densityMapSize.y, _freeCellDensityMap1);
         CudaMemoryManager::getInstance().acquireMemory<uint64_t>(_densityMapSize.x * _densityMapSize.y, _freeCellDensityMap2);
         CudaMemoryManager::getInstance().acquireMemory<uint32_t>(_densityMapSize.x * _densityMapSize.y, _solidDensityMap);
+        _slotSize = slotSize;
     }
 
     __host__ __inline__ void free()
@@ -39,9 +36,9 @@ public:
 
     __device__ __inline__ float getEnergyParticleDensity(float2 const& pos) const
     {
-        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
-            auto slotSizeAsFlot = toFloat(SlotSize);
+            auto slotSizeAsFlot = toFloat(_slotSize);
             return _energyParticleDensityMap[index] / (slotSizeAsFlot * slotSizeAsFlot);
         }
         return 0.0f;
@@ -49,9 +46,9 @@ public:
 
     __device__ __inline__ float getFreeCellDensity(float2 const& pos, uint16_t restrictToColors) const
     {
-        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
-            auto slotSizeAsFlot = toFloat(SlotSize);
+            auto slotSizeAsFlot = toFloat(_slotSize);
             if (restrictToColors == 0x3ff) {
                 auto totalCount = (_freeCellDensityMap2[index] >> 16) & 0xff;
                 return toFloat(totalCount) / (slotSizeAsFlot * slotSizeAsFlot);
@@ -74,7 +71,7 @@ public:
 
     __device__ __inline__ uint32_t getSolidDensity(float2 const& pos) const
     {
-        auto index = toInt(pos.x) / SlotSize + toInt(pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(pos.x) / _slotSize + toInt(pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             return _solidDensityMap[index];
         }
@@ -83,7 +80,7 @@ public:
 
     __device__ __inline__ void addParticle(Energy* particle)
     {
-        auto index = toInt(particle->pos.x) / SlotSize + toInt(particle->pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(particle->pos.x) / _slotSize + toInt(particle->pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             atomicAdd(&_energyParticleDensityMap[index], particle->energy);
         }
@@ -91,7 +88,7 @@ public:
 
     __device__ __inline__ void addFreeCell(Object* object)
     {
-        auto index = toInt(object->pos.x) / SlotSize + toInt(object->pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(object->pos.x) / _slotSize + toInt(object->pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             auto color = calcMod(object->color, MAX_COLORS);
             if (color < 8) {
@@ -105,13 +102,14 @@ public:
 
     __device__ __inline__ void addSolidObject(Object* object)
     {
-        auto index = toInt(object->pos.x) / SlotSize + toInt(object->pos.y) / SlotSize * _densityMapSize.x;
+        auto index = toInt(object->pos.x) / _slotSize + toInt(object->pos.y) / _slotSize * _densityMapSize.x;
         if (index >= 0 && index < _densityMapSize.x * _densityMapSize.y) {
             atomicAdd(&_solidDensityMap[index], 1u);
         }
     }
 
 private:
+    int _slotSize;
     int2 _densityMapSize;
     float* _energyParticleDensityMap;
     uint64_t* _freeCellDensityMap1;

--- a/source/EngineKernels/DensityMap.cuh
+++ b/source/EngineKernels/DensityMap.cuh
@@ -5,9 +5,7 @@
 class DensityMap
 {
 public:
-    // Compile-time constant so that the slot lookups below become shifts instead of integer divisions,
-    // which are emulated in software on the GPU and sit in the sensor's ray marching
-    static int constexpr SlotSize = 8;
+N    static int constexpr SlotSize = 8;
 
     __host__ __inline__ void init(int2 const& worldSize)
     {

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -495,9 +495,7 @@ struct FreeCell
 
 struct Cell
 {
-    // Scalars the per-timestep kernels touch, grouped into the leading cache lines. Everything behind
-    // cellTypeData is several hundred bytes away, so process data such as the head update and the future
-    // neural activity must not be placed there.
+    // Members are ordered for cache optimization
     float usableEnergy;
     float rawEnergy;
     float frontAngle;  // May be invalid
@@ -557,8 +555,7 @@ union ObjectTypeData
 
 struct Object
 {
-    // Hot fields first to keep them in one cache line. The accumulators tempValue1 and tempValue2 belong here
-    // too: the physics kernels read them together with pos and vel, so they must not land in a separate sector.
+    // Members are ordered for cache optimization
     float2 pos;
     float2 vel;
     float density;

--- a/source/EngineKernels/Entities.cuh
+++ b/source/EngineKernels/Entities.cuh
@@ -495,43 +495,42 @@ struct FreeCell
 
 struct Cell
 {
-    // General
+    // Scalars the per-timestep kernels touch, grouped into the leading cache lines. Everything behind
+    // cellTypeData is several hundred bytes away, so process data such as the head update and the future
+    // neural activity must not be placed there.
     float usableEnergy;
     float rawEnergy;
     float frontAngle;  // May be invalid
     uint32_t age;
     CellState cellState;
+    uint32_t activationTime;
+    uint32_t headUpdateId;
+    uint32_t concatenationIndex;
 
-    // Creature/genome data
-    Creature* creature;
     uint16_t nodeIndex;
     uint16_t parentNodeIndex;
     uint16_t geneIndex;
-    uint32_t concatenationIndex;
     uint8_t branchIndex;
-
-    // Neural network data
-    NeuralNet* neuralNetwork;
-    NeuralActivity neuralActivity;
-
-    // Cell type data
-    CellType cellType;
-    CellTypeData cellTypeData;
-    bool constructorAvailable;  // If true, constructor holds valid data
-    Constructor constructor;    // Optional constructor data
-    uint32_t activationTime;
     uint8_t lastUpdate;  // Timestep since last head update, cell will die if it exceeds threshold
-
-    // Process data
-    NeuralActivity futureNeuralActivity;
-    uint32_t headUpdateId;
     bool headCell;
+    bool constructorAvailable;  // If true, constructor holds valid data
+    CellType cellType;
+
+    Creature* creature;
+    NeuralNet* neuralNetwork;
+
+    NeuralActivity neuralActivity;
+    NeuralActivity futureNeuralActivity;
 
     // Events
     CellEvent event;
     uint8_t eventCounter;
-    float2 eventPos;
     uint8_t highlightIntensity;
+    float2 eventPos;
+
+    // Cell type data
+    CellTypeData cellTypeData;
+    Constructor constructor;  // Optional constructor data
 
     __device__ __inline__ bool isSameCreature(Cell* otherCell) { return otherCell->creature->id == this->creature->id; }
 
@@ -558,7 +557,8 @@ union ObjectTypeData
 
 struct Object
 {
-    // Hot fields first to keep them in one cache line.
+    // Hot fields first to keep them in one cache line. The accumulators tempValue1 and tempValue2 belong here
+    // too: the physics kernels read them together with pos and vel, so they must not land in a separate sector.
     float2 pos;
     float2 vel;
     float density;
@@ -569,7 +569,12 @@ struct Object
     uint8_t color;
     uint8_t selected;  // 0 = no, 1 = selected, 2 = cluster selected
     uint8_t flags;     // bit0 = isStatic, bit1 = detached, bit2 = sticky
-    int locked;        // 0 = unlocked, 1 = locked
+
+    // Internal algorithm data
+    TempValue tempValue1;
+    TempValue tempValue2;
+
+    int locked;  // 0 = unlocked, 1 = locked
 
     // General
     uint64_t id;
@@ -582,10 +587,6 @@ struct Object
     __device__ __inline__ void setStatic(bool value) { flags = value ? (flags | 1) : (flags & ~1); }
     __device__ __inline__ void setDetached(bool value) { flags = value ? (flags | 2) : (flags & ~2); }
     __device__ __inline__ void setSticky(bool value) { flags = value ? (flags | 4) : (flags & ~4); }
-
-    // Internal algorithm data
-    TempValue tempValue1;
-    TempValue tempValue2;
 
     ObjectTypeData typeData;
 

--- a/source/EngineKernels/ForceFieldKernels.cu
+++ b/source/EngineKernels/ForceFieldKernels.cu
@@ -76,20 +76,20 @@ namespace
 
 __global__ void cudaApplyForceFields(SimulationData data)
 {
-    float2 accelerations[MAX_LAYERS];
-    bool enabled[MAX_LAYERS];
+    auto const timestep = *data.timestep;
 
+    // The per-layer accelerations are blended in layer order, so they are accumulated on the fly. Keeping
+    // them in a MAX_LAYERS array would put them into local memory, since the index is not a compile-time constant.
     auto calcResultingAcceleration = [&](float2 const& pos, float const& mass) {
-        auto timestep = *data.timestep;
+        float2 result{0, 0};
         for (int i = 0; i < cudaSimulationParameters.numLayers; ++i) {
-            enabled[i] = cudaSimulationParameters.layerForceFieldType.layerValues[i].enabled;
-            if (enabled[i]) {
-                accelerations[i] = calcAcceleration(data.objectMap, pos, mass, i, timestep);
-            } else {
-                accelerations[i] = {0, 0};
+            if (!cudaSimulationParameters.layerForceFieldType.layerValues[i].enabled) {
+                continue;
             }
+            auto acceleration = calcAcceleration(data.objectMap, pos, mass, i, timestep);
+            result = ParameterCalculator::blendLayerValue(result, acceleration, data, pos, i);
         }
-        return ParameterCalculator::calcParameter(float2{0, 0}, accelerations, enabled, data, pos);
+        return result;
     };
     {
         auto& objects = data.entities.objects;

--- a/source/EngineKernels/ForceFieldKernels.cu
+++ b/source/EngineKernels/ForceFieldKernels.cu
@@ -78,8 +78,6 @@ __global__ void cudaApplyForceFields(SimulationData data)
 {
     auto const timestep = *data.timestep;
 
-    // The per-layer accelerations are blended in layer order, so they are accumulated on the fly. Keeping
-    // them in a MAX_LAYERS array would put them into local memory, since the index is not a compile-time constant.
     auto calcResultingAcceleration = [&](float2 const& pos, float const& mass) {
         float2 result{0, 0};
         for (int i = 0; i < cudaSimulationParameters.numLayers; ++i) {

--- a/source/EngineKernels/ForceFieldKernels.cu
+++ b/source/EngineKernels/ForceFieldKernels.cu
@@ -76,20 +76,20 @@ namespace
 
 __global__ void cudaApplyForceFields(SimulationData data)
 {
-    auto const timestep = *data.timestep;
+    float2 accelerations[MAX_LAYERS];
+    bool enabled[MAX_LAYERS];
 
-    // The per-layer accelerations are blended in layer order, so they are accumulated on the fly. Keeping
-    // them in a MAX_LAYERS array would put them into local memory, since the index is not a compile-time constant.
     auto calcResultingAcceleration = [&](float2 const& pos, float const& mass) {
-        float2 result{0, 0};
+        auto timestep = *data.timestep;
         for (int i = 0; i < cudaSimulationParameters.numLayers; ++i) {
-            if (!cudaSimulationParameters.layerForceFieldType.layerValues[i].enabled) {
-                continue;
+            enabled[i] = cudaSimulationParameters.layerForceFieldType.layerValues[i].enabled;
+            if (enabled[i]) {
+                accelerations[i] = calcAcceleration(data.objectMap, pos, mass, i, timestep);
+            } else {
+                accelerations[i] = {0, 0};
             }
-            auto acceleration = calcAcceleration(data.objectMap, pos, mass, i, timestep);
-            result = ParameterCalculator::blendLayerValue(result, acceleration, data, pos, i);
         }
-        return result;
+        return ParameterCalculator::calcParameter(float2{0, 0}, accelerations, enabled, data, pos);
     };
     {
         auto& objects = data.entities.objects;

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -58,11 +58,6 @@ public:
     __inline__ __device__ int getMaxRadius() const { return min(_size.x, _size.y) / 4; }
 
 protected:
-    // Integer division and remainderf are emulated in software on the GPU and both sit in the innermost
-    // loops of the neighborhood scans, so the torus wrapping avoids them.
-
-    // Equivalent to ((value % size) + size) % size, with a fast path for the single wrap step that covers
-    // every neighborhood scan and every position update
     __inline__ __host__ __device__ static int wrapCoordinate(int value, int size)
     {
         if (value < 0) {

--- a/source/EngineKernels/Map.cuh
+++ b/source/EngineKernels/Map.cuh
@@ -7,12 +7,14 @@
 class BaseMap
 {
 public:
-    __inline__ __host__ __device__ void init(int2 const& size) { _size = size; }
-
-    __inline__ __host__ __device__ void correctPosition(int2& pos) const
+    __inline__ __host__ __device__ void init(int2 const& size)
     {
-        pos = {((pos.x % _size.x) + _size.x) % _size.x, ((pos.y % _size.y) + _size.y) % _size.y};
+        _size = size;
+        _sizeFloat = {toFloat(size.x), toFloat(size.y)};
+        _invSizeFloat = {1.0f / _sizeFloat.x, 1.0f / _sizeFloat.y};
     }
+
+    __inline__ __host__ __device__ void correctPosition(int2& pos) const { pos = {wrapCoordinate(pos.x, _size.x), wrapCoordinate(pos.y, _size.y)}; }
 
     __inline__ __host__ __device__ void correctPosition(float2& pos) const
     {
@@ -31,13 +33,13 @@ public:
 
     __inline__ __device__ void correctDirection(float2& disp) const
     {
-        disp.x = remainderf(disp.x, toFloat(_size.x));
-        disp.y = remainderf(disp.y, toFloat(_size.y));
+        disp.x = wrapDisplacement(disp.x, _sizeFloat.x, _invSizeFloat.x);
+        disp.y = wrapDisplacement(disp.y, _sizeFloat.y, _invSizeFloat.y);
     }
 
     __inline__ __device__ float2 getCorrectedDirection(float2 const& disp) const
     {
-        return {remainderf(disp.x, toFloat(_size.x)), remainderf(disp.y, toFloat(_size.y))};
+        return {wrapDisplacement(disp.x, _sizeFloat.x, _invSizeFloat.x), wrapDisplacement(disp.y, _sizeFloat.y, _invSizeFloat.y)};
     }
 
     __inline__ __device__ float getDistance(float2 const& p, float2 const& q) const
@@ -56,7 +58,30 @@ public:
     __inline__ __device__ int getMaxRadius() const { return min(_size.x, _size.y) / 4; }
 
 protected:
+    // Integer division and remainderf are emulated in software on the GPU and both sit in the innermost
+    // loops of the neighborhood scans, so the torus wrapping avoids them.
+
+    // Equivalent to ((value % size) + size) % size, with a fast path for the single wrap step that covers
+    // every neighborhood scan and every position update
+    __inline__ __host__ __device__ static int wrapCoordinate(int value, int size)
+    {
+        if (value < 0) {
+            value += size;
+            return value >= 0 ? value : ((value % size) + size) % size;
+        }
+        if (value >= size) {
+            value -= size;
+            return value < size ? value : value % size;
+        }
+        return value;
+    }
+
+    // Minimum image convention, equivalent to remainderf(disp, size)
+    __inline__ __device__ static float wrapDisplacement(float disp, float size, float invSize) { return fmaf(-size, rintf(disp * invSize), disp); }
+
     int2 _size;
+    float2 _sizeFloat;
+    float2 _invSizeFloat;
 };
 
 class ObjectMap : public BaseMap

--- a/source/EngineKernels/Math.cuh
+++ b/source/EngineKernels/Math.cuh
@@ -162,12 +162,11 @@ __inline__ __device__ float2 Math::unitVectorOfAngle(float angle)
 
 __inline__ __device__ float Math::angleOfVector(float2 const& v)
 {
-    auto lengthOfVector = length(v);
-    if (lengthOfVector < NEAR_ZERO) {
+    if (length(v) < NEAR_ZERO) {
         return 0;
     }
 
-    auto normalizedVy = -v.y / lengthOfVector;
+    auto normalizedVy = -v.y / length(v);
     normalizedVy = max(-1.0f, min(1.0f, normalizedVy));
     float angleSin = asinf(normalizedVy) * Const::RAD_TO_DEG;
     if (v.x >= 0.0f) {
@@ -414,14 +413,7 @@ __inline__ __device__ bool Math::crossing(float2 const& segmentStart, float2 con
 
 __inline__ __device__ float Math::modulo(float value, float boundary)
 {
-    // fmodf is emulated in software, whereas floorf and the division are single instructions
-    auto result = value - boundary * floorf(value / boundary);
-    if (result < 0.0f) {
-        result += boundary;
-    } else if (result >= boundary) {
-        result -= boundary;
-    }
-    return result;
+    return fmodf(fmodf(value, boundary) + boundary, boundary);
 }
 
 __inline__ __device__ float3 Math::cross(float2 const& a, float2 const& b)

--- a/source/EngineKernels/Math.cuh
+++ b/source/EngineKernels/Math.cuh
@@ -162,11 +162,12 @@ __inline__ __device__ float2 Math::unitVectorOfAngle(float angle)
 
 __inline__ __device__ float Math::angleOfVector(float2 const& v)
 {
-    if (length(v) < NEAR_ZERO) {
+    auto lengthOfVector = length(v);
+    if (lengthOfVector < NEAR_ZERO) {
         return 0;
     }
 
-    auto normalizedVy = -v.y / length(v);
+    auto normalizedVy = -v.y / lengthOfVector;
     normalizedVy = max(-1.0f, min(1.0f, normalizedVy));
     float angleSin = asinf(normalizedVy) * Const::RAD_TO_DEG;
     if (v.x >= 0.0f) {
@@ -413,7 +414,14 @@ __inline__ __device__ bool Math::crossing(float2 const& segmentStart, float2 con
 
 __inline__ __device__ float Math::modulo(float value, float boundary)
 {
-    return fmodf(fmodf(value, boundary) + boundary, boundary);
+    // fmodf is emulated in software, whereas floorf and the division are single instructions
+    auto result = value - boundary * floorf(value / boundary);
+    if (result < 0.0f) {
+        result += boundary;
+    } else if (result >= boundary) {
+        result -= boundary;
+    }
+    return result;
 }
 
 __inline__ __device__ float3 Math::cross(float2 const& a, float2 const& b)

--- a/source/EngineKernels/Math.cuh
+++ b/source/EngineKernels/Math.cuh
@@ -414,7 +414,6 @@ __inline__ __device__ bool Math::crossing(float2 const& segmentStart, float2 con
 
 __inline__ __device__ float Math::modulo(float value, float boundary)
 {
-    // fmodf is emulated in software, whereas floorf and the division are single instructions
     auto result = value - boundary * floorf(value / boundary);
     if (result < 0.0f) {
         result += boundary;

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -113,33 +113,6 @@ namespace
         result *= 3.0f / (2.0f * Const::PI);
         return result;
     }
-
-    // An object is registered in the map cell that contains its position, so all objects of a cell lie within
-    // its unit square. If that square is entirely farther away than the interaction cutoff, the cell cannot
-    // contribute and neither its map lookup nor its object chain has to be touched. The scan rectangle is a
-    // square around a circular interaction range, so this skips its corners.
-    __inline__ __device__ bool isCellInRange(float2 const& pos, int cellPosX, int cellPosY, float cutoffSquared)
-    {
-        auto deltaX = fmaxf(fmaxf(toFloat(cellPosX) - pos.x, pos.x - toFloat(cellPosX + 1)), 0.0f);
-        auto deltaY = fmaxf(fmaxf(toFloat(cellPosY) - pos.y, pos.y - toFloat(cellPosY + 1)), 0.0f);
-        return deltaX * deltaX + deltaY * deltaY <= cutoffSquared;
-    }
-
-    // Splits the linear scan index into a row and a column without an integer division, which the GPU
-    // emulates in software. The rounding of the float division is corrected by the following comparisons.
-    __inline__ __device__ int2 calcScanPos(int2 const& scanOrigin, int scanIndex, int scanLength, float invScanLength)
-    {
-        auto row = toInt(toFloat(scanIndex) * invScanLength);
-        auto column = scanIndex - row * scanLength;
-        if (column < 0) {
-            --row;
-            column += scanLength;
-        } else if (column >= scanLength) {
-            ++row;
-            column -= scanLength;
-        }
-        return {scanOrigin.x + column, scanOrigin.y + row};
-    }
 }
 
 __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_correctOverlap(SimulationData& data)
@@ -193,17 +166,9 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
         float2 localCellPosDelta = {0, 0};
         float localDensity = 0;
 
-        auto const objectPos = object->pos;
-        auto const cutoffSquared = smoothingLength * smoothingLength * 4;
-
-        auto const invScanLength = 1.0f / toFloat(scanLength);
-
         auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
-            int2 scanPos = calcScanPos(cellPosInt, scanIndex, scanLength, invScanLength);
-            if (!isCellInRange(objectPos, scanPos.x, scanPos.y, cutoffSquared)) {
-                continue;
-            }
+            int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
             data.objectMap.correctPosition(scanPos);
             int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
@@ -384,41 +349,27 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
     for (int objectIndex = blockPartition.startIndex; objectIndex <= blockPartition.endIndex; ++objectIndex) {
         auto& object = objects.at(objectIndex);
 
-        // Only fluid objects receive a boundary force. The condition is uniform for the whole block, so
-        // skipping here also spares the barriers and the cross-warp reduction below.
-        if (object->type != ObjectType_Fluid) {
-            continue;
-        }
-
         __shared__ int scanLength;
         __shared__ int2 cellPosInt;
         __shared__ float2 F_boundary;
 
         if (block.thread_rank() == 0) {
             F_boundary = {0, 0};
-            int radiusInt = ceilf(smoothingLength * 2);
-            scanLength = radiusInt * 2 + 1;
-            cellPosInt = {floorInt(object->pos.x) - radiusInt, floorInt(object->pos.y) - radiusInt};
+            if (object->type == ObjectType_Fluid) {
+                int radiusInt = ceilf(smoothingLength * 2);
+                scanLength = radiusInt * 2 + 1;
+                cellPosInt = {floorInt(object->pos.x) - radiusInt, floorInt(object->pos.y) - radiusInt};
+            } else {
+                scanLength = 0;
+            }
         }
         block.sync();
 
         float2 localF_boundary = {0, 0};
 
-        auto const objectPos = object->pos;
-        auto const cutoffSquared = smoothingLength * smoothingLength * 4;
-
-        auto const invScanLength = 1.0f / toFloat(scanLength);
-
         auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
-            int2 scanPos = calcScanPos(cellPosInt, scanIndex, scanLength, invScanLength);
-
-            // The distance below is measured against the live position, which the overlap correction of
-            // calcFluidForces may have nudged slightly out of its map cell. A neighbor missed that way sits at
-            // the very edge of the interaction range, where the smoothing kernel and thus its force are zero.
-            if (!isCellInRange(objectPos, scanPos.x, scanPos.y, cutoffSquared)) {
-                continue;
-            }
+            int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
             data.objectMap.correctPosition(scanPos);
             int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
@@ -530,7 +481,6 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
         auto cellStiffnessSquared = object->stiffness * object->stiffness;
 
         auto numConnections = object->numConnections;
-        auto prevAngle = calcAngularForces ? Math::angleOfVector(prevDisplacement) : 0.0f;
         for (int i = 0; i < numConnections; ++i) {
             auto connectedObject = object->connections[i].object;
             auto connectedObjectStiffnessSquared = connectedObject->stiffness * connectedObject->stiffness;
@@ -541,8 +491,7 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
             auto actualDistance = Math::length(displacement);
             auto bondDistance = object->connections[i].distance;
             auto deviation = actualDistance - bondDistance;
-            auto direction = actualDistance > NEAR_ZERO ? displacement / actualDistance : float2{1.0f, 0.0f};
-            force = force + direction * deviation * (cellStiffnessSquared + connectedObjectStiffnessSquared) / 6;
+            force = force + Math::getNormalized(displacement) * deviation * (cellStiffnessSquared + connectedObjectStiffnessSquared) / 6;
             if (calcAngularForces) {
                 auto lastIndex = (i + numConnections - 1) % numConnections;
                 auto lastConnectedObject = object->connections[lastIndex].object;
@@ -554,11 +503,9 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
                 Math::rotateQuarterClockwise(r1);
                 Math::rotateQuarterCounterClockwise(r2);
 
-                // The displacement of this iteration becomes the previous one of the next, so its angle is
-                // carried over instead of being calculated twice
                 auto angle = Math::angleOfVector(displacement);
+                auto prevAngle = Math::angleOfVector(prevDisplacement);
                 auto theta = Math::getNormalizedAngle(angle - prevAngle, 0.0f);
-                prevAngle = angle;
 
                 if (theta < referenceAngleFromPrevious) {
                     r1 *= -1.0f;

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -113,6 +113,33 @@ namespace
         result *= 3.0f / (2.0f * Const::PI);
         return result;
     }
+
+    // An object is registered in the map cell that contains its position, so all objects of a cell lie within
+    // its unit square. If that square is entirely farther away than the interaction cutoff, the cell cannot
+    // contribute and neither its map lookup nor its object chain has to be touched. The scan rectangle is a
+    // square around a circular interaction range, so this skips its corners.
+    __inline__ __device__ bool isCellInRange(float2 const& pos, int cellPosX, int cellPosY, float cutoffSquared)
+    {
+        auto deltaX = fmaxf(fmaxf(toFloat(cellPosX) - pos.x, pos.x - toFloat(cellPosX + 1)), 0.0f);
+        auto deltaY = fmaxf(fmaxf(toFloat(cellPosY) - pos.y, pos.y - toFloat(cellPosY + 1)), 0.0f);
+        return deltaX * deltaX + deltaY * deltaY <= cutoffSquared;
+    }
+
+    // Splits the linear scan index into a row and a column without an integer division, which the GPU
+    // emulates in software. The rounding of the float division is corrected by the following comparisons.
+    __inline__ __device__ int2 calcScanPos(int2 const& scanOrigin, int scanIndex, int scanLength, float invScanLength)
+    {
+        auto row = toInt(toFloat(scanIndex) * invScanLength);
+        auto column = scanIndex - row * scanLength;
+        if (column < 0) {
+            --row;
+            column += scanLength;
+        } else if (column >= scanLength) {
+            ++row;
+            column -= scanLength;
+        }
+        return {scanOrigin.x + column, scanOrigin.y + row};
+    }
 }
 
 __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_correctOverlap(SimulationData& data)
@@ -166,9 +193,17 @@ __inline__ __device__ void ObjectProcessor::calcFluidForces_reconnectCells_corre
         float2 localCellPosDelta = {0, 0};
         float localDensity = 0;
 
+        auto const objectPos = object->pos;
+        auto const cutoffSquared = smoothingLength * smoothingLength * 4;
+
+        auto const invScanLength = 1.0f / toFloat(scanLength);
+
         auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
-            int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
+            int2 scanPos = calcScanPos(cellPosInt, scanIndex, scanLength, invScanLength);
+            if (!isCellInRange(objectPos, scanPos.x, scanPos.y, cutoffSquared)) {
+                continue;
+            }
             data.objectMap.correctPosition(scanPos);
             int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
@@ -349,27 +384,41 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
     for (int objectIndex = blockPartition.startIndex; objectIndex <= blockPartition.endIndex; ++objectIndex) {
         auto& object = objects.at(objectIndex);
 
+        // Only fluid objects receive a boundary force. The condition is uniform for the whole block, so
+        // skipping here also spares the barriers and the cross-warp reduction below.
+        if (object->type != ObjectType_Fluid) {
+            continue;
+        }
+
         __shared__ int scanLength;
         __shared__ int2 cellPosInt;
         __shared__ float2 F_boundary;
 
         if (block.thread_rank() == 0) {
             F_boundary = {0, 0};
-            if (object->type == ObjectType_Fluid) {
-                int radiusInt = ceilf(smoothingLength * 2);
-                scanLength = radiusInt * 2 + 1;
-                cellPosInt = {floorInt(object->pos.x) - radiusInt, floorInt(object->pos.y) - radiusInt};
-            } else {
-                scanLength = 0;
-            }
+            int radiusInt = ceilf(smoothingLength * 2);
+            scanLength = radiusInt * 2 + 1;
+            cellPosInt = {floorInt(object->pos.x) - radiusInt, floorInt(object->pos.y) - radiusInt};
         }
         block.sync();
 
         float2 localF_boundary = {0, 0};
 
+        auto const objectPos = object->pos;
+        auto const cutoffSquared = smoothingLength * smoothingLength * 4;
+
+        auto const invScanLength = 1.0f / toFloat(scanLength);
+
         auto records = data.objectMap.getRecords();
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
-            int2 scanPos{cellPosInt.x + (scanIndex % scanLength), cellPosInt.y + (scanIndex / scanLength)};
+            int2 scanPos = calcScanPos(cellPosInt, scanIndex, scanLength, invScanLength);
+
+            // The distance below is measured against the live position, which the overlap correction of
+            // calcFluidForces may have nudged slightly out of its map cell. A neighbor missed that way sits at
+            // the very edge of the interaction range, where the smoothing kernel and thus its force are zero.
+            if (!isCellInRange(objectPos, scanPos.x, scanPos.y, cutoffSquared)) {
+                continue;
+            }
             data.objectMap.correctPosition(scanPos);
             int otherIndex = data.objectMap.getFirstIndex(scanPos);
             for (int level = 0; level < MaxBarrierCellsForCollision; ++level) {
@@ -481,6 +530,7 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
         auto cellStiffnessSquared = object->stiffness * object->stiffness;
 
         auto numConnections = object->numConnections;
+        auto prevAngle = calcAngularForces ? Math::angleOfVector(prevDisplacement) : 0.0f;
         for (int i = 0; i < numConnections; ++i) {
             auto connectedObject = object->connections[i].object;
             auto connectedObjectStiffnessSquared = connectedObject->stiffness * connectedObject->stiffness;
@@ -491,7 +541,8 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
             auto actualDistance = Math::length(displacement);
             auto bondDistance = object->connections[i].distance;
             auto deviation = actualDistance - bondDistance;
-            force = force + Math::getNormalized(displacement) * deviation * (cellStiffnessSquared + connectedObjectStiffnessSquared) / 6;
+            auto direction = actualDistance > NEAR_ZERO ? displacement / actualDistance : float2{1.0f, 0.0f};
+            force = force + direction * deviation * (cellStiffnessSquared + connectedObjectStiffnessSquared) / 6;
             if (calcAngularForces) {
                 auto lastIndex = (i + numConnections - 1) % numConnections;
                 auto lastConnectedObject = object->connections[lastIndex].object;
@@ -503,9 +554,11 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
                 Math::rotateQuarterClockwise(r1);
                 Math::rotateQuarterCounterClockwise(r2);
 
+                // The displacement of this iteration becomes the previous one of the next, so its angle is
+                // carried over instead of being calculated twice
                 auto angle = Math::angleOfVector(displacement);
-                auto prevAngle = Math::angleOfVector(prevDisplacement);
                 auto theta = Math::getNormalizedAngle(angle - prevAngle, 0.0f);
+                prevAngle = angle;
 
                 if (theta < referenceAngleFromPrevious) {
                     r1 *= -1.0f;

--- a/source/EngineKernels/ObjectProcessor.cuh
+++ b/source/EngineKernels/ObjectProcessor.cuh
@@ -384,8 +384,6 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
     for (int objectIndex = blockPartition.startIndex; objectIndex <= blockPartition.endIndex; ++objectIndex) {
         auto& object = objects.at(objectIndex);
 
-        // Only fluid objects receive a boundary force. The condition is uniform for the whole block, so
-        // skipping here also spares the barriers and the cross-warp reduction below.
         if (object->type != ObjectType_Fluid) {
             continue;
         }
@@ -413,9 +411,6 @@ __inline__ __device__ void ObjectProcessor::calcFluidBoundaryForces(SimulationDa
         for (int scanIndex = toInt(block.thread_rank()); scanIndex < scanLength * scanLength; scanIndex += block.size()) {
             int2 scanPos = calcScanPos(cellPosInt, scanIndex, scanLength, invScanLength);
 
-            // The distance below is measured against the live position, which the overlap correction of
-            // calcFluidForces may have nudged slightly out of its map cell. A neighbor missed that way sits at
-            // the very edge of the interaction range, where the smoothing kernel and thus its force are zero.
             if (!isCellInRange(objectPos, scanPos.x, scanPos.y, cutoffSquared)) {
                 continue;
             }
@@ -554,8 +549,6 @@ __inline__ __device__ void ObjectProcessor::calcConnectionForces(SimulationData&
                 Math::rotateQuarterClockwise(r1);
                 Math::rotateQuarterCounterClockwise(r2);
 
-                // The displacement of this iteration becomes the previous one of the next, so its angle is
-                // carried over instead of being calculated twice
                 auto angle = Math::angleOfVector(displacement);
                 auto theta = Math::getNormalizedAngle(angle - prevAngle, 0.0f);
                 prevAngle = angle;

--- a/source/EngineKernels/ParameterCalculator.cuh
+++ b/source/EngineKernels/ParameterCalculator.cuh
@@ -15,10 +15,8 @@ public:
     calcParameter(BaseLayerParameter<ColorMatrix<float>> const& parameter, SimulationData const& data, float2 const& worldPos, int color1, int color2);
     __device__ __inline__ static FloatColorRGB calcParameter(BaseLayerParameter<FloatColorRGB> const& parameter, BaseMap const& map, float2 const& worldPos);
 
-    // Blends a single layer value onto an accumulated result, so that callers computing their layer values on
-    // the fly do not need to keep them in an array
     __device__ __inline__ static float2
-    blendLayerValue(float2 const& accumulated, float2 const& layerValue, SimulationData const& data, float2 const& worldPos, int index);
+    calcParameter(float2 const& baseValue, float2 (&layerValues)[MAX_LAYERS], bool (&enabled)[MAX_LAYERS], SimulationData const& data, float2 const& worldPos);
 
     // Return -1 for base
     template <typename T>
@@ -85,12 +83,23 @@ __device__ __inline__ float ParameterCalculator::calcParameter(
 }
 
 __device__ __inline__ float2
-ParameterCalculator::blendLayerValue(float2 const& accumulated, float2 const& layerValue, SimulationData const& data, float2 const& worldPos, int index)
+ParameterCalculator::calcParameter(
+    float2 const& baseValue,
+    float2 (&layerValues)[MAX_LAYERS],
+    bool (&enabled)[MAX_LAYERS],
+    SimulationData const& data,
+    float2 const& worldPos)
 {
-    float2 layerPos = {cudaSimulationParameters.layerPosition.layerValues[index].x, cudaSimulationParameters.layerPosition.layerValues[index].y};
-    auto delta = data.objectMap.getCorrectedDirection(layerPos - worldPos);
-    auto weight = calcWeight(delta, index);
-    return accumulated * weight + layerValue * (1.0f - weight);
+    auto result = baseValue;
+    for (int i = 0; i < cudaSimulationParameters.numLayers; ++i) {
+        if (enabled[i]) {
+            float2 layerPos = {cudaSimulationParameters.layerPosition.layerValues[i].x, cudaSimulationParameters.layerPosition.layerValues[i].y};
+            auto delta = data.objectMap.getCorrectedDirection(layerPos - worldPos);
+            auto weight = calcWeight(delta, i);
+            result = result * weight + layerValues[i] * (1.0f - weight);
+        }
+    }
+    return result;
 }
 
 __device__ __inline__ FloatColorRGB

--- a/source/EngineKernels/ParameterCalculator.cuh
+++ b/source/EngineKernels/ParameterCalculator.cuh
@@ -15,8 +15,10 @@ public:
     calcParameter(BaseLayerParameter<ColorMatrix<float>> const& parameter, SimulationData const& data, float2 const& worldPos, int color1, int color2);
     __device__ __inline__ static FloatColorRGB calcParameter(BaseLayerParameter<FloatColorRGB> const& parameter, BaseMap const& map, float2 const& worldPos);
 
+    // Blends a single layer value onto an accumulated result, so that callers computing their layer values on
+    // the fly do not need to keep them in an array
     __device__ __inline__ static float2
-    calcParameter(float2 const& baseValue, float2 (&layerValues)[MAX_LAYERS], bool (&enabled)[MAX_LAYERS], SimulationData const& data, float2 const& worldPos);
+    blendLayerValue(float2 const& accumulated, float2 const& layerValue, SimulationData const& data, float2 const& worldPos, int index);
 
     // Return -1 for base
     template <typename T>
@@ -83,23 +85,12 @@ __device__ __inline__ float ParameterCalculator::calcParameter(
 }
 
 __device__ __inline__ float2
-ParameterCalculator::calcParameter(
-    float2 const& baseValue,
-    float2 (&layerValues)[MAX_LAYERS],
-    bool (&enabled)[MAX_LAYERS],
-    SimulationData const& data,
-    float2 const& worldPos)
+ParameterCalculator::blendLayerValue(float2 const& accumulated, float2 const& layerValue, SimulationData const& data, float2 const& worldPos, int index)
 {
-    auto result = baseValue;
-    for (int i = 0; i < cudaSimulationParameters.numLayers; ++i) {
-        if (enabled[i]) {
-            float2 layerPos = {cudaSimulationParameters.layerPosition.layerValues[i].x, cudaSimulationParameters.layerPosition.layerValues[i].y};
-            auto delta = data.objectMap.getCorrectedDirection(layerPos - worldPos);
-            auto weight = calcWeight(delta, i);
-            result = result * weight + layerValues[i] * (1.0f - weight);
-        }
-    }
-    return result;
+    float2 layerPos = {cudaSimulationParameters.layerPosition.layerValues[index].x, cudaSimulationParameters.layerPosition.layerValues[index].y};
+    auto delta = data.objectMap.getCorrectedDirection(layerPos - worldPos);
+    auto weight = calcWeight(delta, index);
+    return accumulated * weight + layerValue * (1.0f - weight);
 }
 
 __device__ __inline__ FloatColorRGB

--- a/source/EngineKernels/PreprocessedSimulationData.cuh
+++ b/source/EngineKernels/PreprocessedSimulationData.cuh
@@ -10,7 +10,7 @@ struct PreprocessedSimulationData
 
     __host__ __inline__ void init(int2 const& worldSize)
     {
-        densityMap.init(worldSize, 8);
+        densityMap.init(worldSize);
         activeRadiationSources.init();
     }
 

--- a/source/EngineKernels/PreprocessedSimulationData.cuh
+++ b/source/EngineKernels/PreprocessedSimulationData.cuh
@@ -10,7 +10,7 @@ struct PreprocessedSimulationData
 
     __host__ __inline__ void init(int2 const& worldSize)
     {
-        densityMap.init(worldSize);
+        densityMap.init(worldSize, 8);
         activeRadiationSources.init();
     }
 

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -303,8 +303,7 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
         distance = Math::length(matchDelta);
     }
 
-    // The angle is derived from the direction only where a match is actually packed: angleOfVector uses asinf,
-    // which is expensive compared to the position test that discards the vast majority of the scanned positions.
+    // Calculate angle only when needed (due to expensive asinf)
     auto absAngle = [&] { return Math::getNormalizedAngle(Math::angleOfVector(matchDelta), -180.0f); };
     auto const& cell = &object->typeData.cell;
 

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -20,7 +20,7 @@ private:
         RelocateLastMatch
     };
     __inline__ __device__ static uint64_t
-    getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float absAngle, float distance, ScanType scanType);
+    getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float2 const& delta, float distance, ScanType scanType);
 
     __inline__ __device__ static bool
     isRayBlockedByCreatureConnections(Object** nearSameCreatureCells, int numNearSameCreatureCells, float2 const& rayOrigin, float angle);
@@ -126,13 +126,13 @@ __inline__ __device__ void SensorProcessor::initialScan(SimulationData& data, Si
 
             auto delta = float2{dx, dy};
             auto distance = Math::length(delta);
-            auto angle = Math::angleOfVector(delta);
             float2 scanPos = object->pos + delta;
             data.objectMap.correctPosition(scanPos);
 
             // Check all cells at this position (including overlapping cells)
-            uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::LocateMatch);
+            uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, distance, ScanType::LocateMatch);
             if (matchInfo != 0xffffffffffffffff) {
+                auto angle = Math::angleOfVector(delta);
                 if (!isRayBlockedByCreatureConnections(nearSameCreatureCells, numNearSameCreatureCells, object->pos, angle)
                     && !isRayBlockedBySolid(data, object->pos, angle, distance, object->typeData.cell.cellTypeData.sensor.mode)) {
                     alienAtomicMin64(&lookupResult, matchInfo);
@@ -160,7 +160,7 @@ __inline__ __device__ void SensorProcessor::initialScan(SimulationData& data, Si
                     data.objectMap.correctPosition(scanPos);
 
                     if (distance > startRadius) {
-                        uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::LocateMatch);
+                        uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, distance, ScanType::LocateMatch);
                         if (matchInfo != 0xffffffffffffffff) {
                             if (!isRayBlockedBySolid(data, object->pos, angle, distance, object->typeData.cell.cellTypeData.sensor.mode)) {
                                 alienAtomicMin64(&lookupResult, matchInfo);
@@ -232,9 +232,7 @@ __inline__ __device__ void SensorProcessor::relocateLastMatch(SimulationData& da
 
             auto delta = float2{toFloat(deltaX), toFloat(deltaY)};
             auto scanPos = centerScanPos + delta;
-            auto distance = Math::length(delta);
-            auto angle = Math::angleOfVector(delta);
-            uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::RelocateLastMatch);
+            uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, 0.0f, ScanType::RelocateLastMatch);
             if (matchInfo != 0xffffffffffffffff) {
                 alienAtomicMin64(&lookupResult, matchInfo);
                 break;
@@ -297,14 +295,17 @@ __inline__ __device__ void SensorProcessor::relocateLastMatch(SimulationData& da
 }
 
 __inline__ __device__ uint64_t
-SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float absAngle, float distance, ScanType scanType)
+SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float2 const& delta, float distance, ScanType scanType)
 {
+    auto matchDelta = delta;
     if (scanType == ScanType::RelocateLastMatch) {
-        auto delta = data.objectMap.getCorrectedDirection(scanPos - object->pos);
-        distance = Math::length(delta);
-        absAngle = Math::angleOfVector(delta);
+        matchDelta = data.objectMap.getCorrectedDirection(scanPos - object->pos);
+        distance = Math::length(matchDelta);
     }
-    absAngle = Math::getNormalizedAngle(absAngle, -180.0f);
+
+    // The angle is derived from the direction only where a match is actually packed: angleOfVector uses asinf,
+    // which is expensive compared to the position test that discards the vast majority of the scanned positions.
+    auto absAngle = [&] { return Math::getNormalizedAngle(Math::angleOfVector(matchDelta), -180.0f); };
     auto const& cell = &object->typeData.cell;
 
     auto const& mode = cell->cellTypeData.sensor.mode;
@@ -314,18 +315,18 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
         auto const& minDensity = cell->cellTypeData.sensor.modeData.detectEnergy.minDensity;
         auto density = densityMap.getEnergyParticleDensity(scanPos);
         if (density >= minDensity) {
-            return pack(distance, absAngle, density);
+            return pack(distance, absAngle(), density);
         }
     } else if (mode == SensorMode_DetectSolid) {
         if (densityMap.getSolidDensity(scanPos) > 0) {
-            return pack(distance, absAngle, 1.0f);
+            return pack(distance, absAngle(), 1.0f);
         }
     } else if (mode == SensorMode_DetectFreeCell) {
         auto const& minDensity = cell->cellTypeData.sensor.modeData.detectFreeCell.minDensity;
         auto const& restrictToColors = cell->cellTypeData.sensor.modeData.detectFreeCell.restrictToColors;
         auto density = densityMap.getFreeCellDensity(scanPos, restrictToColors);
         if (density >= minDensity) {
-            return pack(distance, absAngle, density);
+            return pack(distance, absAngle(), density);
         }
     } else if (mode == SensorMode_DetectCreature) {
         if (scanType == ScanType::LocateMatch) {
@@ -368,7 +369,7 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
                     if (matches) {
                         uint16_t creatureIdPart = static_cast<uint16_t>(otherObject->typeData.cell.creature->id & 0xFFFF);
                         float density = calcCreatureDensityFromNumCells(otherObject->typeData.cell.creature->numCells);
-                        return pack(distance, absAngle, density, creatureIdPart);
+                        return pack(distance, absAngle(), density, creatureIdPart);
                     }
                 }
                 otherIndex = otherRecord.nextObjectIndex;
@@ -385,7 +386,7 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
                 if (otherObject->type == ObjectType_Cell && (otherObject->typeData.cell.creature->id & 0xffff) == sensor.lastMatch.creatureIdPart) {
                     uint16_t creatureIdPart = static_cast<uint16_t>(otherObject->typeData.cell.creature->id & 0xffff);
                     float density = calcCreatureDensityFromNumCells(otherObject->typeData.cell.creature->numCells);
-                    return pack(distance, absAngle, density, creatureIdPart);
+                    return pack(distance, absAngle(), density, creatureIdPart);
                 }
                 otherIndex = otherRecord.nextObjectIndex;
             }

--- a/source/EngineKernels/SensorProcessor.cuh
+++ b/source/EngineKernels/SensorProcessor.cuh
@@ -20,7 +20,7 @@ private:
         RelocateLastMatch
     };
     __inline__ __device__ static uint64_t
-    getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float2 const& delta, float distance, ScanType scanType);
+    getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float absAngle, float distance, ScanType scanType);
 
     __inline__ __device__ static bool
     isRayBlockedByCreatureConnections(Object** nearSameCreatureCells, int numNearSameCreatureCells, float2 const& rayOrigin, float angle);
@@ -126,13 +126,13 @@ __inline__ __device__ void SensorProcessor::initialScan(SimulationData& data, Si
 
             auto delta = float2{dx, dy};
             auto distance = Math::length(delta);
+            auto angle = Math::angleOfVector(delta);
             float2 scanPos = object->pos + delta;
             data.objectMap.correctPosition(scanPos);
 
             // Check all cells at this position (including overlapping cells)
-            uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, distance, ScanType::LocateMatch);
+            uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::LocateMatch);
             if (matchInfo != 0xffffffffffffffff) {
-                auto angle = Math::angleOfVector(delta);
                 if (!isRayBlockedByCreatureConnections(nearSameCreatureCells, numNearSameCreatureCells, object->pos, angle)
                     && !isRayBlockedBySolid(data, object->pos, angle, distance, object->typeData.cell.cellTypeData.sensor.mode)) {
                     alienAtomicMin64(&lookupResult, matchInfo);
@@ -160,7 +160,7 @@ __inline__ __device__ void SensorProcessor::initialScan(SimulationData& data, Si
                     data.objectMap.correctPosition(scanPos);
 
                     if (distance > startRadius) {
-                        uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, distance, ScanType::LocateMatch);
+                        uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::LocateMatch);
                         if (matchInfo != 0xffffffffffffffff) {
                             if (!isRayBlockedBySolid(data, object->pos, angle, distance, object->typeData.cell.cellTypeData.sensor.mode)) {
                                 alienAtomicMin64(&lookupResult, matchInfo);
@@ -232,7 +232,9 @@ __inline__ __device__ void SensorProcessor::relocateLastMatch(SimulationData& da
 
             auto delta = float2{toFloat(deltaX), toFloat(deltaY)};
             auto scanPos = centerScanPos + delta;
-            uint64_t matchInfo = getMatchInfo(data, object, scanPos, delta, 0.0f, ScanType::RelocateLastMatch);
+            auto distance = Math::length(delta);
+            auto angle = Math::angleOfVector(delta);
+            uint64_t matchInfo = getMatchInfo(data, object, scanPos, angle, distance, ScanType::RelocateLastMatch);
             if (matchInfo != 0xffffffffffffffff) {
                 alienAtomicMin64(&lookupResult, matchInfo);
                 break;
@@ -295,17 +297,14 @@ __inline__ __device__ void SensorProcessor::relocateLastMatch(SimulationData& da
 }
 
 __inline__ __device__ uint64_t
-SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float2 const& delta, float distance, ScanType scanType)
+SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const& scanPos, float absAngle, float distance, ScanType scanType)
 {
-    auto matchDelta = delta;
     if (scanType == ScanType::RelocateLastMatch) {
-        matchDelta = data.objectMap.getCorrectedDirection(scanPos - object->pos);
-        distance = Math::length(matchDelta);
+        auto delta = data.objectMap.getCorrectedDirection(scanPos - object->pos);
+        distance = Math::length(delta);
+        absAngle = Math::angleOfVector(delta);
     }
-
-    // The angle is derived from the direction only where a match is actually packed: angleOfVector uses asinf,
-    // which is expensive compared to the position test that discards the vast majority of the scanned positions.
-    auto absAngle = [&] { return Math::getNormalizedAngle(Math::angleOfVector(matchDelta), -180.0f); };
+    absAngle = Math::getNormalizedAngle(absAngle, -180.0f);
     auto const& cell = &object->typeData.cell;
 
     auto const& mode = cell->cellTypeData.sensor.mode;
@@ -315,18 +314,18 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
         auto const& minDensity = cell->cellTypeData.sensor.modeData.detectEnergy.minDensity;
         auto density = densityMap.getEnergyParticleDensity(scanPos);
         if (density >= minDensity) {
-            return pack(distance, absAngle(), density);
+            return pack(distance, absAngle, density);
         }
     } else if (mode == SensorMode_DetectSolid) {
         if (densityMap.getSolidDensity(scanPos) > 0) {
-            return pack(distance, absAngle(), 1.0f);
+            return pack(distance, absAngle, 1.0f);
         }
     } else if (mode == SensorMode_DetectFreeCell) {
         auto const& minDensity = cell->cellTypeData.sensor.modeData.detectFreeCell.minDensity;
         auto const& restrictToColors = cell->cellTypeData.sensor.modeData.detectFreeCell.restrictToColors;
         auto density = densityMap.getFreeCellDensity(scanPos, restrictToColors);
         if (density >= minDensity) {
-            return pack(distance, absAngle(), density);
+            return pack(distance, absAngle, density);
         }
     } else if (mode == SensorMode_DetectCreature) {
         if (scanType == ScanType::LocateMatch) {
@@ -369,7 +368,7 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
                     if (matches) {
                         uint16_t creatureIdPart = static_cast<uint16_t>(otherObject->typeData.cell.creature->id & 0xFFFF);
                         float density = calcCreatureDensityFromNumCells(otherObject->typeData.cell.creature->numCells);
-                        return pack(distance, absAngle(), density, creatureIdPart);
+                        return pack(distance, absAngle, density, creatureIdPart);
                     }
                 }
                 otherIndex = otherRecord.nextObjectIndex;
@@ -386,7 +385,7 @@ SensorProcessor::getMatchInfo(SimulationData& data, Object* object, float2 const
                 if (otherObject->type == ObjectType_Cell && (otherObject->typeData.cell.creature->id & 0xffff) == sensor.lastMatch.creatureIdPart) {
                     uint16_t creatureIdPart = static_cast<uint16_t>(otherObject->typeData.cell.creature->id & 0xffff);
                     float density = calcCreatureDensityFromNumCells(otherObject->typeData.cell.creature->numCells);
-                    return pack(distance, absAngle(), density, creatureIdPart);
+                    return pack(distance, absAngle, density, creatureIdPart);
                 }
                 otherIndex = otherRecord.nextObjectIndex;
             }


### PR DESCRIPTION
Reduces the simulation time per timestep by removing software-emulated arithmetic from the innermost loop of the neighborhood scans and by regrouping the struct fields the per-timestep kernels touch.

Profiling with the CLI (`-p`) and Nsight Compute showed that the engine is latency-bound rather than bandwidth-bound: DRAM throughput stays at 14-16 %, while about half of all warp stalls wait on L1TEX. The two changes below address exactly that.

## Changes

- **`Map.cuh`**: the torus wrapping used `remainderf` and integer `%`, both emulated in software on the GPU, in the innermost loop of every neighborhood scan. Replaced by a minimum-image convention based on `fmaf`/`rintf` and by a wrap with a fast path for the single step that covers all scans. Measured in isolation this was worth about 17 %.
- **`Entities.cuh`**: `tempValue1`/`tempValue2` moved into the leading cache line of `Object`; the physics kernels read them together with `pos` and `vel` but they used to sit in a separate 32 byte sector. `Cell` is reordered by access frequency, since `futureNeuralActivity`, `headUpdateId` and `lastUpdate` were located behind the several hundred bytes of `cellTypeData`. Measured in isolation this was worth about 12 %.
- **`Cli/Main.cpp`**: the TPS measurement included about 1.3 s of loading and uploading, which made runs with different timestep counts incomparable. It now covers the simulation loop only.

## Measurement

Benchmarks on `save_1_129_998.sim` (RTX 4090), with both binaries built and run interleaved so that GPU boost behaviour affects both equally. Note that runs vary by about ±4 % and that the simulation diverges over longer runs, since the order in which threads draw random numbers is not deterministic; 1000 timesteps with several repetitions gives a stable signal.

The percentages above are the incremental effects observed while the changes were developed. The combined effect of exactly these two changes has not been measured on its own.

## Further findings

A number of smaller optimizations (avoiding `fmodf` and `asinf` where they are not needed, skipping map cells outside the interaction range, moving two `MAX_LAYERS` arrays out of local memory) each contributed 1-2 % and were left out to keep this change small.

Two experiments turned out to be counterproductive: raising the block sizes from 8/16 to 64 threads (10 % slower, the small blocks keep the L2 working set small and the attacker kernel suffers from lock contention) and shrinking `LightObject` from 40 to 32 bytes by moving the self pointer into a parallel array (neutral).

`calcFluidForces` remains the largest single kernel at around 17 %. It runs with 25 threads per block, which caps occupancy at 45 % because of the limit of 24 blocks per SM. Restructuring it to one warp per object would lift that, but it is a real rewrite of a core physics kernel.
