### PR TITLE
Download Startup.sim from browser if no autosave exists

### DIFF
--- a/source/Base/Resources.h
+++ b/source/Base/Resources.h
@@ -7,7 +7,7 @@ namespace Const
     std::string const ProgramVersion = "5.0.0-alpha.26";
     std::string const DiscordURL = "https://discord.gg/7bjyZdXXQ2";
     std::string const AlienServerURL = "api.alien-project.org";
-    std::string const StartupSimulationResourceName = "Startup.sim";
+    std::string const StartupSimulationResourceName = "Startup/Version1";
 
     std::filesystem::path const ResourcePath = "resources";
     std::filesystem::path const AutosavePath = ResourcePath / "autosave";

--- a/source/Base/Resources.h
+++ b/source/Base/Resources.h
@@ -7,6 +7,7 @@ namespace Const
     std::string const ProgramVersion = "5.0.0-alpha.26";
     std::string const DiscordURL = "https://discord.gg/7bjyZdXXQ2";
     std::string const AlienServerURL = "api.alien-project.org";
+    std::string const StartupSimulationResourceName = "Startup.sim";
 
     std::filesystem::path const ResourcePath = "resources";
     std::filesystem::path const AutosavePath = ResourcePath / "autosave";

--- a/source/EngineTests/BalanceTests.cpp
+++ b/source/EngineTests/BalanceTests.cpp
@@ -153,7 +153,7 @@ TEST_F(BalanceTests, longRunning_smallCreatures_vs_largeCreatures_fewDigestionCa
 
     _simulationFacade->setSimulationData(data);
 
-    _simulationFacade->calcTimesteps(20000);
+    _simulationFacade->calcTimesteps(25000);
 
 
     auto stats = calcLineageStats();
@@ -179,7 +179,7 @@ TEST_F(BalanceTests, longRunning_smallCreatures_vs_largeCreatures_highDigestionC
 
     _simulationFacade->setSimulationData(data);
 
-    _simulationFacade->calcTimesteps(20000);
+    _simulationFacade->calcTimesteps(25000);
 
     auto stats = calcLineageStats();
     EXPECT_LT(90, stats.numLargeCells);

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -15,6 +15,8 @@
 #include <Base/LoggingService.h>
 #include <Base/Resources.h>
 
+#include <Network/NetworkResourceRawTO.h>
+
 #include <EngineInterface/SimulationFacade.h>
 
 #include <PersisterInterface/PersisterFacade.h>
@@ -68,6 +70,25 @@ namespace
     std::chrono::milliseconds::rep const FadeInDuration = 500;
 
     auto const StartupSenderId = "Startup";
+
+    auto const StartupSimulationResourceName = std::string("Startup.sim");
+
+    std::optional<NetworkResourceRawTO> findStartupSimulation(std::vector<NetworkResourceRawTO> const& resourceTOs)
+    {
+        std::optional<NetworkResourceRawTO> result;
+        for (auto const& resourceTO : resourceTOs) {
+            if (resourceTO->resourceType != NetworkResourceType_Simulation || resourceTO->resourceName != StartupSimulationResourceName) {
+                continue;
+            }
+            if (resourceTO->workspaceType == WorkspaceType_AlienProject) {
+                return resourceTO;
+            }
+            if (!result.has_value()) {
+                result = resourceTO;
+            }
+        }
+        return result;
+    }
 }
 
 void MainLoopController::setup()
@@ -97,6 +118,10 @@ void MainLoopController::process()
         processFirstTick();
     } else if (_programState == ProgramState::LoadingScreen) {
         processLoadingScreen();
+    } else if (_programState == ProgramState::SearchingStartupSimulation) {
+        processSearchingStartupSimulation();
+    } else if (_programState == ProgramState::DownloadingStartupSimulation) {
+        processDownloadingStartupSimulation();
     } else if (_programState == ProgramState::FadeOutLoadingScreen) {
         processFadeOutLoadingScreen();
     } else if (_programState == ProgramState::FadeInUI) {
@@ -136,10 +161,11 @@ void MainLoopController::processFirstTick()
 {
     drawLoadingScreen();
 
-    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
-    auto readData = ReadSimulationRequestData{.filename = Const::AutosaveFile, .initSimulation = true};
-    _loadSimRequestId = _PersisterFacade::get()->scheduleReadSimulation(senderInfo, readData);
-    _programState = ProgramState::LoadingScreen;
+    if (std::filesystem::exists(Const::AutosaveFile)) {
+        scheduleLoadingAutosave();
+    } else {
+        scheduleSearchingStartupSimulation();
+    }
 
     OverlayController::get().process();
 
@@ -153,35 +179,123 @@ void MainLoopController::processLoadingScreen()
     if (auto requestedSimState = _PersisterFacade::get()->getRequestState(_loadSimRequestId)) {
         if (requestedSimState.value() == PersisterRequestState::Finished) {
             auto const& data = _PersisterFacade::get()->fetchReadSimulationData(_loadSimRequestId);
-            auto const& deserializedSim = data.simulationDesc;
-            Viewport::get().setCenterInWorldPos(deserializedSim._center);
-            Viewport::get().setZoomFactor(deserializedSim._zoom);
-            TemporalControlWindow::get().onSnapshot();
-
-            _simulationLoadedTimepoint = std::chrono::steady_clock::now();
-            _programState = ProgramState::FadeOutLoadingScreen;
+            finishSimulationLoading(data.simulationDesc);
         }
         if (requestedSimState.value() == PersisterRequestState::Error) {
-            GenericMessageDialog::get().information("Error", "The default simulation file could not be read.\nAn empty simulation will be created.");
-
-            SimulationDesc deserializedSim;
-            deserializedSim.worldSize({1000, 500}).timestep(0).zoom(12.0f).center({500.0f, 250.0f}).realTime(std::chrono::milliseconds(0));
-
-            _SimulationFacade::get()->newSimulation(deserializedSim._timestep, deserializedSim._worldSize, deserializedSim._simulationParameters);
-            _SimulationFacade::get()->setSimulationData(deserializedSim._mainData);
-            _SimulationFacade::get()->setStatisticsHistory(deserializedSim._statistics);
-            _SimulationFacade::get()->setRealTime(deserializedSim._realTime);
-            Viewport::get().setCenterInWorldPos(deserializedSim._center);
-            Viewport::get().setZoomFactor(deserializedSim._zoom);
-            TemporalControlWindow::get().onSnapshot();
-
-            _simulationLoadedTimepoint = std::chrono::steady_clock::now();
-            _programState = ProgramState::FadeOutLoadingScreen;
+            setupEmptySimulation("The default simulation file could not be read.\nAn empty simulation will be created.");
         }
     }
     OverlayController::get().process();
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+void MainLoopController::processSearchingStartupSimulation()
+{
+    drawLoadingScreen();
+
+    if (auto requestedState = _PersisterFacade::get()->getRequestState(_getNetworkResourcesRequestId)) {
+        if (requestedState.value() == PersisterRequestState::Finished) {
+            auto const& data = _PersisterFacade::get()->fetchGetNetworkResourcesData(_getNetworkResourcesRequestId);
+            if (auto const& resourceTO = findStartupSimulation(data.resourceTOs)) {
+                scheduleDownloadingStartupSimulation(resourceTO.value());
+            } else {
+                setupEmptySimulation(
+                    "The startup simulation '" + StartupSimulationResourceName + "' could not be found in the browser.\nAn empty simulation will be created.");
+            }
+        }
+        if (requestedState.value() == PersisterRequestState::Error) {
+            setupEmptySimulation("The browser data could not be retrieved.\nAn empty simulation will be created.");
+        }
+    }
+    OverlayController::get().process();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+void MainLoopController::processDownloadingStartupSimulation()
+{
+    drawLoadingScreen();
+
+    if (auto requestedState = _PersisterFacade::get()->getRequestState(_downloadSimRequestId)) {
+        if (requestedState.value() == PersisterRequestState::Finished) {
+            auto const& data = _PersisterFacade::get()->fetchDownloadNetworkResourcesData(_downloadSimRequestId);
+            auto const& deserializedSim = std::get<SimulationDesc>(data.resourceData);
+            try {
+                setupSimulation(deserializedSim);
+                _loadedSimulationName = data.resourceName;
+                finishSimulationLoading(deserializedSim);
+            } catch (...) {
+                _SimulationFacade::get()->closeSimulation();
+                setupEmptySimulation("The startup simulation could not be loaded.\nAn empty simulation will be created.");
+            }
+        }
+        if (requestedState.value() == PersisterRequestState::Error) {
+            setupEmptySimulation("The startup simulation could not be downloaded.\nAn empty simulation will be created.");
+        }
+    }
+    OverlayController::get().process();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+void MainLoopController::scheduleLoadingAutosave()
+{
+    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
+    auto readData = ReadSimulationRequestData{.filename = Const::AutosaveFile, .initSimulation = true};
+    _loadSimRequestId = _PersisterFacade::get()->scheduleReadSimulation(senderInfo, readData);
+    _loadedSimulationName = Const::AutosaveFileWithoutPath.string();
+    _programState = ProgramState::LoadingScreen;
+}
+
+void MainLoopController::scheduleSearchingStartupSimulation()
+{
+    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
+    _getNetworkResourcesRequestId = _PersisterFacade::get()->scheduleGetNetworkResources(senderInfo, GetNetworkResourcesRequestData());
+    _programState = ProgramState::SearchingStartupSimulation;
+}
+
+void MainLoopController::scheduleDownloadingStartupSimulation(NetworkResourceRawTO const& resourceTO)
+{
+    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
+    auto downloadData = DownloadNetworkResourceRequestData{
+        .resourceId = resourceTO->id,
+        .resourceName = resourceTO->resourceName,
+        .resourceVersion = resourceTO->version,
+        .resourceType = NetworkResourceType_Simulation,
+        .downloadCache = BrowserWindow::get().getSimulationCache()};
+    _downloadSimRequestId = _PersisterFacade::get()->scheduleDownloadNetworkResource(senderInfo, downloadData);
+    _programState = ProgramState::DownloadingStartupSimulation;
+}
+
+void MainLoopController::setupSimulation(SimulationDesc const& simulationDesc)
+{
+    _SimulationFacade::get()->newSimulation(simulationDesc._timestep, simulationDesc._worldSize, simulationDesc._simulationParameters);
+    _SimulationFacade::get()->setSimulationData(simulationDesc._mainData);
+    _SimulationFacade::get()->setStatisticsHistory(simulationDesc._statistics);
+    _SimulationFacade::get()->setRealTime(simulationDesc._realTime);
+}
+
+void MainLoopController::setupEmptySimulation(std::string const& errorMessage)
+{
+    GenericMessageDialog::get().information("Error", errorMessage);
+
+    SimulationDesc emptySim;
+    emptySim.worldSize({1000, 500}).timestep(0).zoom(12.0f).center({500.0f, 250.0f}).realTime(std::chrono::milliseconds(0));
+
+    setupSimulation(emptySim);
+    _loadedSimulationName.clear();
+    finishSimulationLoading(emptySim);
+}
+
+void MainLoopController::finishSimulationLoading(SimulationDesc const& simulationDesc)
+{
+    Viewport::get().setCenterInWorldPos(simulationDesc._center);
+    Viewport::get().setZoomFactor(simulationDesc._zoom);
+    TemporalControlWindow::get().onSnapshot();
+
+    _simulationLoadedTimepoint = std::chrono::steady_clock::now();
+    _programState = ProgramState::FadeOutLoadingScreen;
 }
 
 void MainLoopController::processFadeOutLoadingScreen()
@@ -210,7 +324,9 @@ void MainLoopController::processFadeInUI()
 
     increaseAlphaForFadeInUI();
     if (ImGui::GetStyle().Alpha == 1.0f) {
-        printOverlayMessage(Const::AutosaveFileWithoutPath.string());
+        if (!_loadedSimulationName.empty()) {
+            printOverlayMessage(_loadedSimulationName);
+        }
         _programState = ProgramState::OperatingMode;
     }
 }

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -1,5 +1,6 @@
 #include "MainLoopController.h"
 
+#include <ranges>
 #include <thread>
 
 #include <glad/glad.h>
@@ -15,12 +16,11 @@
 #include <Base/LoggingService.h>
 #include <Base/Resources.h>
 
-#include <Network/NetworkResourceRawTO.h>
-
 #include <EngineInterface/SimulationFacade.h>
 
 #include <PersisterInterface/PersisterFacade.h>
 #include <PersisterInterface/SerializerService.h>
+#include <PersisterInterface/TaskProcessor.h>
 
 #include "AboutDialog.h"
 #include "AlienGui.h"
@@ -70,25 +70,6 @@ namespace
     std::chrono::milliseconds::rep const FadeInDuration = 500;
 
     auto const StartupSenderId = "Startup";
-
-    auto const StartupSimulationResourceName = std::string("Startup.sim");
-
-    std::optional<NetworkResourceRawTO> findStartupSimulation(std::vector<NetworkResourceRawTO> const& resourceTOs)
-    {
-        std::optional<NetworkResourceRawTO> result;
-        for (auto const& resourceTO : resourceTOs) {
-            if (resourceTO->resourceType != NetworkResourceType_Simulation || resourceTO->resourceName != StartupSimulationResourceName) {
-                continue;
-            }
-            if (resourceTO->workspaceType == WorkspaceType_AlienProject) {
-                return resourceTO;
-            }
-            if (!result.has_value()) {
-                result = resourceTO;
-            }
-        }
-        return result;
-    }
 }
 
 void MainLoopController::setup()
@@ -97,6 +78,9 @@ void MainLoopController::setup()
 
     _logo = OpenGLHelper::loadTexture(Const::LogoFilename);
     _saveOnExit = GlobalSettings::get().getValue("controllers.main loop.save on exit", _saveOnExit);
+
+    _startupProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
+    _downloadProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
 }
 
 void MainLoopController::process()
@@ -118,10 +102,6 @@ void MainLoopController::process()
         processFirstTick();
     } else if (_programState == ProgramState::LoadingScreen) {
         processLoadingScreen();
-    } else if (_programState == ProgramState::SearchingStartupSimulation) {
-        processSearchingStartupSimulation();
-    } else if (_programState == ProgramState::DownloadingStartupSimulation) {
-        processDownloadingStartupSimulation();
     } else if (_programState == ProgramState::FadeOutLoadingScreen) {
         processFadeOutLoadingScreen();
     } else if (_programState == ProgramState::FadeInUI) {
@@ -162,10 +142,11 @@ void MainLoopController::processFirstTick()
     drawLoadingScreen();
 
     if (std::filesystem::exists(Const::AutosaveFile)) {
-        scheduleLoadingAutosave();
+        scheduleReadingAutosave();
     } else {
         scheduleSearchingStartupSimulation();
     }
+    _programState = ProgramState::LoadingScreen;
 
     OverlayController::get().process();
 
@@ -176,96 +157,72 @@ void MainLoopController::processLoadingScreen()
 {
     drawLoadingScreen();
 
-    if (auto requestedSimState = _PersisterFacade::get()->getRequestState(_loadSimRequestId)) {
-        if (requestedSimState.value() == PersisterRequestState::Finished) {
-            auto const& data = _PersisterFacade::get()->fetchReadSimulationData(_loadSimRequestId);
+    _startupProcessor->process();
+    _downloadProcessor->process();
+
+    OverlayController::get().process();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+void MainLoopController::scheduleReadingAutosave()
+{
+    _startupProcessor->executeTask(
+        [](auto const& senderId) {
+            return _PersisterFacade::get()->scheduleReadSimulation(
+                SenderInfo{.senderId = senderId, .wishResultData = true, .wishErrorInfo = true},
+                ReadSimulationRequestData{.filename = Const::AutosaveFile, .initSimulation = true});
+        },
+        [this](auto const& requestId) {
+            auto const& data = _PersisterFacade::get()->fetchReadSimulationData(requestId);
+            _loadedSimulationName = Const::AutosaveFileWithoutPath.string();
             finishSimulationLoading(data.simulationDesc);
-        }
-        if (requestedSimState.value() == PersisterRequestState::Error) {
-            setupEmptySimulation("The default simulation file could not be read.\nAn empty simulation will be created.");
-        }
-    }
-    OverlayController::get().process();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-}
-
-void MainLoopController::processSearchingStartupSimulation()
-{
-    drawLoadingScreen();
-
-    if (auto requestedState = _PersisterFacade::get()->getRequestState(_getNetworkResourcesRequestId)) {
-        if (requestedState.value() == PersisterRequestState::Finished) {
-            auto const& data = _PersisterFacade::get()->fetchGetNetworkResourcesData(_getNetworkResourcesRequestId);
-            if (auto const& resourceTO = findStartupSimulation(data.resourceTOs)) {
-                scheduleDownloadingStartupSimulation(resourceTO.value());
-            } else {
-                setupEmptySimulation(
-                    "The startup simulation '" + StartupSimulationResourceName + "' could not be found in the browser.\nAn empty simulation will be created.");
-            }
-        }
-        if (requestedState.value() == PersisterRequestState::Error) {
-            setupEmptySimulation("The browser data could not be retrieved.\nAn empty simulation will be created.");
-        }
-    }
-    OverlayController::get().process();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-}
-
-void MainLoopController::processDownloadingStartupSimulation()
-{
-    drawLoadingScreen();
-
-    if (auto requestedState = _PersisterFacade::get()->getRequestState(_downloadSimRequestId)) {
-        if (requestedState.value() == PersisterRequestState::Finished) {
-            auto const& data = _PersisterFacade::get()->fetchDownloadNetworkResourcesData(_downloadSimRequestId);
-            auto const& deserializedSim = std::get<SimulationDesc>(data.resourceData);
-            try {
-                setupSimulation(deserializedSim);
-                _loadedSimulationName = data.resourceName;
-                finishSimulationLoading(deserializedSim);
-            } catch (...) {
-                _SimulationFacade::get()->closeSimulation();
-                setupEmptySimulation("The startup simulation could not be loaded.\nAn empty simulation will be created.");
-            }
-        }
-        if (requestedState.value() == PersisterRequestState::Error) {
-            setupEmptySimulation("The startup simulation could not be downloaded.\nAn empty simulation will be created.");
-        }
-    }
-    OverlayController::get().process();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-}
-
-void MainLoopController::scheduleLoadingAutosave()
-{
-    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
-    auto readData = ReadSimulationRequestData{.filename = Const::AutosaveFile, .initSimulation = true};
-    _loadSimRequestId = _PersisterFacade::get()->scheduleReadSimulation(senderInfo, readData);
-    _loadedSimulationName = Const::AutosaveFileWithoutPath.string();
-    _programState = ProgramState::LoadingScreen;
+        },
+        [this](auto const&) { setupEmptySimulation(); });
 }
 
 void MainLoopController::scheduleSearchingStartupSimulation()
 {
-    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
-    _getNetworkResourcesRequestId = _PersisterFacade::get()->scheduleGetNetworkResources(senderInfo, GetNetworkResourcesRequestData());
-    _programState = ProgramState::SearchingStartupSimulation;
+    _startupProcessor->executeTask(
+        [](auto const& senderId) {
+            return _PersisterFacade::get()->scheduleGetNetworkResources(
+                SenderInfo{.senderId = senderId, .wishResultData = true, .wishErrorInfo = true}, GetNetworkResourcesRequestData());
+        },
+        [this](auto const& requestId) {
+            auto const& data = _PersisterFacade::get()->fetchGetNetworkResourcesData(requestId);
+            auto startupSimulation = std::ranges::find_if(data.resourceTOs, [](auto const& resourceTO) {
+                return resourceTO->resourceType == NetworkResourceType_Simulation && resourceTO->resourceName == Const::StartupSimulationResourceName;
+            });
+            if (startupSimulation != data.resourceTOs.end()) {
+                scheduleDownloadingStartupSimulation(*startupSimulation);
+            } else {
+                setupEmptySimulation();
+            }
+        },
+        [this](auto const&) { setupEmptySimulation(); });
 }
 
 void MainLoopController::scheduleDownloadingStartupSimulation(NetworkResourceRawTO const& resourceTO)
 {
-    auto senderInfo = SenderInfo{.senderId = SenderId{StartupSenderId}, .wishResultData = true, .wishErrorInfo = true};
-    auto downloadData = DownloadNetworkResourceRequestData{
-        .resourceId = resourceTO->id,
-        .resourceName = resourceTO->resourceName,
-        .resourceVersion = resourceTO->version,
-        .resourceType = NetworkResourceType_Simulation,
-        .downloadCache = BrowserWindow::get().getSimulationCache()};
-    _downloadSimRequestId = _PersisterFacade::get()->scheduleDownloadNetworkResource(senderInfo, downloadData);
-    _programState = ProgramState::DownloadingStartupSimulation;
+    _downloadProcessor->executeTask(
+        [&](auto const& senderId) {
+            return _PersisterFacade::get()->scheduleDownloadNetworkResource(
+                SenderInfo{.senderId = senderId, .wishResultData = true, .wishErrorInfo = true},
+                DownloadNetworkResourceRequestData{
+                    .resourceId = resourceTO->id,
+                    .resourceName = resourceTO->resourceName,
+                    .resourceVersion = resourceTO->version,
+                    .resourceType = NetworkResourceType_Simulation,
+                    .downloadCache = BrowserWindow::get().getSimulationCache()});
+        },
+        [this](auto const& requestId) {
+            auto const& data = _PersisterFacade::get()->fetchDownloadNetworkResourcesData(requestId);
+            auto const& deserializedSim = std::get<SimulationDesc>(data.resourceData);
+            _loadedSimulationName = data.resourceName;
+            setupSimulation(deserializedSim);
+            finishSimulationLoading(deserializedSim);
+        },
+        [this](auto const&) { setupEmptySimulation(); });
 }
 
 void MainLoopController::setupSimulation(SimulationDesc const& simulationDesc)
@@ -276,15 +233,14 @@ void MainLoopController::setupSimulation(SimulationDesc const& simulationDesc)
     _SimulationFacade::get()->setRealTime(simulationDesc._realTime);
 }
 
-void MainLoopController::setupEmptySimulation(std::string const& errorMessage)
+void MainLoopController::setupEmptySimulation()
 {
-    GenericMessageDialog::get().information("Error", errorMessage);
+    GenericMessageDialog::get().information("Error", "The simulation could not be loaded.\nAn empty simulation will be created.");
 
     SimulationDesc emptySim;
     emptySim.worldSize({1000, 500}).timestep(0).zoom(12.0f).center({500.0f, 250.0f}).realTime(std::chrono::milliseconds(0));
 
     setupSimulation(emptySim);
-    _loadedSimulationName.clear();
     finishSimulationLoading(emptySim);
 }
 

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -185,7 +185,6 @@ void MainLoopController::scheduleReadingAutosave()
 
 void MainLoopController::scheduleSearchingStartupSimulation()
 {
-    OverlayController::get().activateProgressAnimation(true);
     _searchProcessor->executeTask(
         [](auto const& senderId) {
             return _PersisterFacade::get()->scheduleGetNetworkResources(
@@ -249,8 +248,6 @@ void MainLoopController::setupEmptySimulation()
 
 void MainLoopController::finishSimulationLoading(SimulationDesc const& simulationDesc)
 {
-    OverlayController::get().activateProgressAnimation(false);
-
     Viewport::get().setCenterInWorldPos(simulationDesc._center);
     Viewport::get().setZoomFactor(simulationDesc._zoom);
     TemporalControlWindow::get().onSnapshot();

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -183,6 +183,7 @@ void MainLoopController::scheduleReadingAutosave()
 
 void MainLoopController::scheduleSearchingStartupSimulation()
 {
+    OverlayController::get().activateProgressAnimation(true);
     _startupProcessor->executeTask(
         [](auto const& senderId) {
             return _PersisterFacade::get()->scheduleGetNetworkResources(
@@ -246,6 +247,8 @@ void MainLoopController::setupEmptySimulation()
 
 void MainLoopController::finishSimulationLoading(SimulationDesc const& simulationDesc)
 {
+    OverlayController::get().activateProgressAnimation(false);
+
     Viewport::get().setCenterInWorldPos(simulationDesc._center);
     Viewport::get().setZoomFactor(simulationDesc._zoom);
     TemporalControlWindow::get().onSnapshot();

--- a/source/Gui/MainLoopController.cpp
+++ b/source/Gui/MainLoopController.cpp
@@ -79,7 +79,8 @@ void MainLoopController::setup()
     _logo = OpenGLHelper::loadTexture(Const::LogoFilename);
     _saveOnExit = GlobalSettings::get().getValue("controllers.main loop.save on exit", _saveOnExit);
 
-    _startupProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
+    _autosaveProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
+    _searchProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
     _downloadProcessor = _TaskProcessor::createTaskProcessor(_PersisterFacade::get());
 }
 
@@ -157,7 +158,8 @@ void MainLoopController::processLoadingScreen()
 {
     drawLoadingScreen();
 
-    _startupProcessor->process();
+    _autosaveProcessor->process();
+    _searchProcessor->process();
     _downloadProcessor->process();
 
     OverlayController::get().process();
@@ -167,7 +169,7 @@ void MainLoopController::processLoadingScreen()
 
 void MainLoopController::scheduleReadingAutosave()
 {
-    _startupProcessor->executeTask(
+    _autosaveProcessor->executeTask(
         [](auto const& senderId) {
             return _PersisterFacade::get()->scheduleReadSimulation(
                 SenderInfo{.senderId = senderId, .wishResultData = true, .wishErrorInfo = true},
@@ -178,13 +180,13 @@ void MainLoopController::scheduleReadingAutosave()
             _loadedSimulationName = Const::AutosaveFileWithoutPath.string();
             finishSimulationLoading(data.simulationDesc);
         },
-        [this](auto const&) { setupEmptySimulation(); });
+        [this](auto const&) { scheduleSearchingStartupSimulation(); });
 }
 
 void MainLoopController::scheduleSearchingStartupSimulation()
 {
     OverlayController::get().activateProgressAnimation(true);
-    _startupProcessor->executeTask(
+    _searchProcessor->executeTask(
         [](auto const& senderId) {
             return _PersisterFacade::get()->scheduleGetNetworkResources(
                 SenderInfo{.senderId = senderId, .wishResultData = true, .wishErrorInfo = true}, GetNetworkResourcesRequestData());

--- a/source/Gui/MainLoopController.h
+++ b/source/Gui/MainLoopController.h
@@ -5,6 +5,9 @@
 #include <Base/Singleton.h>
 
 #include <EngineInterface/Definitions.h>
+#include <EngineInterface/Descs.h>
+
+#include <Network/NetworkResourceRawTO.h>
 
 #include <PersisterInterface/Definitions.h>
 #include <PersisterInterface/PersisterRequestId.h>
@@ -26,11 +29,20 @@ public:
 private:
     void processFirstTick();
     void processLoadingScreen();
+    void processSearchingStartupSimulation();
+    void processDownloadingStartupSimulation();
     void processFadeOutLoadingScreen();
     void processFadeInUI();
     void processOperatingMode();
     void processScheduleExit();
     void processExiting();
+
+    void scheduleLoadingAutosave();
+    void scheduleSearchingStartupSimulation();
+    void scheduleDownloadingStartupSimulation(NetworkResourceRawTO const& resourceTO);
+    void setupSimulation(SimulationDesc const& simulationDesc);
+    void setupEmptySimulation(std::string const& errorMessage);
+    void finishSimulationLoading(SimulationDesc const& simulationDesc);
 
     void drawLoadingScreen();
     void decreaseAlphaForFadeOutLoadingScreen();
@@ -44,6 +56,8 @@ private:
     {
         FirstTick,
         LoadingScreen,
+        SearchingStartupSimulation,
+        DownloadingStartupSimulation,
         FadeOutLoadingScreen,
         FadeInUI,
         OperatingMode,
@@ -55,7 +69,10 @@ private:
     bool _saveOnExit = true;
 
     PersisterRequestId _loadSimRequestId;
+    PersisterRequestId _getNetworkResourcesRequestId;
+    PersisterRequestId _downloadSimRequestId;
     PersisterRequestId _saveSimRequestId;
+    std::string _loadedSimulationName;
 
     TextureData _logo;
     std::optional<std::chrono::steady_clock::time_point> _simulationLoadedTimepoint;

--- a/source/Gui/MainLoopController.h
+++ b/source/Gui/MainLoopController.h
@@ -64,7 +64,8 @@ private:
     ProgramState _programState = ProgramState::FirstTick;
     bool _saveOnExit = true;
 
-    TaskProcessor _startupProcessor;
+    TaskProcessor _autosaveProcessor;
+    TaskProcessor _searchProcessor;
     TaskProcessor _downloadProcessor;
     PersisterRequestId _saveSimRequestId;
     std::string _loadedSimulationName;

--- a/source/Gui/MainLoopController.h
+++ b/source/Gui/MainLoopController.h
@@ -29,19 +29,17 @@ public:
 private:
     void processFirstTick();
     void processLoadingScreen();
-    void processSearchingStartupSimulation();
-    void processDownloadingStartupSimulation();
     void processFadeOutLoadingScreen();
     void processFadeInUI();
     void processOperatingMode();
     void processScheduleExit();
     void processExiting();
 
-    void scheduleLoadingAutosave();
+    void scheduleReadingAutosave();
     void scheduleSearchingStartupSimulation();
     void scheduleDownloadingStartupSimulation(NetworkResourceRawTO const& resourceTO);
     void setupSimulation(SimulationDesc const& simulationDesc);
-    void setupEmptySimulation(std::string const& errorMessage);
+    void setupEmptySimulation();
     void finishSimulationLoading(SimulationDesc const& simulationDesc);
 
     void drawLoadingScreen();
@@ -56,8 +54,6 @@ private:
     {
         FirstTick,
         LoadingScreen,
-        SearchingStartupSimulation,
-        DownloadingStartupSimulation,
         FadeOutLoadingScreen,
         FadeInUI,
         OperatingMode,
@@ -68,9 +64,8 @@ private:
     ProgramState _programState = ProgramState::FirstTick;
     bool _saveOnExit = true;
 
-    PersisterRequestId _loadSimRequestId;
-    PersisterRequestId _getNetworkResourcesRequestId;
-    PersisterRequestId _downloadSimRequestId;
+    TaskProcessor _startupProcessor;
+    TaskProcessor _downloadProcessor;
     PersisterRequestId _saveSimRequestId;
     std::string _loadedSimulationName;
 

--- a/source/Gui/OverlayController.cpp
+++ b/source/Gui/OverlayController.cpp
@@ -61,14 +61,9 @@ void OverlayController::setOn(bool value)
     _on = value;
 }
 
-void OverlayController::activateProgressAnimation(bool value)
-{
-    _progressAnimationActivated = value;
-}
-
 void OverlayController::processProgressAnimation()
 {
-    if (_progressAnimationActivated || _PersisterFacade::get()->isBusy()) {
+    if (_PersisterFacade::get()->isBusy()) {
         _busyTimepoint = std::chrono::steady_clock::now();
     }
     if (!_busyTimepoint.has_value()) {

--- a/source/Gui/OverlayController.cpp
+++ b/source/Gui/OverlayController.cpp
@@ -61,11 +61,14 @@ void OverlayController::setOn(bool value)
     _on = value;
 }
 
-void OverlayController::activateProgressAnimation(bool value) {}
+void OverlayController::activateProgressAnimation(bool value)
+{
+    _progressAnimationActivated = value;
+}
 
 void OverlayController::processProgressAnimation()
 {
-    if (_PersisterFacade::get()->isBusy()) {
+    if (_progressAnimationActivated || _PersisterFacade::get()->isBusy()) {
         _busyTimepoint = std::chrono::steady_clock::now();
     }
     if (!_busyTimepoint.has_value()) {

--- a/source/Gui/OverlayController.h
+++ b/source/Gui/OverlayController.h
@@ -18,14 +18,12 @@ public:
 
     bool isOn() const;
     void setOn(bool value);
-    void activateProgressAnimation(bool value);
 
 private:
     void processProgressAnimation();
     void processMessage();
 
     bool _show = false;
-    bool _progressAnimationActivated = false;
     bool _withLightning = false;
     bool _on = true;
     std::string _message;

--- a/source/Gui/OverlayController.h
+++ b/source/Gui/OverlayController.h
@@ -25,6 +25,7 @@ private:
     void processMessage();
 
     bool _show = false;
+    bool _progressAnimationActivated = false;
     bool _withLightning = false;
     bool _on = true;
     std::string _message;


### PR DESCRIPTION
If `resources/autosave/autosave.sim` is missing at startup, the simulation named `Startup.sim` (`Const::StartupSimulationResourceName`) is looked up in the browser resources and downloaded during the loading screen.

Any error along the way - browser data not available, `Startup.sim` not found, download or read failure - results in an empty simulation plus a message dialog, as before.

The startup requests now use the existing `TaskProcessor` instead of manual request-id polling, which removes two program states and the per-step error handling. The overlay message after startup shows the actually loaded simulation name.

Note: `Startup.sim` does not exist on the server yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)