### PR TITLE
Edit color matrices via dialog only

### DIFF
--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -460,33 +460,33 @@ bool AlienGui::ColorField(uint32_t cellColor, float width, float height)
 
 void AlienGui::CheckboxColorMatrix(CheckboxColorMatrixParameters const& parameters, bool (&value)[MAX_COLORS][MAX_COLORS], ColorMatrixDialog<bool>& dialog)
 {
-    BasicInputColorMatrixParameters<bool> basicParameters;
-    basicParameters._name = parameters._name;
-    basicParameters._textWidth = parameters._textWidth;
-    basicParameters._customizationColors = parameters._customizationColors;
-    basicParameters._defaultValue = parameters._defaultValue;
-    basicParameters._tooltip = parameters._tooltip;
-    basicParameters._highlightedSubString = parameters._highlightedSubString;
-    basicParameters._rowLabel = parameters._rowLabel;
-    basicParameters._columnLabel = parameters._columnLabel;
-    basicParameters._disableDiagonal = parameters._disableDiagonal;
-    BasicInputColorMatrix<bool>(basicParameters, value, dialog);
+    ExpandedColorMatrixParameters<bool> matrixParameters;
+    matrixParameters._name = parameters._name;
+    matrixParameters._textWidth = parameters._textWidth;
+    matrixParameters._customizationColors = parameters._customizationColors;
+    matrixParameters._defaultValue = parameters._defaultValue;
+    matrixParameters._tooltip = parameters._tooltip;
+    matrixParameters._highlightedSubString = parameters._highlightedSubString;
+    matrixParameters._rowLabel = parameters._rowLabel;
+    matrixParameters._columnLabel = parameters._columnLabel;
+    matrixParameters._disableDiagonal = parameters._disableDiagonal;
+    BasicInputColorMatrix<bool>(matrixParameters, value, dialog);
 }
 
 void AlienGui::InputIntColorMatrix(InputIntColorMatrixParameters const& parameters, int (&value)[MAX_COLORS][MAX_COLORS], ColorMatrixDialog<int>& dialog)
 {
-    BasicInputColorMatrixParameters<int> basicParameters;
-    basicParameters._name = parameters._name;
-    basicParameters._min = parameters._min;
-    basicParameters._max = parameters._max;
-    basicParameters._format = "%d";
-    basicParameters._logarithmic = parameters._logarithmic;
-    basicParameters._textWidth = parameters._textWidth;
-    basicParameters._customizationColors = parameters._customizationColors;
-    basicParameters._defaultValue = parameters._defaultValue;
-    basicParameters._tooltip = parameters._tooltip;
-    basicParameters._highlightedSubString = parameters._highlightedSubString;
-    BasicInputColorMatrix<int>(basicParameters, value, dialog);
+    ExpandedColorMatrixParameters<int> matrixParameters;
+    matrixParameters._name = parameters._name;
+    matrixParameters._min = parameters._min;
+    matrixParameters._max = parameters._max;
+    matrixParameters._format = "%d";
+    matrixParameters._logarithmic = parameters._logarithmic;
+    matrixParameters._textWidth = parameters._textWidth;
+    matrixParameters._customizationColors = parameters._customizationColors;
+    matrixParameters._defaultValue = parameters._defaultValue;
+    matrixParameters._tooltip = parameters._tooltip;
+    matrixParameters._highlightedSubString = parameters._highlightedSubString;
+    BasicInputColorMatrix<int>(matrixParameters, value, dialog);
 }
 
 void AlienGui::InputFloatColorMatrix(
@@ -495,19 +495,19 @@ void AlienGui::InputFloatColorMatrix(
     ColorMatrixDialog<float>& dialog,
     bool* enabled)
 {
-    BasicInputColorMatrixParameters<float> basicParameters;
-    basicParameters._name = parameters._name;
-    basicParameters._min = parameters._min;
-    basicParameters._max = parameters._max;
-    basicParameters._logarithmic = parameters._logarithmic;
-    basicParameters._format = parameters._format;
-    basicParameters._textWidth = parameters._textWidth;
-    basicParameters._customizationColors = parameters._customizationColors;
-    basicParameters._defaultValue = parameters._defaultValue;
-    basicParameters._tooltip = parameters._tooltip;
-    basicParameters._disabledValue = parameters._disabledValue;
-    basicParameters._highlightedSubString = parameters._highlightedSubString;
-    BasicInputColorMatrix<float>(basicParameters, value, dialog, enabled);
+    ExpandedColorMatrixParameters<float> matrixParameters;
+    matrixParameters._name = parameters._name;
+    matrixParameters._min = parameters._min;
+    matrixParameters._max = parameters._max;
+    matrixParameters._logarithmic = parameters._logarithmic;
+    matrixParameters._format = parameters._format;
+    matrixParameters._textWidth = parameters._textWidth;
+    matrixParameters._customizationColors = parameters._customizationColors;
+    matrixParameters._defaultValue = parameters._defaultValue;
+    matrixParameters._tooltip = parameters._tooltip;
+    matrixParameters._disabledValue = parameters._disabledValue;
+    matrixParameters._highlightedSubString = parameters._highlightedSubString;
+    BasicInputColorMatrix<float>(matrixParameters, value, dialog, enabled);
 }
 
 bool AlienGui::InputText(InputTextParameters const& parameters, char* buffer, int bufferSize)
@@ -2712,7 +2712,7 @@ bool AlienGui::BasicSlider(Parameter const& parameters, T* value, bool* enabled,
 
 template <typename T>
 void AlienGui::BasicInputColorMatrix(
-    BasicInputColorMatrixParameters<T> const& parameters,
+    ExpandedColorMatrixParameters<T> const& parameters,
     T (&value)[MAX_COLORS][MAX_COLORS],
     ColorMatrixDialog<T>& dialog,
     bool* enabled)
@@ -2759,7 +2759,7 @@ void AlienGui::BasicInputColorMatrix(
     }
     ImGui::PopStyleVar();
     if (isExpanded) {
-        ExpandedColorMatrix(parameters, value, contentWidth, 0, true);
+        ExpandedColorMatrix(ExpandedColorMatrixParameters<T>(parameters).width(scaleInverse(contentWidth)).readOnly(true), value);
     }
     ImGui::EndGroup();
 
@@ -2817,14 +2817,12 @@ namespace
 }
 
 template <typename T>
-void AlienGui::ExpandedColorMatrix(
-    BasicInputColorMatrixParameters<T> const& parameters,
-    T (&value)[MAX_COLORS][MAX_COLORS],
-    float width,
-    float maxCellSize,
-    bool readOnly)
+void AlienGui::ExpandedColorMatrix(ExpandedColorMatrixParameters<T> const& parameters, T (&value)[MAX_COLORS][MAX_COLORS])
 {
     auto const& style = ImGui::GetStyle();
+    auto readOnly = parameters._readOnly;
+    auto width = parameters._width != 0.0f ? scale(parameters._width) : ImGui::GetContentRegionAvail().x;
+    auto maxCellSize = scale(parameters._maxCellSize);
     auto showLabels = !readOnly;
     auto rowLabelWidth = showLabels ? ImGui::GetTextLineHeight() + style.ItemSpacing.x : 0.0f;
     auto tableWidth = std::max(width - rowLabelWidth, scale(MinColorMatrixWidth));
@@ -2934,24 +2932,9 @@ void AlienGui::ExpandedColorMatrix(
     }
 }
 
-template void AlienGui::ExpandedColorMatrix<bool>(
-    BasicInputColorMatrixParameters<bool> const& parameters,
-    bool (&value)[MAX_COLORS][MAX_COLORS],
-    float width,
-    float maxCellSize,
-    bool readOnly);
-template void AlienGui::ExpandedColorMatrix<int>(
-    BasicInputColorMatrixParameters<int> const& parameters,
-    int (&value)[MAX_COLORS][MAX_COLORS],
-    float width,
-    float maxCellSize,
-    bool readOnly);
-template void AlienGui::ExpandedColorMatrix<float>(
-    BasicInputColorMatrixParameters<float> const& parameters,
-    float (&value)[MAX_COLORS][MAX_COLORS],
-    float width,
-    float maxCellSize,
-    bool readOnly);
+template void AlienGui::ExpandedColorMatrix<bool>(ExpandedColorMatrixParameters<bool> const& parameters, bool (&value)[MAX_COLORS][MAX_COLORS]);
+template void AlienGui::ExpandedColorMatrix<int>(ExpandedColorMatrixParameters<int> const& parameters, int (&value)[MAX_COLORS][MAX_COLORS]);
+template void AlienGui::ExpandedColorMatrix<float>(ExpandedColorMatrixParameters<float> const& parameters, float (&value)[MAX_COLORS][MAX_COLORS]);
 
 // RotateStart, RotationCenter, etc. are taken from https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
 //>>>>>>>>>>

--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -35,6 +35,8 @@ namespace
     auto constexpr TabMarkerSize = 11.0f;
     auto constexpr TabMarkerRounding = 3.0f;
     auto constexpr MinColorMatrixWidth = 50.0f;
+    auto constexpr ColorMatrixGrabSize = 4.0f;
+    auto constexpr ReadOnlyCellPadding = 1.0f;
 
     bool isColorVectorDefault(FloatColorRGB* value, ColorVector<FloatColorRGB> const& defaultValue)
     {
@@ -468,10 +470,10 @@ void AlienGui::CheckboxColorMatrix(CheckboxColorMatrixParameters const& paramete
     basicParameters._rowLabel = parameters._rowLabel;
     basicParameters._columnLabel = parameters._columnLabel;
     basicParameters._disableDiagonal = parameters._disableDiagonal;
-    BasicInputColorMatrix<bool>(basicParameters, value, &dialog);
+    BasicInputColorMatrix<bool>(basicParameters, value, dialog);
 }
 
-void AlienGui::InputIntColorMatrix(InputIntColorMatrixParameters const& parameters, int (&value)[MAX_COLORS][MAX_COLORS])
+void AlienGui::InputIntColorMatrix(InputIntColorMatrixParameters const& parameters, int (&value)[MAX_COLORS][MAX_COLORS], ColorMatrixDialog<int>& dialog)
 {
     BasicInputColorMatrixParameters<int> basicParameters;
     basicParameters._name = parameters._name;
@@ -484,10 +486,14 @@ void AlienGui::InputIntColorMatrix(InputIntColorMatrixParameters const& paramete
     basicParameters._defaultValue = parameters._defaultValue;
     basicParameters._tooltip = parameters._tooltip;
     basicParameters._highlightedSubString = parameters._highlightedSubString;
-    BasicInputColorMatrix<int>(basicParameters, value, nullptr);
+    BasicInputColorMatrix<int>(basicParameters, value, dialog);
 }
 
-void AlienGui::InputFloatColorMatrix(InputFloatColorMatrixParameters const& parameters, float (&value)[MAX_COLORS][MAX_COLORS], bool* enabled)
+void AlienGui::InputFloatColorMatrix(
+    InputFloatColorMatrixParameters const& parameters,
+    float (&value)[MAX_COLORS][MAX_COLORS],
+    ColorMatrixDialog<float>& dialog,
+    bool* enabled)
 {
     BasicInputColorMatrixParameters<float> basicParameters;
     basicParameters._name = parameters._name;
@@ -501,7 +507,7 @@ void AlienGui::InputFloatColorMatrix(InputFloatColorMatrixParameters const& para
     basicParameters._tooltip = parameters._tooltip;
     basicParameters._disabledValue = parameters._disabledValue;
     basicParameters._highlightedSubString = parameters._highlightedSubString;
-    BasicInputColorMatrix<float>(basicParameters, value, nullptr, enabled);
+    BasicInputColorMatrix<float>(basicParameters, value, dialog, enabled);
 }
 
 bool AlienGui::InputText(InputTextParameters const& parameters, char* buffer, int bufferSize)
@@ -2708,7 +2714,7 @@ template <typename T>
 void AlienGui::BasicInputColorMatrix(
     BasicInputColorMatrixParameters<T> const& parameters,
     T (&value)[MAX_COLORS][MAX_COLORS],
-    ColorMatrixDialog<T>* dialog,
+    ColorMatrixDialog<T>& dialog,
     bool* enabled)
 {
     ImGui::PushID(parameters._name.c_str());
@@ -2741,60 +2747,21 @@ void AlienGui::BasicInputColorMatrix(
 
     ImGui::SameLine();
 
-    if (isExpanded) {
-        ExpandedColorMatrix(parameters, value, ImGui::GetContentRegionAvail().x - textWidth);
-    } else {
-        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - textWidth);
-        if (dialog) {
-            ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
-            if (ImGui::Button("Edit matrix", ImVec2(ImGui::GetContentRegionAvail().x - textWidth, 0))) {
-                dialog->open(parameters, value, [&value](ColorMatrix<T> const& adoptedValue) {
-                    for (auto const& [valueRow, adoptedRow] : std::views::zip(value, adoptedValue.values)) {
-                        std::ranges::copy(adoptedRow, std::begin(valueRow));
-                    }
-                });
+    auto contentWidth = ImGui::GetContentRegionAvail().x - textWidth;
+    ImGui::BeginGroup();
+    ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
+    if (ImGui::Button("Edit matrix", ImVec2(contentWidth, 0))) {
+        dialog.open(parameters, value, [&value](ColorMatrix<T> const& adoptedValue) {
+            for (auto const& [valueRow, adoptedRow] : std::views::zip(value, adoptedValue.values)) {
+                std::ranges::copy(adoptedRow, std::begin(valueRow));
             }
-            ImGui::PopStyleVar();
-        } else {
-            auto format = parameters._format;
-            T sliderValue;
-            T minValue = value[0][0], maxValue = value[0][0];
-            for (int i = 0; i < MAX_COLORS; ++i) {
-                for (int j = 0; j < MAX_COLORS; ++j) {
-                    maxValue = std::max(maxValue, value[i][j]);
-                    minValue = std::min(minValue, value[i][j]);
-                }
-            }
-
-            if (minValue != maxValue) {
-                if constexpr (std::is_same<T, float>()) {
-                    format = parameters._format + " ... " + applyFormatToValue(maxValue, parameters._format, false);
-                } else {
-                    format = std::to_string(minValue) + " ... " + std::to_string(maxValue);
-                }
-            } else {
-                format = applyFormatToValue(value[0][0], parameters._format, false);
-            }
-            sliderValue = minValue;
-
-            auto sliderMoved = false;
-            if constexpr (std::is_same<T, float>()) {
-                sliderMoved |= ImGui::SliderFloat(
-                    "##slider", &sliderValue, parameters._min, parameters._max, format.c_str(), parameters._logarithmic ? ImGuiSliderFlags_Logarithmic : 0);
-            }
-            if constexpr (std::is_same<T, int>()) {
-                sliderMoved |= ImGui::SliderInt(
-                    "##slider", &sliderValue, parameters._min, parameters._max, format.c_str(), parameters._logarithmic ? ImGuiSliderFlags_Logarithmic : 0);
-            }
-            if (sliderMoved) {
-                for (int i = 0; i < MAX_COLORS; ++i) {
-                    for (int j = 0; j < MAX_COLORS; ++j) {
-                        value[i][j] = sliderValue;
-                    }
-                }
-            }
-        }
+        });
     }
+    ImGui::PopStyleVar();
+    if (isExpanded) {
+        ExpandedColorMatrix(parameters, value, contentWidth, 0, true);
+    }
+    ImGui::EndGroup();
 
     ImGui::SameLine();
     if (parameters._defaultValue) {
@@ -2828,33 +2795,68 @@ void AlienGui::BasicInputColorMatrix(
         AlienGui::HelpMarker(*parameters._tooltip);
     }
 
-    if (dialog) {
-        dialog->process();
-    }
+    dialog.process();
 
     ImGui::PopID();
 }
 
+namespace
+{
+    template <typename T>
+    void ReadOnlyMatrixCell(T value, std::string const& format)
+    {
+        char text[32];
+        snprintf(text, sizeof(text), format.c_str(), value);
+
+        ImGui::SetWindowFontScale(0.8f);
+        auto offsetX = std::max(0.0f, (ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(text).x) / 2);
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offsetX);
+        ImGui::TextUnformatted(text);
+        ImGui::SetWindowFontScale(1.0f);
+    }
+}
+
 template <typename T>
-void AlienGui::ExpandedColorMatrix(BasicInputColorMatrixParameters<T> const& parameters, T (&value)[MAX_COLORS][MAX_COLORS], float width, float maxCellSize)
+void AlienGui::ExpandedColorMatrix(
+    BasicInputColorMatrixParameters<T> const& parameters,
+    T (&value)[MAX_COLORS][MAX_COLORS],
+    float width,
+    float maxCellSize,
+    bool readOnly)
 {
     auto const& style = ImGui::GetStyle();
-    auto rowLabelWidth = ImGui::GetTextLineHeight() + style.ItemSpacing.x;
+    auto showLabels = !readOnly;
+    auto rowLabelWidth = showLabels ? ImGui::GetTextLineHeight() + style.ItemSpacing.x : 0.0f;
     auto tableWidth = std::max(width - rowLabelWidth, scale(MinColorMatrixWidth));
+    if (maxCellSize > 0) {
+        tableWidth = std::min(tableWidth, (MAX_COLORS + 1) * (maxCellSize + 2 * style.CellPadding.x + 1.0f));
+    }
 
+    auto slimSliderGrab = false;
     if constexpr (std::is_same<T, bool>()) {
         auto cellSizeLimit = maxCellSize > 0 ? maxCellSize : ImGui::GetFrameHeight();
         auto cellSize = std::min(tableWidth / (MAX_COLORS + 1) - 2 * style.CellPadding.x - 1.0f, cellSizeLimit);
         auto framePaddingY = std::max(0.0f, (cellSize - ImGui::GetFontSize()) / 2);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, framePaddingY));
+    } else {
+        slimSliderGrab = !readOnly;
+    }
+    if (slimSliderGrab) {
+        ImGui::PushStyleVar(ImGuiStyleVar_GrabMinSize, scale(ColorMatrixGrabSize));
+    }
+    if (readOnly) {
+        // The value labels need almost the entire cell, otherwise they are cut off in the last column
+        ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(scale(ReadOnlyCellPadding), style.CellPadding.y));
     }
 
     ImGui::BeginGroup();
 
     auto blockStartX = ImGui::GetCursorPosX();
-    auto columnLabelSize = ImGui::CalcTextSize(parameters._columnLabel.c_str());
-    ImGui::SetCursorPosX(blockStartX + rowLabelWidth + std::max(0.0f, (tableWidth - columnLabelSize.x) / 2));
-    ImGui::TextUnformatted(parameters._columnLabel.c_str());
+    if (showLabels) {
+        auto columnLabelSize = ImGui::CalcTextSize(parameters._columnLabel.c_str());
+        ImGui::SetCursorPosX(blockStartX + rowLabelWidth + std::max(0.0f, (tableWidth - columnLabelSize.x) / 2));
+        ImGui::TextUnformatted(parameters._columnLabel.c_str());
+    }
 
     auto tableStartPos = ImGui::GetCursorPos();
     ImGui::SetCursorPos({blockStartX + rowLabelWidth, tableStartPos.y});
@@ -2866,7 +2868,7 @@ void AlienGui::ExpandedColorMatrix(BasicInputColorMatrixParameters<T> const& par
                 ImGui::PushID(col);
                 ImGui::TableNextColumn();
                 auto cellWidth = scaleInverse(ImGui::GetContentRegionAvail().x);
-                if (col < MAX_COLORS) {
+                if (col < MAX_COLORS && !readOnly) {
                     cellWidth += 3.0f;
                 }
                 if (row == 0 && col > 0) {
@@ -2874,28 +2876,34 @@ void AlienGui::ExpandedColorMatrix(BasicInputColorMatrixParameters<T> const& par
                 } else if (row > 0 && col == 0) {
                     ColorField(parameters._customizationColors[row - 1].toRgbColor(), cellWidth);
                 } else if (row > 0 && col > 0) {
-                    if constexpr (std::is_same<T, float>()) {
-                        SliderFloat(
-                            SliderFloatParameters()
-                                .format(parameters._format)
-                                .tiny(true)
-                                .width(cellWidth)
-                                .textWidth(0)
-                                .min(parameters._min)
-                                .max(parameters._max)
-                                .logarithmic(parameters._logarithmic),
-                            &value[row - 1][col - 1]);
-                    }
-                    if constexpr (std::is_same<T, int>()) {
-                        SliderInt(
-                            SliderIntParameters().tiny(true).textWidth(0).min(parameters._min).max(parameters._max).logarithmic(parameters._logarithmic),
-                            &value[row - 1][col - 1]);
-                    }
                     if constexpr (std::is_same<T, bool>()) {
                         if (parameters._disableDiagonal && row == col) {
                             ImGui::Dummy({0, ImGui::GetFrameHeight()});
                         } else {
+                            auto offsetX = std::max(0.0f, (ImGui::GetContentRegionAvail().x - ImGui::GetFrameHeight()) / 2);
+                            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offsetX);
+                            ImGui::BeginDisabled(readOnly);
                             ImGui::Checkbox(("##" + parameters._name).c_str(), &value[row - 1][col - 1]);
+                            ImGui::EndDisabled();
+                        }
+                    } else if (readOnly) {
+                        ReadOnlyMatrixCell(value[row - 1][col - 1], parameters._format);
+                    } else {
+                        if constexpr (std::is_same<T, float>()) {
+                            SliderFloat(
+                                SliderFloatParameters()
+                                    .format(parameters._format)
+                                    .width(cellWidth)
+                                    .textWidth(0)
+                                    .min(parameters._min)
+                                    .max(parameters._max)
+                                    .logarithmic(parameters._logarithmic),
+                                &value[row - 1][col - 1]);
+                        }
+                        if constexpr (std::is_same<T, int>()) {
+                            SliderInt(
+                                SliderIntParameters().textWidth(0).min(parameters._min).max(parameters._max).logarithmic(parameters._logarithmic),
+                                &value[row - 1][col - 1]);
                         }
                     }
                 }
@@ -2908,11 +2916,19 @@ void AlienGui::ExpandedColorMatrix(BasicInputColorMatrixParameters<T> const& par
     }
     auto tableEndPos = ImGui::GetCursorPos();
 
-    drawVerticalText(parameters._rowLabel, {blockStartX + ImGui::GetTextLineHeight() / 2, (tableStartPos.y + tableEndPos.y) / 2});
+    if (showLabels) {
+        drawVerticalText(parameters._rowLabel, {blockStartX + ImGui::GetTextLineHeight() / 2, (tableStartPos.y + tableEndPos.y) / 2});
+    }
 
     ImGui::SetCursorPos(tableEndPos);
     ImGui::EndGroup();
 
+    if (readOnly) {
+        ImGui::PopStyleVar();
+    }
+    if (slimSliderGrab) {
+        ImGui::PopStyleVar();
+    }
     if constexpr (std::is_same<T, bool>()) {
         ImGui::PopStyleVar();
     }
@@ -2922,17 +2938,20 @@ template void AlienGui::ExpandedColorMatrix<bool>(
     BasicInputColorMatrixParameters<bool> const& parameters,
     bool (&value)[MAX_COLORS][MAX_COLORS],
     float width,
-    float maxCellSize);
+    float maxCellSize,
+    bool readOnly);
 template void AlienGui::ExpandedColorMatrix<int>(
     BasicInputColorMatrixParameters<int> const& parameters,
     int (&value)[MAX_COLORS][MAX_COLORS],
     float width,
-    float maxCellSize);
+    float maxCellSize,
+    bool readOnly);
 template void AlienGui::ExpandedColorMatrix<float>(
     BasicInputColorMatrixParameters<float> const& parameters,
     float (&value)[MAX_COLORS][MAX_COLORS],
     float width,
-    float maxCellSize);
+    float maxCellSize,
+    bool readOnly);
 
 // RotateStart, RotationCenter, etc. are taken from https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
 //>>>>>>>>>>

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -173,7 +173,12 @@ public:
     };
 
     template <typename T>
-    static void ExpandedColorMatrix(BasicInputColorMatrixParameters<T> const& parameters, T (&value)[MAX_COLORS][MAX_COLORS], float width, float maxCellSize = 0);
+    static void ExpandedColorMatrix(
+        BasicInputColorMatrixParameters<T> const& parameters,
+        T (&value)[MAX_COLORS][MAX_COLORS],
+        float width,
+        float maxCellSize = 0,
+        bool readOnly = false);
 
     struct CheckboxColorMatrixParameters
     {
@@ -201,7 +206,7 @@ public:
         MEMBER(InputIntColorMatrixParameters, std::optional<std::string>, highlightedSubString, std::nullopt);
         MEMBER(InputIntColorMatrixParameters, std::optional<std::string>, tooltip, std::nullopt);
     };
-    static void InputIntColorMatrix(InputIntColorMatrixParameters const& parameters, int (&value)[MAX_COLORS][MAX_COLORS]);
+    static void InputIntColorMatrix(InputIntColorMatrixParameters const& parameters, int (&value)[MAX_COLORS][MAX_COLORS], ColorMatrixDialog<int>& dialog);
 
     struct InputFloatColorMatrixParameters
     {
@@ -217,7 +222,11 @@ public:
         MEMBER(InputFloatColorMatrixParameters, std::optional<std::string>, highlightedSubString, std::nullopt);
         MEMBER(InputFloatColorMatrixParameters, std::optional<std::string>, tooltip, std::nullopt);
     };
-    static void InputFloatColorMatrix(InputFloatColorMatrixParameters const& parameters, float (&value)[MAX_COLORS][MAX_COLORS], bool* enabled = nullptr);
+    static void InputFloatColorMatrix(
+        InputFloatColorMatrixParameters const& parameters,
+        float (&value)[MAX_COLORS][MAX_COLORS],
+        ColorMatrixDialog<float>& dialog,
+        bool* enabled = nullptr);
 
     struct InputTextParameters
     {
@@ -588,7 +597,7 @@ private:
     static void BasicInputColorMatrix(
         BasicInputColorMatrixParameters<T> const& parameters,
         T (&value)[MAX_COLORS][MAX_COLORS],
-        ColorMatrixDialog<T>* dialog = nullptr,
+        ColorMatrixDialog<T>& dialog,
         bool* enabled = nullptr);
 
     //static bool BeginTable(std::string const& id, int column, ImGuiTableFlags flags = 0, RealVector2D size = RealVector2D(0.0f, 0.0f));

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -154,31 +154,29 @@ public:
     static bool ColorField(uint32_t cellColor, float width = 0, float height = 0);
 
     template <typename T>
-    struct BasicInputColorMatrixParameters
+    struct ExpandedColorMatrixParameters
     {
-        MEMBER(BasicInputColorMatrixParameters, std::string, name, "");
-        MEMBER(BasicInputColorMatrixParameters, T, min, static_cast<T>(0));
-        MEMBER(BasicInputColorMatrixParameters, T, max, static_cast<T>(0));
-        MEMBER(BasicInputColorMatrixParameters, bool, logarithmic, false);
-        MEMBER(BasicInputColorMatrixParameters, std::string, format, "%.2f");
-        MEMBER(BasicInputColorMatrixParameters, float, textWidth, 100);
-        MEMBER(BasicInputColorMatrixParameters, ColorVector<FloatColorRGB>, customizationColors, getDefaultCustomizationColorVector());
-        MEMBER(BasicInputColorMatrixParameters, std::optional<std::vector<std::vector<T>>>, defaultValue, std::nullopt);
-        MEMBER(BasicInputColorMatrixParameters, std::optional<std::vector<std::vector<T>>>, disabledValue, std::nullopt);
-        MEMBER(BasicInputColorMatrixParameters, std::optional<std::string>, highlightedSubString, std::nullopt);
-        MEMBER(BasicInputColorMatrixParameters, std::optional<std::string>, tooltip, std::nullopt);
-        MEMBER(BasicInputColorMatrixParameters, std::string, rowLabel, "[cell color]");
-        MEMBER(BasicInputColorMatrixParameters, std::string, columnLabel, "[target cell color]");
-        MEMBER(BasicInputColorMatrixParameters, bool, disableDiagonal, false);
+        MEMBER(ExpandedColorMatrixParameters, std::string, name, "");
+        MEMBER(ExpandedColorMatrixParameters, T, min, static_cast<T>(0));
+        MEMBER(ExpandedColorMatrixParameters, T, max, static_cast<T>(0));
+        MEMBER(ExpandedColorMatrixParameters, bool, logarithmic, false);
+        MEMBER(ExpandedColorMatrixParameters, std::string, format, "%.2f");
+        MEMBER(ExpandedColorMatrixParameters, float, textWidth, 100);
+        MEMBER(ExpandedColorMatrixParameters, ColorVector<FloatColorRGB>, customizationColors, getDefaultCustomizationColorVector());
+        MEMBER(ExpandedColorMatrixParameters, std::optional<std::vector<std::vector<T>>>, defaultValue, std::nullopt);
+        MEMBER(ExpandedColorMatrixParameters, std::optional<std::vector<std::vector<T>>>, disabledValue, std::nullopt);
+        MEMBER(ExpandedColorMatrixParameters, std::optional<std::string>, highlightedSubString, std::nullopt);
+        MEMBER(ExpandedColorMatrixParameters, std::optional<std::string>, tooltip, std::nullopt);
+        MEMBER(ExpandedColorMatrixParameters, std::string, rowLabel, "[cell color]");
+        MEMBER(ExpandedColorMatrixParameters, std::string, columnLabel, "[target cell color]");
+        MEMBER(ExpandedColorMatrixParameters, bool, disableDiagonal, false);
+        MEMBER(ExpandedColorMatrixParameters, float, width, 0);
+        MEMBER(ExpandedColorMatrixParameters, float, maxCellSize, 0);
+        MEMBER(ExpandedColorMatrixParameters, bool, readOnly, false);
     };
 
     template <typename T>
-    static void ExpandedColorMatrix(
-        BasicInputColorMatrixParameters<T> const& parameters,
-        T (&value)[MAX_COLORS][MAX_COLORS],
-        float width,
-        float maxCellSize = 0,
-        bool readOnly = false);
+    static void ExpandedColorMatrix(ExpandedColorMatrixParameters<T> const& parameters, T (&value)[MAX_COLORS][MAX_COLORS]);
 
     struct CheckboxColorMatrixParameters
     {
@@ -595,7 +593,7 @@ private:
 
     template <typename T>
     static void BasicInputColorMatrix(
-        BasicInputColorMatrixParameters<T> const& parameters,
+        ExpandedColorMatrixParameters<T> const& parameters,
         T (&value)[MAX_COLORS][MAX_COLORS],
         ColorMatrixDialog<T>& dialog,
         bool* enabled = nullptr);

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -174,7 +174,6 @@ public:
         MEMBER(ExpandedColorMatrixParameters, float, maxCellSize, 0);
         MEMBER(ExpandedColorMatrixParameters, bool, readOnly, false);
     };
-
     template <typename T>
     static void ExpandedColorMatrix(ExpandedColorMatrixParameters<T> const& parameters, T (&value)[MAX_COLORS][MAX_COLORS]);
 

--- a/source/Gui/ColorMatrixDialog.cpp
+++ b/source/Gui/ColorMatrixDialog.cpp
@@ -14,6 +14,8 @@ namespace
 {
     auto const DialogSize = RealVector2D(560.0f, 480.0f);
     auto constexpr ButtonAreaHeight = 50.0f;
+    auto constexpr MaxCellSizeForSlider = 40.0f;
+    auto constexpr MaxCellSizeForCheckbox = 28.0f;
 
     float buttonWidth(std::string const& text)
     {
@@ -90,15 +92,8 @@ template <typename T>
 void ColorMatrixDialog<T>::processContent()
 {
     if (ImGui::BeginChild("##matrix", ImVec2(0, -scale(ButtonAreaHeight)), false)) {
-        auto const& style = ImGui::GetStyle();
-        auto available = ImGui::GetContentRegionAvail();
-        auto numCells = toFloat(MAX_COLORS + 1);
-        auto rowLabelWidth = ImGui::GetTextLineHeight() + style.ItemSpacing.x;
-        auto cellSizeForWidth = (available.x - rowLabelWidth) / numCells - 2 * style.CellPadding.x - 1.0f;
-        auto cellSizeForHeight = (available.y - ImGui::GetTextLineHeight() - style.ItemSpacing.y) / numCells - 2 * style.CellPadding.y;
-        auto cellSize = std::max(std::min(cellSizeForWidth, cellSizeForHeight), 0.0f);
-        auto blockWidth = rowLabelWidth + numCells * (cellSize + 2 * style.CellPadding.x + 1.0f);
-        AlienGui::ExpandedColorMatrix(_parameters, _matrix.values, std::min(available.x, blockWidth), cellSize);
+        auto maxCellSize = std::is_same_v<T, bool> ? MaxCellSizeForCheckbox : MaxCellSizeForSlider;
+        AlienGui::ExpandedColorMatrix(_parameters, _matrix.values, ImGui::GetContentRegionAvail().x, scale(maxCellSize));
     }
     ImGui::EndChild();
 

--- a/source/Gui/ColorMatrixDialog.cpp
+++ b/source/Gui/ColorMatrixDialog.cpp
@@ -69,7 +69,7 @@ ColorMatrixDialog<T>::ColorMatrixDialog()
 
 template <typename T>
 void ColorMatrixDialog<T>::open(
-    AlienGui::BasicInputColorMatrixParameters<T> const& parameters,
+    AlienGui::ExpandedColorMatrixParameters<T> const& parameters,
     T const (&value)[MAX_COLORS][MAX_COLORS],
     std::function<void(ColorMatrix<T> const&)> const& onAdoptCallback)
 {
@@ -93,7 +93,9 @@ void ColorMatrixDialog<T>::processContent()
 {
     if (ImGui::BeginChild("##matrix", ImVec2(0, -scale(ButtonAreaHeight)), false)) {
         auto maxCellSize = std::is_same_v<T, bool> ? MaxCellSizeForCheckbox : MaxCellSizeForSlider;
-        AlienGui::ExpandedColorMatrix(_parameters, _matrix.values, ImGui::GetContentRegionAvail().x, scale(maxCellSize));
+        AlienGui::ExpandedColorMatrix(
+            AlienGui::ExpandedColorMatrixParameters<T>(_parameters).width(scaleInverse(ImGui::GetContentRegionAvail().x)).maxCellSize(maxCellSize),
+            _matrix.values);
     }
     ImGui::EndChild();
 

--- a/source/Gui/ColorMatrixDialog.h
+++ b/source/Gui/ColorMatrixDialog.h
@@ -16,7 +16,7 @@ public:
     ColorMatrixDialog();
 
     void open(
-        AlienGui::BasicInputColorMatrixParameters<T> const& parameters,
+        AlienGui::ExpandedColorMatrixParameters<T> const& parameters,
         T const (&value)[MAX_COLORS][MAX_COLORS],
         std::function<void(ColorMatrix<T> const&)> const& onAdoptCallback);
     void process();
@@ -26,7 +26,7 @@ private:
     void onAdopt();
 
     ModalWindow _modalWindow;
-    AlienGui::BasicInputColorMatrixParameters<T> _parameters;
+    AlienGui::ExpandedColorMatrixParameters<T> _parameters;
     ColorMatrix<T> _matrix;
     std::function<void(ColorMatrix<T> const&)> _onAdoptCallback;
 };

--- a/source/Gui/SpecificationGuiService.cpp
+++ b/source/Gui/SpecificationGuiService.cpp
@@ -195,7 +195,7 @@ void SpecificationGuiService::createWidgetsForBoolSpec(
                 .columnLabel("[target customization]")
                 .disableDiagonal(true),
             *reinterpret_cast<bool(*)[MAX_COLORS][MAX_COLORS]>(ref.value),
-            _colorMatrixDialogById[ImGui::GetID("colorMatrix")]);
+            _boolColorMatrixDialogById[ImGui::GetID("colorMatrix")]);
 
     } else {
         AlienGui::Checkbox(
@@ -228,7 +228,7 @@ void SpecificationGuiService::createWidgetsForIntSpec(
         AlienGui::InputIntColorMatrix(
             AlienGui::InputIntColorMatrixParameters()
                 .name(parameterSpec._name)
-                .max(intSpec._min)
+                .min(intSpec._min)
                 .max(intSpec._max)
                 .logarithmic(intSpec._logarithmic)
                 .textWidth(TextColumnWidth)
@@ -236,7 +236,8 @@ void SpecificationGuiService::createWidgetsForIntSpec(
                 .highlightedSubString(filter.containedText)
                 .tooltip(parameterSpec._description)
                 .defaultValue(toVector<MAX_COLORS, MAX_COLORS>(*reinterpret_cast<int(*)[MAX_COLORS][MAX_COLORS]>(origValue))),
-            *reinterpret_cast<int(*)[MAX_COLORS][MAX_COLORS]>(value));
+            *reinterpret_cast<int(*)[MAX_COLORS][MAX_COLORS]>(value),
+            _intColorMatrixDialogById[ImGui::GetID("colorMatrix")]);
 
     } else {
         AlienGui::SliderInt(
@@ -302,6 +303,7 @@ void SpecificationGuiService::createWidgetsForFloatSpec(
                         ? std::make_optional(toVector<MAX_COLORS, MAX_COLORS>(*reinterpret_cast<float(*)[MAX_COLORS][MAX_COLORS]>(disabledValue)))
                         : std::optional<std::vector<std::vector<float>>>()),
             *reinterpret_cast<float(*)[MAX_COLORS][MAX_COLORS]>(value),
+            _floatColorMatrixDialogById[ImGui::GetID("colorMatrix")],
             enabledValue);
 
     } else {

--- a/source/Gui/SpecificationGuiService.h
+++ b/source/Gui/SpecificationGuiService.h
@@ -90,5 +90,7 @@ private:
 
     mutable std::unordered_map<unsigned int, bool> _visibilityById;
 
-    mutable std::unordered_map<unsigned int, ColorMatrixDialog<bool>> _colorMatrixDialogById;
+    mutable std::unordered_map<unsigned int, ColorMatrixDialog<bool>> _boolColorMatrixDialogById;
+    mutable std::unordered_map<unsigned int, ColorMatrixDialog<int>> _intColorMatrixDialogById;
+    mutable std::unordered_map<unsigned int, ColorMatrixDialog<float>> _floatColorMatrixDialogById;
 };


### PR DESCRIPTION
Color matrices in the simulation parameters window are now read-only and are edited exclusively in the matrix dialog.

### Simulation parameters window
- Every color matrix has an *Edit matrix* button, not just `customizationTransitionMatrix`.
- The button stays visible when the matrix is expanded; it sits above the matrix.
- Values are displayed read-only: plain labels for int/float (no sliders, no input widgets), greyed-out checkboxes for bool.
- Row and column labels (`[cell color]`, `[target cell color]`) are omitted in the read-only view, the table uses the full width instead. Cell padding is reduced there so the values are not cut off in the last column.

### Matrix dialog
- Dialogs for int and float matrices in addition to the existing bool one.
- The horizontal layout no longer depends on the window height: the table width is capped by a constant maximum cell size instead of being derived from the available height, so resizing vertically no longer changes the widget widths.
- Sliders use the normal font size again; only the slider grab is kept slim via `GrabMinSize`.

Also fixes a typo in `createWidgetsForIntSpec()` where `.max()` was called instead of `.min()`.
