### PR TITLE
Add save picture function with adjustable resolution

### DIFF
--- a/source/Gui/CMakeLists.txt
+++ b/source/Gui/CMakeLists.txt
@@ -139,6 +139,8 @@ PUBLIC
     ResetPasswordDialog.h
     ResizeWorldDialog.cpp
     ResizeWorldDialog.h
+    SavePictureDialog.cpp
+    SavePictureDialog.h
     SelectionWindow.cpp
     SelectionWindow.h
     Shader.cpp

--- a/source/Gui/Definitions.h
+++ b/source/Gui/Definitions.h
@@ -62,6 +62,8 @@ class WindowController;
 
 class ResizeWorldDialog;
 
+class SavePictureDialog;
+
 class _InspectionWindow;
 using InspectionWindow = std::shared_ptr<_InspectionWindow>;
 

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -47,6 +47,7 @@
 #include "OpenGLHelper.h"
 #include "OverlayController.h"
 #include "PatternEditorWindow.h"
+#include "SavePictureDialog.h"
 #include "SelectionWindow.h"
 #include "SimulationInteractionController.h"
 #include "SimulationParametersMainWindow.h"
@@ -343,6 +344,7 @@ void MainLoopController::processMenubar()
         AlienGui::MenuItemParameters().name("Open").keyCtrl(true).key(ImGuiKey_O), [&] { FileTransferController::get().onOpenSimulationDialog(); });
     AlienGui::MenuItem(
         AlienGui::MenuItemParameters().name("Save").keyCtrl(true).key(ImGuiKey_S), [&] { FileTransferController::get().onSaveSimulationDialog(); });
+    AlienGui::MenuItem(AlienGui::MenuItemParameters().name("Save picture"), [&] { SavePictureDialog::get().open(); });
     AlienGui::MenuSeparator();
     auto running = _SimulationFacade::get()->isSimulationRunning();
     AlienGui::MenuItem(AlienGui::MenuItemParameters().name("Run").key(ImGuiKey_Space).disabled(running).closeMenuWhenItemClicked(false), [&] {

--- a/source/Gui/MainWindow.cpp
+++ b/source/Gui/MainWindow.cpp
@@ -68,6 +68,7 @@
 #include "PatternEditorWindow.h"
 #include "PreviewSettingsDialog.h"
 #include "ResetPasswordDialog.h"
+#include "SavePictureDialog.h"
 #include "SelectionWindow.h"
 #include "SignalsBufferDialog.h"
 #include "SimulationInteractionController.h"
@@ -157,6 +158,7 @@ _MainWindow::_MainWindow()
     ResetPasswordDialog::get().setup();
     GenericMessageDialog::get().setup();
     GenericFileDialog::get().setup();
+    SavePictureDialog::get().setup();
     SignalsBufferDialog::get().setup();
     DelayedExecutionController::get().setup();
     UiController::get().setup();

--- a/source/Gui/RenderPipeline.cpp
+++ b/source/Gui/RenderPipeline.cpp
@@ -244,8 +244,10 @@ namespace
     }
 }
 
-void _RenderPipeline::execute()
+void _RenderPipeline::execute(RenderTarget const& finalTarget)
 {
+    _finalTarget = finalTarget;
+
     // Copy vertex buffer from Cuda to OpenGL
     _SimulationFacade::get()->tryCopyBuffersFromCudaToOpenGL(_geometryBuffers, Viewport::get().getVisibleWorldRect());
 
@@ -394,7 +396,7 @@ RenderTarget _RenderPipeline::determineRenderTarget(
         }
     } else {
         if (!subsequentStepsHaveTarget(sequence, stepIndex) && isLastBlock) {
-            target = RenderTarget(ScreenTarget());
+            target = _finalTarget;
         } else {
 
             auto reuseTarget = false;

--- a/source/Gui/RenderPipeline.h
+++ b/source/Gui/RenderPipeline.h
@@ -45,7 +45,9 @@ public:
     _RenderPipeline(RenderBlocks&& blocks);
 
     void resize(IntVector2D const& size);
-    void execute();
+
+    // The last render step writes to `finalTarget`
+    void execute(RenderTarget const& finalTarget = ScreenTarget());
 
 private:
     void resizeTarget(TextureTarget const& target);
@@ -73,6 +75,8 @@ private:
         std::map<RenderTarget, TargetInfo>& usedTargets);
 
     RenderBlocks _blocks;
+
+    RenderTarget _finalTarget = ScreenTarget();
 
     GeometryBuffers _geometryBuffers;
     std::vector<TextureTarget> _textureTargets;

--- a/source/Gui/RenderStep.cpp
+++ b/source/Gui/RenderStep.cpp
@@ -60,11 +60,13 @@ void _RenderStep::prepareExecution(ExecutionParameters const& parameters)
     auto worldRect = Viewport::get().getVisibleWorldRect();
     auto viewSize = Viewport::get().getViewSize();
     auto zoom = Viewport::get().getZoomFactor();
+    auto renderScale = Viewport::get().getRenderScale();
     //auto timestep = simulationFacade->getCurrentTimestep();
 
     _shader->use();
     _shader->setFloat("zoom", zoom);
-    _shader->setFloat("radius", std::max(parameters._minBallRadius, zoom));
+    _shader->setFloat("renderScale", renderScale);
+    _shader->setFloat("radius", std::max(parameters._minBallRadius * renderScale, zoom));
     _shader->setVec2("worldSize", toRealVector2D(worldSize));
     _shader->setVec2("rectUpperLeft", worldRect.topLeft);
     _shader->setVec2("rectLowerRight", worldRect.bottomRight);
@@ -397,7 +399,7 @@ _CellTypeOverlayRenderStep::~_CellTypeOverlayRenderStep()
 void _CellTypeOverlayRenderStep::execute(ExecutionParameters parameters)
 {
     // Only render if zoom exceeds threshold and overlay is active
-    auto zoom = Viewport::get().getZoomFactor();
+    auto zoom = Viewport::get().getScreenZoomFactor();
     auto overlayActive = SimulationView::get().isOverlayActive();
 
     if (zoom <= ZoomFactorForCellDetails || !overlayActive) {
@@ -570,7 +572,7 @@ SelectedConnectionRenderStep _SelectedConnectionRenderStep::create(StepParameter
 
 void _SelectedConnectionRenderStep::execute(ExecutionParameters parameters)
 {
-    auto zoom = Viewport::get().getZoomFactor();
+    auto zoom = Viewport::get().getScreenZoomFactor();
     if (zoom <= ZoomFactorForCellDetails) {
         return;
     }

--- a/source/Gui/SavePictureDialog.cpp
+++ b/source/Gui/SavePictureDialog.cpp
@@ -1,0 +1,94 @@
+#include "SavePictureDialog.h"
+
+#include <algorithm>
+#include <filesystem>
+
+#include <imgui.h>
+
+#include <Base/AlienExceptions.h>
+#include <Base/GlobalSettings.h>
+
+#include "AlienGui.h"
+#include "DelayedExecutionController.h"
+#include "GenericFileDialog.h"
+#include "GenericMessageDialog.h"
+#include "OverlayController.h"
+#include "SimulationView.h"
+#include "Viewport.h"
+
+namespace
+{
+    auto constexpr TextWidth = 130.0f;
+}
+
+SavePictureDialog::SavePictureDialog()
+    : AlienDialog("Save picture", {450.0f, 180.0f})
+{}
+
+void SavePictureDialog::initIntern()
+{
+    _width = GlobalSettings::get().getValue("dialogs.save picture.width", _width);
+    _height = GlobalSettings::get().getValue("dialogs.save picture.height", _height);
+    _referencePath = GlobalSettings::get().getValue("dialogs.save picture.reference path", _referencePath);
+}
+
+void SavePictureDialog::shutdownIntern()
+{
+    GlobalSettings::get().setValue("dialogs.save picture.width", _width);
+    GlobalSettings::get().setValue("dialogs.save picture.height", _height);
+    GlobalSettings::get().setValue("dialogs.save picture.reference path", _referencePath);
+}
+
+void SavePictureDialog::openIntern()
+{
+    if (_width <= 0 || _height <= 0) {
+        auto viewSize = Viewport::get().getViewSize();
+        _width = viewSize.x;
+        _height = viewSize.y;
+    }
+}
+
+void SavePictureDialog::processIntern()
+{
+    AlienGui::InputInt(AlienGui::InputIntParameters().name("Width").textWidth(TextWidth), _width);
+    AlienGui::InputInt(AlienGui::InputIntParameters().name("Height").textWidth(TextWidth), _height);
+    if (AlienGui::Button("Adopt view size")) {
+        auto viewSize = Viewport::get().getViewSize();
+        _width = viewSize.x;
+        _height = viewSize.y;
+    }
+    _width = std::max(1, _width);
+    _height = std::max(1, _height);
+
+    AlienGui::Separator();
+
+    if (AlienGui::Button("OK")) {
+        close();
+        delayedExecution([this] { onSavePicture(); });
+    }
+    ImGui::SetItemDefaultFocus();
+
+    ImGui::SameLine();
+    if (AlienGui::Button("Cancel")) {
+        close();
+    }
+}
+
+void SavePictureDialog::onSavePicture()
+{
+    GenericFileDialog::get().showSaveFileDialog("Save picture", "Picture (*.png){.png},.*", _referencePath, [this](std::filesystem::path const& path) {
+        auto referencePath = path;
+        _referencePath = referencePath.remove_filename().string();
+
+        auto filename = path;
+        if (filename.extension().empty()) {
+            filename.replace_extension(".png");
+        }
+        try {
+            SimulationView::get().savePicture(filename, {_width, _height});
+            printOverlayMessage(filename.filename().string());
+        } catch (AlienException const& exception) {
+            GenericMessageDialog::get().information("Save picture", std::string("The picture could not be saved.\n\n") + exception.what());
+        }
+    });
+}

--- a/source/Gui/SavePictureDialog.h
+++ b/source/Gui/SavePictureDialog.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include <Base/Singleton.h>
+
+#include "AlienDialog.h"
+#include "Definitions.h"
+
+class SavePictureDialog : public AlienDialog
+{
+    MAKE_SINGLETON_NO_DEFAULT_CONSTRUCTION(SavePictureDialog);
+
+private:
+    SavePictureDialog();
+
+    void initIntern() override;
+    void shutdownIntern() override;
+    void openIntern() override;
+    void processIntern() override;
+
+    void onSavePicture();
+
+    int _width = 0;
+    int _height = 0;
+    std::string _referencePath;
+};

--- a/source/Gui/SimulationView.cpp
+++ b/source/Gui/SimulationView.cpp
@@ -1,11 +1,17 @@
 #include "SimulationView.h"
 
 #include <algorithm>
+#include <vector>
 
 #include <glad/glad.h>
 
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
 #include <imgui.h>
 
+#include <Base/AlienExceptions.h>
+#include <Base/ExitScopeGuard.h>
 #include <Base/GlobalSettings.h>
 #include <Base/Resources.h>
 
@@ -166,6 +172,86 @@ void SimulationView::setMotionBlur(float value)
 
 void SimulationView::updateMotionBlur() {}
 
+namespace
+{
+    void initPictureTarget(TextureTarget const& target, IntVector2D const& resolution)
+    {
+        glGenTextures(1, &target->texture);
+        glBindTexture(GL_TEXTURE_2D, target->texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, resolution.x, resolution.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+        glGenRenderbuffers(1, &target->depthBuffer);
+        glBindRenderbuffer(GL_RENDERBUFFER, target->depthBuffer);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, resolution.x, resolution.y);
+
+        glGenFramebuffers(1, &target->fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, target->fbo);
+        glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, target->texture, 0);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, target->depthBuffer);
+
+        target->initialized = true;
+    }
+}
+
+void SimulationView::savePicture(std::filesystem::path const& filename, IntVector2D const& resolution)
+{
+    GLint maxTextureSize = 0;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+    if (resolution.x > maxTextureSize || resolution.y > maxTextureSize) {
+        throw AlienException("The resolution must not exceed " + std::to_string(maxTextureSize) + " pixels per dimension on this GPU.");
+    }
+
+    auto origViewSize = Viewport::get().getViewSize();
+    auto origZoomFactor = Viewport::get().getZoomFactor();
+    GLint origFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &origFbo);
+
+    auto target = _TextureTarget::create();
+    ExitScopeGuard restoreState([&] {
+        glBindFramebuffer(GL_FRAMEBUFFER, origFbo);
+        glDeleteFramebuffers(1, &target->fbo);
+        glDeleteRenderbuffers(1, &target->depthBuffer);
+        glDeleteTextures(1, &target->texture);
+
+        Viewport::get().setViewSize(origViewSize);
+        Viewport::get().setZoomFactor(origZoomFactor);
+        Viewport::get().setRenderScale(1.0f);
+        _renderPipeline->resize(origViewSize);
+    });
+
+    initPictureTarget(target, resolution);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        throw AlienException("The offscreen framebuffer for the picture could not be created.");
+    }
+
+    // The visible world rect equals view size / zoom factor. Thus, scaling both by the same amount keeps the
+    // horizontally visible world range while the vertical range follows from the aspect ratio of the picture.
+    // The render scale lets the render steps enlarge all effects with a size in pixels accordingly.
+    auto renderScale = toFloat(resolution.x) / toFloat(origViewSize.x);
+    Viewport::get().setViewSize(resolution);
+    Viewport::get().setZoomFactor(origZoomFactor * renderScale);
+    Viewport::get().setRenderScale(renderScale);
+
+    _renderPipeline->resize(resolution);
+    _renderPipeline->execute(target);
+
+    std::vector<unsigned char> pixels(static_cast<size_t>(resolution.x) * resolution.y * 3);
+    glBindFramebuffer(GL_FRAMEBUFFER, target->fbo);
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, resolution.x, resolution.y, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+
+    // OpenGL provides the rows bottom-up
+    stbi_flip_vertically_on_write(1);
+    if (stbi_write_png(filename.string().c_str(), resolution.x, resolution.y, 3, pixels.data(), resolution.x * 3) == 0) {
+        throw AlienException("The file could not be written.");
+    }
+}
+
 void SimulationView::setupRenderPipeline()
 {
     // Define lambdas for render pipeline
@@ -184,9 +270,10 @@ void SimulationView::setupRenderPipeline()
         return UniformValueMap{{"borderlessRendering", parameters.borderlessRendering.value}};
     };
 
-    // Number of blur repetitions and blur strengths is based on zoom level to balance performance and quality
+    // Number of blur repetitions and blur strengths is based on zoom level to balance performance and quality.
+    // The screen zoom factor is used so that a picture rendered at a higher resolution keeps the same appearance.
     auto blurStrengthFunc = [](SimulationParameters const& parameters) {
-        auto zoom = Viewport::get().getZoomFactor();
+        auto zoom = Viewport::get().getScreenZoomFactor();
         float strength = 0.035f;
         if (zoom < 100.0f) {
             strength *= 3.5f;
@@ -206,7 +293,7 @@ void SimulationView::setupRenderPipeline()
         return UniformValueMap{{"strength", strength}};
     };
     auto blurRepetitionsFunc = [] {
-        auto zoom = Viewport::get().getZoomFactor();
+        auto zoom = Viewport::get().getScreenZoomFactor();
         auto result = 7;
         if (zoom < 100.0f) {
             --result;

--- a/source/Gui/SimulationView.h
+++ b/source/Gui/SimulationView.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <filesystem>
 
 #include <Base/Definitions.h>
 #include <Base/Singleton.h>
@@ -38,6 +39,9 @@ public:
     void setMotionBlur(float value);
 
     void updateMotionBlur();
+
+    // Renders the currently visible world region offscreen and writes it as PNG file
+    void savePicture(std::filesystem::path const& filename, IntVector2D const& resolution);
 
     static auto constexpr DefaultBrightness = 1.0f;
     static auto constexpr DefaultContrast = 1.0f;

--- a/source/Gui/Viewport.cpp
+++ b/source/Gui/Viewport.cpp
@@ -26,6 +26,21 @@ void Viewport::setZoomFactor(float zoomFactor)
     _zoomFactor = zoomFactor;
 }
 
+float Viewport::getRenderScale()
+{
+    return _renderScale;
+}
+
+void Viewport::setRenderScale(float value)
+{
+    _renderScale = value;
+}
+
+float Viewport::getScreenZoomFactor()
+{
+    return _zoomFactor / _renderScale;
+}
+
 RealVector2D Viewport::getCenterInWorldPos()
 {
     return _centerInWorldPos;

--- a/source/Gui/Viewport.h
+++ b/source/Gui/Viewport.h
@@ -14,8 +14,18 @@ class Viewport
 public:
     void setup();
 
+    // World units to rendered pixels
     float getZoomFactor();
     void setZoomFactor(float zoomFactor);
+
+    // Rendered pixels per screen pixel. Greater than 1 while a picture is rendered with a higher resolution
+    // than the view. Everything with a size in pixels needs to be scaled by this factor to keep its appearance.
+    float getRenderScale();
+    void setRenderScale(float value);
+
+    // World units to screen pixels, i.e. the zoom factor an equivalent view on screen would have.
+    // Should be used for decisions that depend on the visual zoom level instead of the rendered resolution.
+    float getScreenZoomFactor();
 
     RealVector2D getCenterInWorldPos();
     void setCenterInWorldPos(RealVector2D const& worldCenter);
@@ -35,6 +45,7 @@ public:
 
 private:
     float _zoomFactor = 1.0f;
+    float _renderScale = 1.0f;
     float _zoomSensitivity = 1.04f;
     RealVector2D _centerInWorldPos;
     IntVector2D _viewSize;

--- a/source/Shaders/BlurHorizontalFS.h
+++ b/source/Shaders/BlurHorizontalFS.h
@@ -15,14 +15,15 @@ uniform vec2 viewportSize;
 uniform float zoom;
 uniform float strength;
 uniform bool zoomDependent;
+uniform float renderScale;
 
 void main()
 {
     vec2 texelSize = 1.0 / viewportSize;
     vec4 result = vec4(0.0);
     float totalWeight = 0.0;
-    float blurRadius = zoomDependent ? zoom * strength : strength;
-    blurRadius = min(blurRadius, 20.0);
+    float blurRadius = zoomDependent ? zoom * strength : strength * renderScale;
+    blurRadius = min(blurRadius, 20.0 * renderScale);
     
     if (blurRadius < 1.0) {
         FragColor = texture(inputTexture1, texCoord);

--- a/source/Shaders/BlurVerticalFS.h
+++ b/source/Shaders/BlurVerticalFS.h
@@ -15,14 +15,15 @@ uniform vec2 viewportSize;
 uniform float zoom;
 uniform float strength;
 uniform bool zoomDependent;
+uniform float renderScale;
 
 void main()
 {
     vec2 texelSize = 1.0 / viewportSize;
     vec4 result = vec4(0.0);
     float totalWeight = 0.0;
-    float blurRadius = zoomDependent ? zoom * strength : strength;
-    
+    float blurRadius = zoomDependent ? zoom * strength : strength * renderScale;
+
     if (blurRadius < 1.0) {
         FragColor = texture(inputTexture1, texCoord);
     } else {

--- a/source/Shaders/CellTypeOverlayGS.h
+++ b/source/Shaders/CellTypeOverlayGS.h
@@ -22,6 +22,7 @@ out vec2 gWorldPos;
 uniform vec2 viewportSize;
 uniform float zoom;
 uniform float radius;
+uniform float renderScale;
 
 // Object type constants (matching ObjectType_ enum)
 const int ObjectType_Solid = 0;
@@ -57,9 +58,9 @@ void main()
     gWorldPos = vWorldPos[0];
     
     // Calculate size in NDC coordinates
-    float clampedZoom = min(40, zoom);
-    float ndcWidth = 480.0 / viewportSize.x * 2.0 * clampedZoom / 30;
-    float ndcHeight = 20.0 / viewportSize.y * 2.0 * clampedZoom / 30;
+    float clampedZoom = min(40, zoom / renderScale);
+    float ndcWidth = 480.0 * renderScale / viewportSize.x * 2.0 * clampedZoom / 30;
+    float ndcHeight = 20.0 * renderScale / viewportSize.y * 2.0 * clampedZoom / 30;
     
     // Get center position (cell position)
     vec4 center = gl_in[0].gl_Position;

--- a/source/Shaders/FluidParticleVS.h
+++ b/source/Shaders/FluidParticleVS.h
@@ -18,6 +18,7 @@ uniform float zoom;
 uniform float radius;
 uniform vec2 viewportSize;
 uniform bool onBackground;
+uniform float renderScale;
 
 void main()
 {
@@ -32,7 +33,7 @@ void main()
     if (onBackground) {
         ballSize = 15.0;
     } else {
-        ballSize = zoom < 7.0 ? 0.0 : 0.2;
+        ballSize = zoom / renderScale < 7.0 ? 0.0 : 0.2;
     }
 
     float g = clamp(aGlow, 0.0, 1.0);

--- a/source/Shaders/GridLinesFS.h
+++ b/source/Shaders/GridLinesFS.h
@@ -17,6 +17,7 @@ uniform vec2 worldSize;
 uniform vec2 rectUpperLeft;
 uniform vec2 rectLowerRight;
 uniform bool gridLines;
+uniform float renderScale;
 
 float modulo(float x, float y) {
     return x - y * floor(x / y);
@@ -47,11 +48,11 @@ void main()
             float distanceY = modulo(worldPos.y + gridDistance / 2.0, gridDistance) - gridDistance / 2.0;
             
             if (abs(distanceX) <= PixelInWorldSize * 8.0) {
-                float viewDistance = max(0.0, 0.1 - abs(distanceX) * zoom / 10.0) * gridRemainder * 0.7;
+                float viewDistance = max(0.0, 0.1 - abs(distanceX) * zoom / (10.0 * renderScale)) * gridRemainder * 0.7;
                 finalColor += vec3(viewDistance, viewDistance, viewDistance);
             }
             if (abs(distanceY) <= PixelInWorldSize * 8.0) {
-                float viewDistance = max(0.0, 0.1 - abs(distanceY) * zoom / 10.0) * gridRemainder * 0.7;
+                float viewDistance = max(0.0, 0.1 - abs(distanceY) * zoom / (10.0 * renderScale)) * gridRemainder * 0.7;
                 finalColor += vec3(viewDistance, viewDistance, viewDistance);
             }
         }
@@ -62,11 +63,11 @@ void main()
             float distanceY = modulo(worldPos.y + gridDistance / 20.0, gridDistance / 10.0) - gridDistance / 20.0;
             
             if (abs(distanceX) <= PixelInWorldSize * 8.0) {
-                float viewDistance = max(0.0, 0.1 - abs(distanceX) * zoom / 10.0) * (1.0 - gridRemainder) * 0.7;
+                float viewDistance = max(0.0, 0.1 - abs(distanceX) * zoom / (10.0 * renderScale)) * (1.0 - gridRemainder) * 0.7;
                 finalColor += vec3(viewDistance, viewDistance, viewDistance);
             }
             if (abs(distanceY) <= PixelInWorldSize * 8.0) {
-                float viewDistance = max(0.0, 0.1 - abs(distanceY) * zoom / 10.0) * (1.0 - gridRemainder) * 0.7;
+                float viewDistance = max(0.0, 0.1 - abs(distanceY) * zoom / (10.0 * renderScale)) * (1.0 - gridRemainder) * 0.7;
                 finalColor += vec3(viewDistance, viewDistance, viewDistance);
             }
         }

--- a/source/Shaders/LineGS.h
+++ b/source/Shaders/LineGS.h
@@ -18,6 +18,7 @@ flat out float aaMargin;
 
 uniform vec2 viewportSize;
 uniform float zoom;
+uniform float renderScale;
 
 vec2 transform(vec2 v)
 {
@@ -39,10 +40,10 @@ void main()
     vec2 perp = vec2(-dir.y, dir.x);
 
     // Core half-width in pixels (same as original line width)
-    float coreWidth = max(zoom * 0.15 * 0.5, 0.5);
+    float coreWidth = max(zoom * 0.15 * 0.5, 0.5 * renderScale);
 
     // Add AA margin for smooth edges without shrinking the visible line
-    float aaWidth = 1.5;
+    float aaWidth = 1.5 * renderScale;
 
     float totalHalfWidth = coreWidth + aaWidth;
     vec2 offset = perp * totalHalfWidth;

--- a/source/Shaders/LocationFS.h
+++ b/source/Shaders/LocationFS.h
@@ -26,6 +26,7 @@ uniform float zoom;
 uniform vec2 worldSize;
 uniform float radius;
 uniform bool borderlessRendering;
+uniform float renderScale;
 
 const int ForceField_None = 0;
 const int ForceField_Radial = 1;
@@ -81,7 +82,7 @@ void main()
     // } else {
     //     maxDim = vec2(gDimension1 + gFadeoutRadius * 2.0, gDimension2 + gFadeoutRadius * 2.0);
     // }
-    float padding = 4.0 / zoom;
+    float padding = 4.0 * renderScale / zoom;
     float halfSize = maxDim * 0.5 + padding;
     vec2 pixelOffset = gQuadCoord * 2.0 * halfSize;
     vec2 pixelWorldPos = gWorldPos + pixelOffset;
@@ -109,7 +110,7 @@ void main()
         // Calculate alpha based on distance
         if (distFromCenter <= gDimension1) {
             // Inside core radius - full opacity with anti-aliasing at edge
-            float edgeStart = gDimension1 - 2.0 / zoom;
+            float edgeStart = gDimension1 - 2.0 * renderScale / zoom;
             float edgeEnd = gDimension1;
             alpha = 1.0;// - smoothstep(edgeStart, edgeEnd, distFromCenter);
         } else {

--- a/source/Shaders/LocationGS.h
+++ b/source/Shaders/LocationGS.h
@@ -34,6 +34,7 @@ out vec2 gQuadCoord;  // Coordinates within the quad, from -0.5 to 0.5
 
 uniform vec2 viewportSize;
 uniform float zoom;
+uniform float renderScale;
 
 void main()
 {
@@ -60,7 +61,7 @@ void main()
     }
     
     // Add some padding for anti-aliasing (4 pixels worth in world space)
-    float padding = 4.0 / zoom;
+    float padding = 4.0 * renderScale / zoom;
     float halfSize = maxDim * 0.5 + padding;
     
     // Calculate size in NDC coordinates

--- a/source/Shaders/NonFluidObjectVS.h
+++ b/source/Shaders/NonFluidObjectVS.h
@@ -18,6 +18,7 @@ uniform vec2 rectUpperLeft;
 uniform float zoom;
 uniform float radius;
 uniform vec2 viewportSize;
+uniform float renderScale;
 
 const int ObjectType_Fluid = 1;
 const float DetailZoom = 5.0;
@@ -41,14 +42,16 @@ void main()
     // Cells are rendered in front of lines (apply negative bias to bring forward)
     gl_Position = vec4(ndc, aPos.z, 1.0);
 
+    float screenZoom = zoom / renderScale;
+
     bool isIsolatedOrTail = ((state >> 16) & 0x1) == 1;
-    if (!isIsolatedOrTail && zoom < DetailZoom) {
+    if (!isIsolatedOrTail && screenZoom < DetailZoom) {
         // Discard cells that have connections when zoomed out to avoid Moire patterns
         gl_Position = vec4(-2.0, -2.0, -2.0, 1.0);
     }
-    float sizeFactor = isIsolatedOrTail ? max(1.0, min(2.0, zoom * 2)): 1.0;
-    
-    float visibleHighlightIntensity = zoom < DetailZoom ? 0.0 : highlightIntensity;
+    float sizeFactor = isIsolatedOrTail ? max(1.0, min(2.0, screenZoom * 2)): 1.0;
+
+    float visibleHighlightIntensity = screenZoom < DetailZoom ? 0.0 : highlightIntensity;
     vColor = mix(aColor, vec3(1.0), visibleHighlightIntensity * 0.2);
     gl_PointSize = radius * (0.4 + visibleHighlightIntensity * 0.2) * sizeFactor;
 }

--- a/source/Shaders/SelectedObjectFS.h
+++ b/source/Shaders/SelectedObjectFS.h
@@ -14,6 +14,7 @@ in vec2 gQuadCoord;
 uniform float zoom;
 uniform vec2 worldSize;
 uniform float radius;
+uniform float renderScale;
 
 const float AlphaForFadeout = 0.1;
 const float AlphaForCircle = 0.3;
@@ -26,13 +27,13 @@ void main()
     // Circle radius in normalized quad space (0.5 = edge)
     float outerRadius = 0.5;
     float middleRadius = 0.4;
-    float innerRadius = middleRadius - 3.0 / zoom; // Thin circle (2 pixels)
+    float innerRadius = middleRadius - 3.0 * renderScale / zoom; // Thin circle (2 pixels)
 
     if (dist > outerRadius || dist < innerRadius) {
         discard;
     }
 
-    float zoomFadeout = min(1.0, zoom / 8);
+    float zoomFadeout = min(1.0, zoom / renderScale / 8);
     FragColor = vec4(1.0, 1.0, 1.0, dist > middleRadius ? AlphaForFadeout * zoomFadeout : AlphaForCircle * zoomFadeout);
 }
 )";

--- a/source/Shaders/TriangleVS.h
+++ b/source/Shaders/TriangleVS.h
@@ -16,6 +16,7 @@ uniform vec2 worldSize;
 uniform vec2 rectUpperLeft;
 uniform float zoom;
 uniform vec2 viewportSize;
+uniform float renderScale;
 
 void main()
 {
@@ -28,7 +29,7 @@ void main()
     gl_Position = vec4(ndc, aPos.z, 1.0);
     
     // At zoom 3 there are not individual cells visible anymore, so no need to highlight the polygone more
-    vertexColor = zoom < 3.0 ? aColor * 1.4 : aColor;
+    vertexColor = zoom / renderScale < 3.0 ? aColor * 1.4 : aColor;
 }
 )";
 }

--- a/source/Shaders/ZoomBrightnessCorrectionFS.h
+++ b/source/Shaders/ZoomBrightnessCorrectionFS.h
@@ -14,12 +14,13 @@ uniform sampler2D inputTexture1;
 uniform vec2 viewportSize;
 uniform float zoom;
 uniform float strength;
+uniform float renderScale;
 
 void main()
 {
     vec2 texelSize = 1.0 / viewportSize;
-    
-    FragColor = texture(inputTexture1, texCoord) * min(1.0, zoom * strength);
+
+    FragColor = texture(inputTexture1, texCoord) * min(1.0, zoom / renderScale * strength);
 }
 )";
 }


### PR DESCRIPTION
Adds a "Save picture" entry to the *Simulation* menu that writes the currently visible world region to a PNG file at a freely adjustable resolution.

## Dialog

`SavePictureDialog` lets the user enter width and height directly (with an *Adopt view size* button) and then opens the usual file dialog with a `*.png` filter. Resolution and last used directory are persisted in the global settings.

The horizontally visible world range is preserved; the vertical range follows from the aspect ratio of the chosen resolution.

## Offscreen rendering

`SimulationView::savePicture` renders the scene into its own framebuffer and reads it back via `glReadPixels`. Viewport, zoom factor and pipeline size are restored through an `ExitScopeGuard`, so they also survive an error. The resolution is checked against `GL_MAX_TEXTURE_SIZE`. `_RenderPipeline::execute` takes an optional final render target, which defaults to the screen.

## Keeping the appearance at higher resolutions

Rendering at a higher resolution scales the geometry, but every effect whose size is defined in pixels stayed absolutely the same and therefore became relatively smaller. In addition, the zoom-dependent heuristics saw the enlarged zoom factor and switched to different levels. The result was a picture with tiny cells, hairline connections and almost no bloom.

`Viewport` now provides:

* `getRenderScale()` — rendered pixels per screen pixel, `1.0` in normal operation
* `getScreenZoomFactor()` — zoom factor divided by the render scale, i.e. the zoom an equivalent view on screen would have

The render scale is passed to all shaders as a `renderScale` uniform. Everything with a size in pixels is multiplied by it, and everything depending on the visual zoom level uses the screen zoom factor instead:

| Quantity | Before | Now |
| --- | --- | --- |
| Cell point radius | `max(6px, zoom)` | `max(6px * scale, zoom)` |
| Line core width / antialiasing | floor `0.5px`, margin `1.5px` | `0.5px * scale`, `1.5px * scale` |
| Bloom radius limit | `20px` | `20px * scale` |
| Bloom strength and repetitions | derived from enlarged zoom | derived from screen zoom |
| Zoom brightness correction | enlarged zoom | screen zoom |
| Detail thresholds (moire cull, cell type overlay, selection arrows, fluid balls, polygon highlighting, grid lines, location and selection borders) | enlarged zoom | screen zoom, pixel sizes scaled |

## Notes

* The final denoise pass still averages over 2x2 texels and is therefore relatively weaker at high resolutions. This makes the picture slightly sharper than the screenshot, which seemed preferable to blurring a high resolution render on purpose.
* Fluid particles are drawn as point sprites, whose size the driver limits via `GL_POINT_SIZE_MAX`. At very large scale factors the fluid clouds may not grow any further.

## Tests

`EngineInterfaceTests` (175), `NetworkTests` (4) and `PersisterTests` (69) pass. The change is GUI and shader only; `EngineTests` was not run.
