### PR TITLE
Add line, curve and polygon modes to creator

### DIFF
--- a/source/EngineKernels/GeometryKernels.cu
+++ b/source/EngineKernels/GeometryKernels.cu
@@ -435,8 +435,7 @@ __global__ void cudaExtractLocationData(SimulationData data, LocationVertexData*
         float2 pos{pos_asRealVector2D.x, pos_asRealVector2D.y};
         correctPositionForRendering(pos, visibleTopLeft, data.worldSize);
 
-        // Use a distinct color for sources (e.g., yellow)
-        float3 color = {0.05f, 0.05f, 0.15f};
+        float3 color = {0.15f, 0.15f, 0.45f};
         auto shapeType = cudaSimulationParameters.sourceShapeType.sourceValues[i];
         auto radius = cudaSimulationParameters.sourceCircularRadius.sourceValues[i];
         auto rect = cudaSimulationParameters.sourceRectangularRect.sourceValues[i];

--- a/source/Gui/CreatorWindow.cpp
+++ b/source/Gui/CreatorWindow.cpp
@@ -53,6 +53,7 @@ namespace
     };
 
     auto const RightColumnWidth = 160.0f;
+    auto const PointButtonWidth = 60.0f;
     auto constexpr MaxNumObjects = size_t{1000000};
     auto constexpr PreviewLineThickness = 2.0f;
     auto constexpr PreviewPointRadius = 3.0f;
@@ -394,7 +395,7 @@ void CreatorWindow::updateInteractionMode()
 {
     auto& simInteractionController = SimulationInteractionController::get();
     if (simInteractionController.getInteractionMode() == InteractionMode_PositionSelection) {
-        _points.clear();
+        abortPointPlacement();
     } else {
         simInteractionController.setInteractionMode(getInteractionMode());
     }
@@ -476,18 +477,34 @@ bool CreatorWindow::processPointButtons(int minNumPoints)
 {
     AlienGui::Separator();
 
-    ImGui::BeginDisabled(toInt(_points.size()) < minNumPoints);
-    auto result = AlienGui::Button("Build");
-    ImGui::EndDisabled();
+    auto result = false;
+    if (!_pointPlacementActive) {
+        if (AlienGui::Button("Start", PointButtonWidth)) {
+            _pointPlacementActive = true;
+        }
+    } else {
+        ImGui::BeginDisabled(toInt(_points.size()) < minNumPoints);
+        if (AlienGui::Button("Finish", PointButtonWidth)) {
+            _pointPlacementActive = false;
+            result = true;
+        }
+        ImGui::EndDisabled();
+    }
 
     ImGui::SameLine();
-    ImGui::BeginDisabled(_points.empty());
-    if (AlienGui::Button("Clear")) {
-        _points.clear();
+    ImGui::BeginDisabled(!_pointPlacementActive);
+    if (AlienGui::Button("Abort", PointButtonWidth)) {
+        abortPointPlacement();
     }
     ImGui::EndDisabled();
 
     return result;
+}
+
+void CreatorWindow::abortPointPlacement()
+{
+    _pointPlacementActive = false;
+    _points.clear();
 }
 
 void CreatorWindow::processToolbar()
@@ -503,7 +520,7 @@ void CreatorWindow::processToolbar()
     }
 
     if (_mode != previousMode) {
-        _points.clear();
+        abortPointPlacement();
     }
 }
 
@@ -544,6 +561,13 @@ void CreatorWindow::processControlPolygonPreview() const
     auto viewPath = mapToViewPositions(_points);
     ImGui::GetBackgroundDrawList()->AddPolyline(
         viewPath.data(), toInt(viewPath.size()), Const::ConstructionPreviewHintLineColor, ImDrawFlags_None, scale(PreviewLineThickness));
+}
+
+void CreatorWindow::processBackground()
+{
+    if (!isShown()) {
+        abortPointPlacement();
+    }
 }
 
 bool CreatorWindow::isShown()
@@ -826,7 +850,7 @@ InteractionMode CreatorWindow::getInteractionMode() const
     if (_mode == CreationMode_Drawing) {
         return InteractionMode_Drawing;
     }
-    if (isPointPlacementMode()) {
+    if (isPointPlacementMode() && _pointPlacementActive) {
         return InteractionMode_PointPlacement;
     }
     return InteractionMode_Selection;

--- a/source/Gui/CreatorWindow.cpp
+++ b/source/Gui/CreatorWindow.cpp
@@ -54,6 +54,24 @@ namespace
 
     auto const RightColumnWidth = 160.0f;
     auto constexpr MaxNumObjects = size_t{1000000};
+    auto constexpr PreviewLineThickness = 2.0f;
+    auto constexpr PreviewPointRadius = 3.0f;
+
+    ImVec2 mapToViewPosition(RealVector2D const& worldPos)
+    {
+        auto viewPos = Viewport::get().mapWorldToViewPosition(worldPos);
+        return ImVec2(viewPos.x, viewPos.y);
+    }
+
+    std::vector<ImVec2> mapToViewPositions(std::vector<RealVector2D> const& worldPositions)
+    {
+        std::vector<ImVec2> result;
+        result.reserve(worldPositions.size());
+        for (auto const& worldPos : worldPositions) {
+            result.emplace_back(mapToViewPosition(worldPos));
+        }
+        return result;
+    }
 
     RealVector2D evaluateBezier(std::vector<RealVector2D> const& controlPoints, float t)
     {
@@ -175,98 +193,201 @@ void CreatorWindow::shutdownIntern()
 void CreatorWindow::processIntern()
 {
     processToolbar();
-
-    if (ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar)) {
-        AlienGui::Group(AlienGui::GroupParameters().text(ModeText.at(_mode)));
-
-        auto color = EditorModel::get().getDefaultColorCode();
-        AlienGui::ComboColor(
-            AlienGui::ComboColorParameters()
-                .customizationColors(_SimulationFacade::get()->getSimulationParameters().customizationColors.value)
-                .name("Color")
-                .textWidth(RightColumnWidth)
-                .tooltip(Const::GenomeColorTooltip),
-            color);
-        EditorModel::get().setDefaultColorCode(color);
-        if (_mode == CreationMode_Drawing) {
-            auto pencilWidth = EditorModel::get().getPencilWidth();
-            AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters()
-                    .name("Pencil radius")
-                    .min(1.0f)
-                    .max(8.0f)
-                    .textWidth(RightColumnWidth)
-                    .format("%.1f")
-                    .tooltip(Const::CreatorPencilRadiusTooltip),
-                &pencilWidth);
-            EditorModel::get().setPencilWidth(pencilWidth);
-        }
-        AlienGui::Switcher(
-            AlienGui::SwitcherParameters()
-                .name("Material")
-                .textWidth(RightColumnWidth)
-                .values({"Solid", "Fluid", "Free cells", "Energy particles"})
-                .tooltip(Const::CreatorDrawingTypeTooltip),
-            &_material);
-        AlienGui::InputFloat(
-            AlienGui::InputFloatParameters().name("Energy").format("%.2f").textWidth(RightColumnWidth).tooltip(Const::CellEnergyTooltip), _energy);
-        if (_material == CreationMaterial_Fluid) {
-            AlienGui::SliderFloat(AlienGui::SliderFloatParameters().name("Glow").min(0).max(1.0f).format("%.2f").textWidth(RightColumnWidth), &_glow);
-        }
-        if (!isEnergyMaterial() && _material != CreationMaterial_Fluid) {
-            AlienGui::SliderFloat(
-                AlienGui::SliderFloatParameters().name("Stiffness").max(1.0f).min(0.0f).textWidth(RightColumnWidth).tooltip(Const::CellStiffnessTooltip),
-                &_stiffness);
-        }
-
-        if (_mode == CreationMode_CreateRectangle) {
-            AlienGui::InputInt(
-                AlienGui::InputIntParameters().name("Horizontal objects").textWidth(RightColumnWidth).tooltip(Const::CreatorRectangleWidthTooltip),
-                _rectHorizontalObjects);
-            AlienGui::InputInt(
-                AlienGui::InputIntParameters().name("Vertical objects").textWidth(RightColumnWidth).tooltip(Const::CreatorRectangleHeightTooltip),
-                _rectVerticalObjects);
-        }
-        if (_mode == CreationMode_CreateHexagon) {
-            AlienGui::InputInt(AlienGui::InputIntParameters().name("Layers").textWidth(RightColumnWidth).tooltip(Const::CreatorHexagonLayersTooltip), _layers);
-        }
-        if (_mode == CreationMode_CreateDisc) {
-            AlienGui::InputFloat(
-                AlienGui::InputFloatParameters().name("Outer radius").textWidth(RightColumnWidth).format("%.0f").tooltip(Const::CreatorDiscOuterRadiusTooltip),
-                _outerRadius);
-            AlienGui::InputFloat(
-                AlienGui::InputFloatParameters().name("Inner radius").textWidth(RightColumnWidth).format("%.0f").tooltip(Const::CreatorDiscInnerRadiusTooltip),
-                _innerRadius);
-        }
-        if (_mode == CreationMode_CreateRectangle || _mode == CreationMode_CreateHexagon || _mode == CreationMode_CreateDisc || isPointPlacementMode()) {
-            AlienGui::InputFloat(
-                AlienGui::InputFloatParameters()
-                    .name("Object distance")
-                    .format("%.2f")
-                    .step(0.1)
-                    .textWidth(RightColumnWidth)
-                    .tooltip(Const::CreatorDistanceTooltip),
-                _objectDistance);
-        }
-        if (_mode != CreationMode_CreateObject) {
-            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Sticky").textWidth(RightColumnWidth).tooltip(Const::CreatorStickyTooltip), _makeSticky);
-        }
-        if (!isEnergyMaterial()) {
-            AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Static").textWidth(RightColumnWidth).tooltip(Const::CellStaticTooltip), _static);
-        }
-    }
-    ImGui::EndChild();
-
     updateInteractionMode();
 
-    if (_mode != CreationMode_Drawing) {
-        AlienGui::Separator();
-        processBuildButtons();
+    switch (_mode) {
+    case CreationMode_CreateObject:
+        processCreateObject();
+        break;
+    case CreationMode_CreateRectangle:
+        processCreateRectangle();
+        break;
+    case CreationMode_CreateHexagon:
+        processCreateHexagon();
+        break;
+    case CreationMode_CreateDisc:
+        processCreateDisc();
+        break;
+    case CreationMode_Drawing:
+        processDrawing();
+        break;
+    case CreationMode_CreateLine:
+        processCreateLine();
+        break;
+    case CreationMode_CreateCurve:
+        processCreateCurve();
+        break;
+    case CreationMode_CreatePolygon:
+        processCreatePolygon();
+        break;
     }
-    if (isPointPlacementMode()) {
-        processPointPreview();
-    }
+
     validateAndCorrect();
+}
+
+void CreatorWindow::processCreateObject()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    if (processBuildButton()) {
+        createSingleObject();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processCreateRectangle()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        AlienGui::InputInt(
+            AlienGui::InputIntParameters().name("Horizontal objects").textWidth(RightColumnWidth).tooltip(Const::CreatorRectangleWidthTooltip),
+            _rectHorizontalObjects);
+        AlienGui::InputInt(
+            AlienGui::InputIntParameters().name("Vertical objects").textWidth(RightColumnWidth).tooltip(Const::CreatorRectangleHeightTooltip),
+            _rectVerticalObjects);
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    if (processBuildButton()) {
+        createRectangle();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processCreateHexagon()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        AlienGui::InputInt(AlienGui::InputIntParameters().name("Layers").textWidth(RightColumnWidth).tooltip(Const::CreatorHexagonLayersTooltip), _layers);
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    if (processBuildButton()) {
+        createHexagon();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processCreateDisc()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        AlienGui::InputFloat(
+            AlienGui::InputFloatParameters().name("Outer radius").textWidth(RightColumnWidth).format("%.0f").tooltip(Const::CreatorDiscOuterRadiusTooltip),
+            _outerRadius);
+        AlienGui::InputFloat(
+            AlienGui::InputFloatParameters().name("Inner radius").textWidth(RightColumnWidth).format("%.0f").tooltip(Const::CreatorDiscInnerRadiusTooltip),
+            _innerRadius);
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    if (processBuildButton()) {
+        createDisc();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processDrawing()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+
+        auto pencilWidth = EditorModel::get().getPencilWidth();
+        AlienGui::SliderFloat(
+            AlienGui::SliderFloatParameters()
+                .name("Pencil radius")
+                .min(1.0f)
+                .max(8.0f)
+                .textWidth(RightColumnWidth)
+                .format("%.1f")
+                .tooltip(Const::CreatorPencilRadiusTooltip),
+            &pencilWidth);
+        EditorModel::get().setPencilWidth(pencilWidth);
+
+        processMaterialWidgets();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+}
+
+void CreatorWindow::processCreateLine()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    processPointPreview(_points, false);
+
+    if (processPointButtons(2)) {
+        createObjectNetwork(distributeAlongPath(_points, _objectDistance), _objectDistance * 1.5f);
+        _points.clear();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processCreateCurve()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    auto path = calcBezierCurvePath();
+    processControlPolygonPreview();
+    processPointPreview(path, false);
+
+    if (processPointButtons(2)) {
+        createObjectNetwork(distributeAlongPath(path, _objectDistance), _objectDistance * 1.5f);
+        _points.clear();
+        EditorModel::get().update();
+    }
+}
+
+void CreatorWindow::processCreatePolygon()
+{
+    if (beginParameterPanel()) {
+        processColorWidget();
+        processMaterialWidgets();
+        processObjectDistanceWidget();
+        processStickyWidget();
+        processStaticWidget();
+    }
+    endParameterPanel();
+
+    processPointPreview(_points, true);
+
+    if (processPointButtons(3)) {
+        createObjectNetwork(distributeHexagonallyInPolygon(_points, _objectDistance), _objectDistance * 1.7f);
+        _points.clear();
+        EditorModel::get().update();
+    }
 }
 
 void CreatorWindow::updateInteractionMode()
@@ -279,42 +400,94 @@ void CreatorWindow::updateInteractionMode()
     }
 }
 
-void CreatorWindow::processBuildButtons()
+bool CreatorWindow::beginParameterPanel()
 {
-    ImGui::BeginDisabled(isPointPlacementMode() && toInt(_points.size()) < getRequiredNumPoints());
-    if (AlienGui::Button("Build")) {
-        switch (_mode) {
-        case CreationMode_CreateObject:
-            createEntity();
-            break;
-        case CreationMode_CreateRectangle:
-            createRectangle();
-            break;
-        case CreationMode_CreateHexagon:
-            createHexagon();
-            break;
-        case CreationMode_CreateDisc:
-            createDisc();
-            break;
-        case CreationMode_CreateLine:
-        case CreationMode_CreateCurve:
-        case CreationMode_CreatePolygon:
-            createFromPoints();
-            _points.clear();
-            break;
-        }
-        EditorModel::get().update();
+    auto result = ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar);
+    if (result) {
+        AlienGui::Group(AlienGui::GroupParameters().text(ModeText.at(_mode)));
+    }
+    return result;
+}
+
+void CreatorWindow::endParameterPanel()
+{
+    ImGui::EndChild();
+}
+
+void CreatorWindow::processColorWidget()
+{
+    auto color = EditorModel::get().getDefaultColorCode();
+    AlienGui::ComboColor(
+        AlienGui::ComboColorParameters()
+            .customizationColors(_SimulationFacade::get()->getSimulationParameters().customizationColors.value)
+            .name("Color")
+            .textWidth(RightColumnWidth)
+            .tooltip(Const::GenomeColorTooltip),
+        color);
+    EditorModel::get().setDefaultColorCode(color);
+}
+
+void CreatorWindow::processMaterialWidgets()
+{
+    AlienGui::Switcher(
+        AlienGui::SwitcherParameters()
+            .name("Material")
+            .textWidth(RightColumnWidth)
+            .values({"Solid", "Fluid", "Free cells", "Energy particles"})
+            .tooltip(Const::CreatorDrawingTypeTooltip),
+        &_material);
+    AlienGui::InputFloat(AlienGui::InputFloatParameters().name("Energy").format("%.2f").textWidth(RightColumnWidth).tooltip(Const::CellEnergyTooltip), _energy);
+    if (_material == CreationMaterial_Fluid) {
+        AlienGui::SliderFloat(AlienGui::SliderFloatParameters().name("Glow").min(0).max(1.0f).format("%.2f").textWidth(RightColumnWidth), &_glow);
+    }
+    if (!isEnergyMaterial() && _material != CreationMaterial_Fluid) {
+        AlienGui::SliderFloat(
+            AlienGui::SliderFloatParameters().name("Stiffness").max(1.0f).min(0.0f).textWidth(RightColumnWidth).tooltip(Const::CellStiffnessTooltip),
+            &_stiffness);
+    }
+}
+
+void CreatorWindow::processObjectDistanceWidget()
+{
+    AlienGui::InputFloat(
+        AlienGui::InputFloatParameters().name("Object distance").format("%.2f").step(0.1).textWidth(RightColumnWidth).tooltip(Const::CreatorDistanceTooltip),
+        _objectDistance);
+}
+
+void CreatorWindow::processStickyWidget()
+{
+    AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Sticky").textWidth(RightColumnWidth).tooltip(Const::CreatorStickyTooltip), _makeSticky);
+}
+
+void CreatorWindow::processStaticWidget()
+{
+    if (!isEnergyMaterial()) {
+        AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Static").textWidth(RightColumnWidth).tooltip(Const::CellStaticTooltip), _static);
+    }
+}
+
+bool CreatorWindow::processBuildButton()
+{
+    AlienGui::Separator();
+    return AlienGui::Button("Build");
+}
+
+bool CreatorWindow::processPointButtons(int minNumPoints)
+{
+    AlienGui::Separator();
+
+    ImGui::BeginDisabled(toInt(_points.size()) < minNumPoints);
+    auto result = AlienGui::Button("Build");
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    ImGui::BeginDisabled(_points.empty());
+    if (AlienGui::Button("Clear")) {
+        _points.clear();
     }
     ImGui::EndDisabled();
 
-    if (isPointPlacementMode()) {
-        ImGui::SameLine();
-        ImGui::BeginDisabled(_points.empty());
-        if (AlienGui::Button("Clear")) {
-            _points.clear();
-        }
-        ImGui::EndDisabled();
-    }
+    return result;
 }
 
 void CreatorWindow::processToolbar()
@@ -334,50 +507,43 @@ void CreatorWindow::processToolbar()
     }
 }
 
-void CreatorWindow::processPointPreview() const
+void CreatorWindow::processPointPreview(std::vector<RealVector2D> const& path, bool closed) const
 {
     if (_points.empty()) {
         return;
     }
 
-    auto toViewPos = [](RealVector2D const& worldPos) {
-        auto viewPos = Viewport::get().mapWorldToViewPosition(worldPos);
-        return ImVec2(viewPos.x, viewPos.y);
-    };
-
-    auto path = _mode == CreationMode_CreateCurve ? calcBezierCurvePath() : _points;
-    std::vector<ImVec2> viewPath;
-    viewPath.reserve(path.size());
-    for (auto const& point : path) {
-        viewPath.emplace_back(toViewPos(point));
-    }
-
     auto drawList = ImGui::GetBackgroundDrawList();
-    auto lineThickness = scale(2.0f);
-    auto closed = _mode == CreationMode_CreatePolygon ? ImDrawFlags_Closed : ImDrawFlags_None;
-    drawList->AddPolyline(viewPath.data(), toInt(viewPath.size()), Const::ConstructionPreviewLineColor, closed, lineThickness);
-
-    if (_mode == CreationMode_CreateCurve) {
-        std::vector<ImVec2> viewControlPolygon;
-        viewControlPolygon.reserve(_points.size());
-        for (auto const& point : _points) {
-            viewControlPolygon.emplace_back(toViewPos(point));
-        }
-        drawList->AddPolyline(
-            viewControlPolygon.data(), toInt(viewControlPolygon.size()), Const::ConstructionPreviewHintLineColor, ImDrawFlags_None, lineThickness);
-    }
+    auto viewPath = mapToViewPositions(path);
+    drawList->AddPolyline(
+        viewPath.data(),
+        toInt(viewPath.size()),
+        Const::ConstructionPreviewLineColor,
+        closed ? ImDrawFlags_Closed : ImDrawFlags_None,
+        scale(PreviewLineThickness));
 
     if (!ImGui::GetIO().WantCaptureMouse) {
         auto mousePos = ImGui::GetMousePos();
-        drawList->AddLine(toViewPos(_points.back()), mousePos, Const::ConstructionPreviewHintLineColor, lineThickness);
-        if (_mode == CreationMode_CreatePolygon && _points.size() > 1) {
-            drawList->AddLine(mousePos, toViewPos(_points.front()), Const::ConstructionPreviewHintLineColor, lineThickness);
+        drawList->AddLine(mapToViewPosition(_points.back()), mousePos, Const::ConstructionPreviewHintLineColor, scale(PreviewLineThickness));
+        if (closed && _points.size() > 1) {
+            drawList->AddLine(mousePos, mapToViewPosition(_points.front()), Const::ConstructionPreviewHintLineColor, scale(PreviewLineThickness));
         }
     }
 
     for (auto const& point : _points) {
-        drawList->AddCircleFilled(toViewPos(point), scale(3.0f), Const::ConstructionPreviewPointColor);
+        drawList->AddCircleFilled(mapToViewPosition(point), scale(PreviewPointRadius), Const::ConstructionPreviewPointColor);
     }
+}
+
+void CreatorWindow::processControlPolygonPreview() const
+{
+    if (_points.size() < 2) {
+        return;
+    }
+
+    auto viewPath = mapToViewPositions(_points);
+    ImGui::GetBackgroundDrawList()->AddPolyline(
+        viewPath.data(), toInt(viewPath.size()), Const::ConstructionPreviewHintLineColor, ImDrawFlags_None, scale(PreviewLineThickness));
 }
 
 bool CreatorWindow::isShown()
@@ -472,7 +638,7 @@ CreatorWindow::CreatorWindow()
     : AlienWindow("Creator", "editors.creator", false, false, {464.0f, 61.0f}, {400.0f, 370.0f})
 {}
 
-void CreatorWindow::createEntity()
+void CreatorWindow::createSingleObject()
 {
     ContentDesc description;
     if (isEnergyMaterial()) {
@@ -574,9 +740,8 @@ void CreatorWindow::createDisc()
     _SimulationFacade::get()->addAndSelectSimulationData(std::move(description));
 }
 
-void CreatorWindow::createFromPoints()
+void CreatorWindow::createObjectNetwork(std::vector<RealVector2D> const& positions, float connectionDistance)
 {
-    auto positions = calcObjectPositionsFromPoints();
     if (positions.empty()) {
         return;
     }
@@ -598,7 +763,6 @@ void CreatorWindow::createFromPoints()
     if (isEnergyMaterial()) {
         description = convertToEnergyParticles(description);
     } else {
-        auto connectionDistance = _objectDistance * (_mode == CreationMode_CreatePolygon ? 1.7f : 1.5f);
         DescEditService::get().reconnectObjects(description, connectionDistance);
     }
     _SimulationFacade::get()->addAndSelectSimulationData(std::move(description));
@@ -622,14 +786,6 @@ std::vector<RealVector2D> CreatorWindow::calcBezierCurvePath() const
         result.emplace_back(evaluateBezier(_points, toFloat(segment) / toFloat(numSegments)));
     }
     return result;
-}
-
-std::vector<RealVector2D> CreatorWindow::calcObjectPositionsFromPoints() const
-{
-    if (_mode == CreationMode_CreatePolygon) {
-        return distributeHexagonallyInPolygon(_points, _objectDistance);
-    }
-    return distributeAlongPath(_mode == CreationMode_CreateCurve ? calcBezierCurvePath() : _points, _objectDistance);
 }
 
 ContentDesc CreatorWindow::convertToEnergyParticles(ContentDesc const& description) const
@@ -674,11 +830,6 @@ InteractionMode CreatorWindow::getInteractionMode() const
         return InteractionMode_PointPlacement;
     }
     return InteractionMode_Selection;
-}
-
-int CreatorWindow::getRequiredNumPoints() const
-{
-    return _mode == CreationMode_CreatePolygon ? 3 : 2;
 }
 
 ObjectTypeDesc CreatorWindow::getObjectTypeDesc() const

--- a/source/Gui/CreatorWindow.cpp
+++ b/source/Gui/CreatorWindow.cpp
@@ -1,7 +1,10 @@
 #include "CreatorWindow.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <ranges>
+#include <span>
 
 #include <imgui.h>
 
@@ -32,10 +35,106 @@ namespace
         {CreationMode_CreateRectangle, "Create a rectangular object network"},
         {CreationMode_CreateHexagon, "Create a hexagonal object network"},
         {CreationMode_CreateDisc, "Create a disc-shaped object network"},
+        {CreationMode_CreateLine, "Create an object network along a line"},
+        {CreationMode_CreateCurve, "Create an object network along a Bezier curve"},
+        {CreationMode_CreatePolygon, "Create a polygon-shaped object network"},
         {CreationMode_Drawing, "Draw freehand"},
     };
 
+    auto const ToolbarModeIcons = std::vector<std::pair<CreationMode, std::string>>{
+        {CreationMode_CreateObject, ICON_DOT},
+        {CreationMode_CreateRectangle, ICON_RECTANGLE},
+        {CreationMode_CreateHexagon, ICON_HEXAGON},
+        {CreationMode_CreateDisc, ICON_DISC},
+        {CreationMode_CreateLine, ICON_FA_SLASH},
+        {CreationMode_CreateCurve, ICON_FA_BEZIER_CURVE},
+        {CreationMode_CreatePolygon, ICON_FA_DRAW_POLYGON},
+        {CreationMode_Drawing, ICON_FA_PAINT_BRUSH},
+    };
+
     auto const RightColumnWidth = 160.0f;
+    auto constexpr MaxNumObjects = size_t{1000000};
+
+    RealVector2D evaluateBezier(std::vector<RealVector2D> const& controlPoints, float t)
+    {
+        auto points = controlPoints;
+        for (auto count = points.size(); count > 1; --count) {
+            auto range = std::span(points).first(count);
+            for (auto&& [current, next] : std::views::zip(range, range | std::views::drop(1))) {
+                current = current * (1.0f - t) + next * t;
+            }
+        }
+        return points.front();
+    }
+
+    std::vector<RealVector2D> distributeAlongPath(std::vector<RealVector2D> const& path, float distance)
+    {
+        std::vector<RealVector2D> result;
+        if (path.size() < 2 || distance < NEAR_ZERO) {
+            return result;
+        }
+        result.emplace_back(path.front());
+        auto pendingDistance = distance;
+        for (auto const& [from, to] : std::views::zip(path, path | std::views::drop(1))) {
+            auto segmentLength = Math::length(to - from);
+            if (segmentLength < NEAR_ZERO) {
+                continue;
+            }
+            auto direction = (to - from) / segmentLength;
+            auto offset = pendingDistance;
+            for (; offset < segmentLength + NEAR_ZERO && result.size() < MaxNumObjects; offset += distance) {
+                result.emplace_back(from + direction * offset);
+            }
+            pendingDistance = offset - segmentLength;
+        }
+        return result;
+    }
+
+    bool isInsidePolygon(std::vector<RealVector2D> const& closedPolygon, RealVector2D const& pos)
+    {
+        auto result = false;
+        for (auto const& [from, to] : std::views::zip(closedPolygon, closedPolygon | std::views::drop(1))) {
+            if ((from.y > pos.y) != (to.y > pos.y)) {
+                auto intersectionX = from.x + (pos.y - from.y) / (to.y - from.y) * (to.x - from.x);
+                if (pos.x < intersectionX) {
+                    result = !result;
+                }
+            }
+        }
+        return result;
+    }
+
+    std::vector<RealVector2D> distributeHexagonallyInPolygon(std::vector<RealVector2D> const& polygon, float distance)
+    {
+        std::vector<RealVector2D> result;
+        if (polygon.size() < 3 || distance < NEAR_ZERO) {
+            return result;
+        }
+        auto closedPolygon = polygon;
+        closedPolygon.emplace_back(polygon.front());
+
+        auto minPos = polygon.front();
+        auto maxPos = polygon.front();
+        for (auto const& point : polygon) {
+            minPos.x = std::min(minPos.x, point.x);
+            minPos.y = std::min(minPos.y, point.y);
+            maxPos.x = std::max(maxPos.x, point.x);
+            maxPos.y = std::max(maxPos.y, point.y);
+        }
+
+        auto rowDistance = distance * sqrtf(3.0f) / 2;
+        auto rowIndex = 0;
+        for (auto y = minPos.y; y < maxPos.y + NEAR_ZERO && result.size() < MaxNumObjects; y += rowDistance) {
+            auto rowOffset = rowIndex % 2 == 0 ? 0.0f : distance / 2;
+            for (auto x = minPos.x + rowOffset; x < maxPos.x + NEAR_ZERO && result.size() < MaxNumObjects; x += distance) {
+                if (isInsidePolygon(closedPolygon, {x, y})) {
+                    result.emplace_back(RealVector2D{x, y});
+                }
+            }
+            ++rowIndex;
+        }
+        return result;
+    }
 }
 
 void CreatorWindow::initIntern()
@@ -75,24 +174,7 @@ void CreatorWindow::shutdownIntern()
 
 void CreatorWindow::processIntern()
 {
-    AlienGui::SelectableToolbarButton(ICON_DOT, _mode, CreationMode_CreateObject, CreationMode_CreateObject);
-    AlienGui::Tooltip(ModeText.at(CreationMode_CreateObject));
-
-    ImGui::SameLine();
-    AlienGui::SelectableToolbarButton(ICON_RECTANGLE, _mode, CreationMode_CreateRectangle, CreationMode_CreateRectangle);
-    AlienGui::Tooltip(ModeText.at(CreationMode_CreateRectangle));
-
-    ImGui::SameLine();
-    AlienGui::SelectableToolbarButton(ICON_HEXAGON, _mode, CreationMode_CreateHexagon, CreationMode_CreateHexagon);
-    AlienGui::Tooltip(ModeText.at(CreationMode_CreateHexagon));
-
-    ImGui::SameLine();
-    AlienGui::SelectableToolbarButton(ICON_DISC, _mode, CreationMode_CreateDisc, CreationMode_CreateDisc);
-    AlienGui::Tooltip(ModeText.at(CreationMode_CreateDisc));
-
-    ImGui::SameLine();
-    AlienGui::SelectableToolbarButton(ICON_FA_PAINT_BRUSH, _mode, CreationMode_Drawing, CreationMode_Drawing);
-    AlienGui::Tooltip(ModeText.at(CreationMode_Drawing));
+    processToolbar();
 
     if (ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar)) {
         AlienGui::Group(AlienGui::GroupParameters().text(ModeText.at(_mode)));
@@ -156,7 +238,7 @@ void CreatorWindow::processIntern()
                 AlienGui::InputFloatParameters().name("Inner radius").textWidth(RightColumnWidth).format("%.0f").tooltip(Const::CreatorDiscInnerRadiusTooltip),
                 _innerRadius);
         }
-        if (_mode == CreationMode_CreateRectangle || _mode == CreationMode_CreateHexagon || _mode == CreationMode_CreateDisc) {
+        if (_mode == CreationMode_CreateRectangle || _mode == CreationMode_CreateHexagon || _mode == CreationMode_CreateDisc || isPointPlacementMode()) {
             AlienGui::InputFloat(
                 AlienGui::InputFloatParameters()
                     .name("Object distance")
@@ -175,29 +257,127 @@ void CreatorWindow::processIntern()
     }
     ImGui::EndChild();
 
-    auto& simInteractionController = SimulationInteractionController::get();
-    if (_mode == CreationMode_Drawing) {
-        simInteractionController.setDrawMode(true);
-    } else {
+    updateInteractionMode();
+
+    if (_mode != CreationMode_Drawing) {
         AlienGui::Separator();
-        simInteractionController.setDrawMode(false);
-        if (AlienGui::Button("Build")) {
-            if (_mode == CreationMode_CreateObject) {
-                createEntity();
-            }
-            if (_mode == CreationMode_CreateRectangle) {
-                createRectangle();
-            }
-            if (_mode == CreationMode_CreateHexagon) {
-                createHexagon();
-            }
-            if (_mode == CreationMode_CreateDisc) {
-                createDisc();
-            }
-            EditorModel::get().update();
-        }
+        processBuildButtons();
+    }
+    if (isPointPlacementMode()) {
+        processPointPreview();
     }
     validateAndCorrect();
+}
+
+void CreatorWindow::updateInteractionMode()
+{
+    auto& simInteractionController = SimulationInteractionController::get();
+    if (simInteractionController.getInteractionMode() == InteractionMode_PositionSelection) {
+        _points.clear();
+    } else {
+        simInteractionController.setInteractionMode(getInteractionMode());
+    }
+}
+
+void CreatorWindow::processBuildButtons()
+{
+    ImGui::BeginDisabled(isPointPlacementMode() && toInt(_points.size()) < getRequiredNumPoints());
+    if (AlienGui::Button("Build")) {
+        switch (_mode) {
+        case CreationMode_CreateObject:
+            createEntity();
+            break;
+        case CreationMode_CreateRectangle:
+            createRectangle();
+            break;
+        case CreationMode_CreateHexagon:
+            createHexagon();
+            break;
+        case CreationMode_CreateDisc:
+            createDisc();
+            break;
+        case CreationMode_CreateLine:
+        case CreationMode_CreateCurve:
+        case CreationMode_CreatePolygon:
+            createFromPoints();
+            _points.clear();
+            break;
+        }
+        EditorModel::get().update();
+    }
+    ImGui::EndDisabled();
+
+    if (isPointPlacementMode()) {
+        ImGui::SameLine();
+        ImGui::BeginDisabled(_points.empty());
+        if (AlienGui::Button("Clear")) {
+            _points.clear();
+        }
+        ImGui::EndDisabled();
+    }
+}
+
+void CreatorWindow::processToolbar()
+{
+    auto previousMode = _mode;
+
+    for (auto const& [mode, icon] : ToolbarModeIcons) {
+        AlienGui::SelectableToolbarButton(icon, _mode, mode, mode);
+        AlienGui::Tooltip(ModeText.at(mode));
+        if (mode != ToolbarModeIcons.back().first) {
+            ImGui::SameLine();
+        }
+    }
+
+    if (_mode != previousMode) {
+        _points.clear();
+    }
+}
+
+void CreatorWindow::processPointPreview() const
+{
+    if (_points.empty()) {
+        return;
+    }
+
+    auto toViewPos = [](RealVector2D const& worldPos) {
+        auto viewPos = Viewport::get().mapWorldToViewPosition(worldPos);
+        return ImVec2(viewPos.x, viewPos.y);
+    };
+
+    auto path = _mode == CreationMode_CreateCurve ? calcBezierCurvePath() : _points;
+    std::vector<ImVec2> viewPath;
+    viewPath.reserve(path.size());
+    for (auto const& point : path) {
+        viewPath.emplace_back(toViewPos(point));
+    }
+
+    auto drawList = ImGui::GetBackgroundDrawList();
+    auto lineThickness = scale(2.0f);
+    auto closed = _mode == CreationMode_CreatePolygon ? ImDrawFlags_Closed : ImDrawFlags_None;
+    drawList->AddPolyline(viewPath.data(), toInt(viewPath.size()), Const::ConstructionPreviewLineColor, closed, lineThickness);
+
+    if (_mode == CreationMode_CreateCurve) {
+        std::vector<ImVec2> viewControlPolygon;
+        viewControlPolygon.reserve(_points.size());
+        for (auto const& point : _points) {
+            viewControlPolygon.emplace_back(toViewPos(point));
+        }
+        drawList->AddPolyline(
+            viewControlPolygon.data(), toInt(viewControlPolygon.size()), Const::ConstructionPreviewHintLineColor, ImDrawFlags_None, lineThickness);
+    }
+
+    if (!ImGui::GetIO().WantCaptureMouse) {
+        auto mousePos = ImGui::GetMousePos();
+        drawList->AddLine(toViewPos(_points.back()), mousePos, Const::ConstructionPreviewHintLineColor, lineThickness);
+        if (_mode == CreationMode_CreatePolygon && _points.size() > 1) {
+            drawList->AddLine(mousePos, toViewPos(_points.front()), Const::ConstructionPreviewHintLineColor, lineThickness);
+        }
+    }
+
+    for (auto const& point : _points) {
+        drawList->AddCircleFilled(toViewPos(point), scale(3.0f), Const::ConstructionPreviewPointColor);
+    }
 }
 
 bool CreatorWindow::isShown()
@@ -276,8 +456,20 @@ void CreatorWindow::finishDrawing()
     _drawingOccupancy.clear();
 }
 
+void CreatorWindow::onAddPoint(RealVector2D const& worldPos)
+{
+    _points.emplace_back(worldPos);
+}
+
+void CreatorWindow::onRemoveLastPoint()
+{
+    if (!_points.empty()) {
+        _points.pop_back();
+    }
+}
+
 CreatorWindow::CreatorWindow()
-    : AlienWindow("Creator", "editors.creator", false, false, {464.0f, 61.0f}, {358.0f, 370.0f})
+    : AlienWindow("Creator", "editors.creator", false, false, {464.0f, 61.0f}, {400.0f, 370.0f})
 {}
 
 void CreatorWindow::createEntity()
@@ -382,6 +574,64 @@ void CreatorWindow::createDisc()
     _SimulationFacade::get()->addAndSelectSimulationData(std::move(description));
 }
 
+void CreatorWindow::createFromPoints()
+{
+    auto positions = calcObjectPositionsFromPoints();
+    if (positions.empty()) {
+        return;
+    }
+
+    ContentDesc description;
+    auto const color = EditorModel::get().getDefaultColorCode();
+    auto const objectType = isEnergyMaterial() ? ObjectTypeDesc{SolidDesc()} : getObjectTypeDesc();
+    for (auto const& pos : positions) {
+        description._objects.emplace_back(ObjectDesc()
+                                              .id(NumberGenerator::get().createEntityId())
+                                              .stiffness(_stiffness)
+                                              .sticky(_makeSticky)
+                                              .pos(pos)
+                                              .color(color)
+                                              .isStatic(_static)
+                                              .type(objectType));
+    }
+
+    if (isEnergyMaterial()) {
+        description = convertToEnergyParticles(description);
+    } else {
+        auto connectionDistance = _objectDistance * (_mode == CreationMode_CreatePolygon ? 1.7f : 1.5f);
+        DescEditService::get().reconnectObjects(description, connectionDistance);
+    }
+    _SimulationFacade::get()->addAndSelectSimulationData(std::move(description));
+}
+
+std::vector<RealVector2D> CreatorWindow::calcBezierCurvePath() const
+{
+    if (_points.size() < 2) {
+        return _points;
+    }
+
+    auto controlPolygonLength = 0.0f;
+    for (auto const& [from, to] : std::views::zip(_points, _points | std::views::drop(1))) {
+        controlPolygonLength += Math::length(to - from);
+    }
+
+    auto numSegments = std::clamp(toInt(controlPolygonLength * 4 / _objectDistance), 16, 10000);
+    std::vector<RealVector2D> result;
+    result.reserve(numSegments + 1);
+    for (auto segment : std::views::iota(0, numSegments + 1)) {
+        result.emplace_back(evaluateBezier(_points, toFloat(segment) / toFloat(numSegments)));
+    }
+    return result;
+}
+
+std::vector<RealVector2D> CreatorWindow::calcObjectPositionsFromPoints() const
+{
+    if (_mode == CreationMode_CreatePolygon) {
+        return distributeHexagonallyInPolygon(_points, _objectDistance);
+    }
+    return distributeAlongPath(_mode == CreationMode_CreateCurve ? calcBezierCurvePath() : _points, _objectDistance);
+}
+
 ContentDesc CreatorWindow::convertToEnergyParticles(ContentDesc const& description) const
 {
     ContentDesc result;
@@ -408,6 +658,27 @@ void CreatorWindow::validateAndCorrect()
 bool CreatorWindow::isEnergyMaterial() const
 {
     return _material == CreationMaterial_EnergyParticle;
+}
+
+bool CreatorWindow::isPointPlacementMode() const
+{
+    return _mode == CreationMode_CreateLine || _mode == CreationMode_CreateCurve || _mode == CreationMode_CreatePolygon;
+}
+
+InteractionMode CreatorWindow::getInteractionMode() const
+{
+    if (_mode == CreationMode_Drawing) {
+        return InteractionMode_Drawing;
+    }
+    if (isPointPlacementMode()) {
+        return InteractionMode_PointPlacement;
+    }
+    return InteractionMode_Selection;
+}
+
+int CreatorWindow::getRequiredNumPoints() const
+{
+    return _mode == CreationMode_CreatePolygon ? 3 : 2;
 }
 
 ObjectTypeDesc CreatorWindow::getObjectTypeDesc() const

--- a/source/Gui/CreatorWindow.h
+++ b/source/Gui/CreatorWindow.h
@@ -48,6 +48,7 @@ private:
     void initIntern() override;
     void shutdownIntern() override;
     void processIntern() override;
+    void processBackground() override;
     bool isShown() override;
 
     void processToolbar();
@@ -72,6 +73,7 @@ private:
     void processStaticWidget();
     bool processBuildButton();
     bool processPointButtons(int minNumPoints);
+    void abortPointPlacement();
 
     void processPointPreview(std::vector<RealVector2D> const& path, bool closed) const;
     void processControlPolygonPreview() const;
@@ -120,6 +122,7 @@ private:
     RealVector2D _lastDrawPos;
 
     std::vector<RealVector2D> _points;
+    bool _pointPlacementActive = false;
 
     CreationMode _mode = CreationMode_Drawing;
 };

--- a/source/Gui/CreatorWindow.h
+++ b/source/Gui/CreatorWindow.h
@@ -7,6 +7,7 @@
 
 #include "AlienWindow.h"
 #include "Definitions.h"
+#include "SimulationInteractionController.h"
 
 using CreationMode = int;
 enum CreationMode_
@@ -15,7 +16,10 @@ enum CreationMode_
     CreationMode_CreateRectangle,
     CreationMode_CreateHexagon,
     CreationMode_CreateDisc,
-    CreationMode_Drawing
+    CreationMode_Drawing,
+    CreationMode_CreateLine,
+    CreationMode_CreateCurve,
+    CreationMode_CreatePolygon
 };
 
 using CreationMaterial = int;
@@ -35,6 +39,9 @@ public:
     void onDrawing();
     void finishDrawing();
 
+    void onAddPoint(RealVector2D const& worldPos);
+    void onRemoveLastPoint();
+
 private:
     CreatorWindow();
 
@@ -43,15 +50,28 @@ private:
     void processIntern() override;
     bool isShown() override;
 
+    void processToolbar();
+    void processBuildButtons();
+    void processPointPreview() const;
+
+    void updateInteractionMode();
+
     void createEntity();
     void createRectangle();
     void createHexagon();
     void createDisc();
+    void createFromPoints();
+
+    std::vector<RealVector2D> calcBezierCurvePath() const;
+    std::vector<RealVector2D> calcObjectPositionsFromPoints() const;
 
     ContentDesc convertToEnergyParticles(ContentDesc const& description) const;
 
     void validateAndCorrect();
     bool isEnergyMaterial() const;
+    bool isPointPlacementMode() const;
+    InteractionMode getInteractionMode() const;
+    int getRequiredNumPoints() const;
 
     ObjectTypeDesc getObjectTypeDesc() const;
 
@@ -80,6 +100,8 @@ private:
     ContentDesc _drawingDescription;
     DescEditService::Occupancy _drawingOccupancy;
     RealVector2D _lastDrawPos;
+
+    std::vector<RealVector2D> _points;
 
     CreationMode _mode = CreationMode_Drawing;
 };

--- a/source/Gui/CreatorWindow.h
+++ b/source/Gui/CreatorWindow.h
@@ -51,19 +51,38 @@ private:
     bool isShown() override;
 
     void processToolbar();
-    void processBuildButtons();
-    void processPointPreview() const;
+
+    void processCreateObject();
+    void processCreateRectangle();
+    void processCreateHexagon();
+    void processCreateDisc();
+    void processDrawing();
+    void processCreateLine();
+    void processCreateCurve();
+    void processCreatePolygon();
 
     void updateInteractionMode();
 
-    void createEntity();
+    bool beginParameterPanel();
+    void endParameterPanel();
+    void processColorWidget();
+    void processMaterialWidgets();
+    void processObjectDistanceWidget();
+    void processStickyWidget();
+    void processStaticWidget();
+    bool processBuildButton();
+    bool processPointButtons(int minNumPoints);
+
+    void processPointPreview(std::vector<RealVector2D> const& path, bool closed) const;
+    void processControlPolygonPreview() const;
+
+    void createSingleObject();
     void createRectangle();
     void createHexagon();
     void createDisc();
-    void createFromPoints();
+    void createObjectNetwork(std::vector<RealVector2D> const& positions, float connectionDistance);
 
     std::vector<RealVector2D> calcBezierCurvePath() const;
-    std::vector<RealVector2D> calcObjectPositionsFromPoints() const;
 
     ContentDesc convertToEnergyParticles(ContentDesc const& description) const;
 
@@ -71,7 +90,6 @@ private:
     bool isEnergyMaterial() const;
     bool isPointPlacementMode() const;
     InteractionMode getInteractionMode() const;
-    int getRequiredNumPoints() const;
 
     ObjectTypeDesc getObjectTypeDesc() const;
 

--- a/source/Gui/SimulationInteractionController.cpp
+++ b/source/Gui/SimulationInteractionController.cpp
@@ -4,11 +4,11 @@
 
 #include <imgui.h>
 
+#include <Base/GlobalSettings.h>
 #include <Base/Resources.h>
 
 #include <EngineInterface/SimulationFacade.h>
 
-#include "AlienGui.h"
 #include "CreatorWindow.h"
 #include "EditorController.h"
 #include "EditorModel.h"
@@ -27,6 +27,13 @@ void SimulationInteractionController::init()
 
     _editorOn = OpenGLHelper::loadTexture(Const::EditorOnFilename);
     _editorOff = OpenGLHelper::loadTexture(Const::EditorOffFilename);
+
+    setEditMode(GlobalSettings::get().getValue("controllers.simulation interaction.edit mode", _modes.editMode));
+}
+
+void SimulationInteractionController::shutdown()
+{
+    GlobalSettings::get().setValue("controllers.simulation interaction.edit mode", _modes.editMode);
 }
 
 void SimulationInteractionController::process()
@@ -36,8 +43,8 @@ void SimulationInteractionController::process()
     if (_modes.editMode) {
         processSelectionRect();
     }
-    if (!CreatorWindow::get().isOn()) {
-        _modes.drawMode = false;
+    if (!CreatorWindow::get().isOn() && _modes.interactionMode != InteractionMode_PositionSelection) {
+        _modes.interactionMode = InteractionMode_Selection;
     }
     processEvents();
 }
@@ -53,24 +60,14 @@ void SimulationInteractionController::setEditMode(bool value)
     EditorController::get().setOn(_modes.editMode);
 }
 
-bool SimulationInteractionController::isDrawMode() const
+InteractionMode SimulationInteractionController::getInteractionMode() const
 {
-    return _modes.drawMode;
+    return _modes.interactionMode;
 }
 
-void SimulationInteractionController::setDrawMode(bool value)
+void SimulationInteractionController::setInteractionMode(InteractionMode value)
 {
-    _modes.drawMode = value;
-}
-
-bool SimulationInteractionController::isPositionSelectionMode() const
-{
-    return _modes.positionSelectionMode;
-}
-
-void SimulationInteractionController::setPositionSelectionMode(bool value)
-{
-    _modes.positionSelectionMode = value;
+    _modes.interactionMode = value;
 }
 
 std::optional<RealVector2D> SimulationInteractionController::getPositionSelectionData() const
@@ -161,8 +158,8 @@ void SimulationInteractionController::leftMouseButtonPressed(IntVector2D const& 
 {
     _modesAtClick = _modes;
 
-    if (_modes.positionSelectionMode) {
-        _modes.positionSelectionMode = false;
+    if (_modes.interactionMode == InteractionMode_PositionSelection) {
+        _modes.interactionMode = InteractionMode_Selection;
         return;
     }
 
@@ -171,7 +168,11 @@ void SimulationInteractionController::leftMouseButtonPressed(IntVector2D const& 
         SimulationView::get().setMotionBlur(SimulationView::get().getMotionBlur() * 2);
     } else {
         if (!ImGui::GetIO().KeyAlt) {
-            if (!_modes.drawMode) {
+            if (_modes.interactionMode == InteractionMode_PointPlacement) {
+                CreatorWindow::get().onAddPoint(Viewport::get().mapViewToWorldPosition(toRealVector2D(mousePos)));
+            } else if (_modes.interactionMode == InteractionMode_Drawing) {
+                CreatorWindow::get().onDrawing();
+            } else {
                 EditorController::get().onSelectObjects(toRealVector2D(mousePos), ImGui::GetIO().KeyCtrl);
                 _worldPosOnClick = Viewport::get().mapViewToWorldPosition(toRealVector2D(mousePos));
                 if (_SimulationFacade::get()->isSimulationRunning()) {
@@ -180,8 +181,6 @@ void SimulationInteractionController::leftMouseButtonPressed(IntVector2D const& 
 
                 auto shallowData = _SimulationFacade::get()->getSelectionShallowData();
                 _selectionPositionOnClick = {shallowData.centerPosX, shallowData.centerPosY};
-            } else {
-                CreatorWindow::get().onDrawing();
             }
         }
     }
@@ -189,23 +188,21 @@ void SimulationInteractionController::leftMouseButtonPressed(IntVector2D const& 
 
 void SimulationInteractionController::leftMouseButtonHold(IntVector2D const& mousePos, IntVector2D const& prevMousePos)
 {
-    if (_modesAtClick.positionSelectionMode) {
+    if (_modesAtClick.interactionMode == InteractionMode_PositionSelection) {
         return;
     }
 
     if (!_modesAtClick.editMode) {
         Viewport::get().zoom(mousePos, calcZoomFactor(_lastZoomTimepoint ? *_lastZoomTimepoint : std::chrono::steady_clock::now()));
-    } else {
+    } else if (_modesAtClick.interactionMode == InteractionMode_Drawing) {
+        CreatorWindow::get().onDrawing();
+    } else if (_modesAtClick.interactionMode == InteractionMode_Selection) {
         RealVector2D prevWorldPos = Viewport::get().mapViewToWorldPosition(toRealVector2D(prevMousePos));
 
-        if (!_modesAtClick.drawMode) {
-            if (!_SimulationFacade::get()->isSimulationRunning()) {
-                EditorController::get().onMoveSelectedObjects(toRealVector2D(mousePos), prevWorldPos);
-            } else {
-                EditorController::get().onFixateSelectedObjects(toRealVector2D(mousePos), *_worldPosOnClick, *_selectionPositionOnClick);
-            }
+        if (!_SimulationFacade::get()->isSimulationRunning()) {
+            EditorController::get().onMoveSelectedObjects(toRealVector2D(mousePos), prevWorldPos);
         } else {
-            CreatorWindow::get().onDrawing();
+            EditorController::get().onFixateSelectedObjects(toRealVector2D(mousePos), *_worldPosOnClick, *_selectionPositionOnClick);
         }
     }
 }
@@ -218,21 +215,19 @@ void SimulationInteractionController::mouseWheelUp(IntVector2D const& mousePos, 
 
 void SimulationInteractionController::leftMouseButtonReleased(IntVector2D const& mousePos, IntVector2D const& prevMousePos)
 {
-    if (_modesAtClick.positionSelectionMode) {
+    if (_modesAtClick.interactionMode == InteractionMode_PositionSelection) {
         return;
     }
 
     if (!_modesAtClick.editMode) {
         SimulationView::get().setMotionBlur(SimulationView::get().getMotionBlur() / 2);
-    } else {
-        if (_modesAtClick.drawMode) {
-            CreatorWindow::get().finishDrawing();
-        } else {
-            if (_SimulationFacade::get()->isSimulationRunning()) {
-                _SimulationFacade::get()->setDetached(false);
-                RealVector2D prevWorldPos = Viewport::get().mapViewToWorldPosition(toRealVector2D(prevMousePos));
-                EditorController::get().onAccelerateSelectedObjects(toRealVector2D(mousePos), prevWorldPos);
-            }
+    } else if (_modesAtClick.interactionMode == InteractionMode_Drawing) {
+        CreatorWindow::get().finishDrawing();
+    } else if (_modesAtClick.interactionMode == InteractionMode_Selection) {
+        if (_SimulationFacade::get()->isSimulationRunning()) {
+            _SimulationFacade::get()->setDetached(false);
+            RealVector2D prevWorldPos = Viewport::get().mapViewToWorldPosition(toRealVector2D(prevMousePos));
+            EditorController::get().onAccelerateSelectedObjects(toRealVector2D(mousePos), prevWorldPos);
         }
     }
 }
@@ -241,8 +236,8 @@ void SimulationInteractionController::rightMouseButtonPressed(IntVector2D const&
 {
     _modesAtClick = _modes;
 
-    if (_modes.positionSelectionMode) {
-        _modes.positionSelectionMode = false;
+    if (_modes.interactionMode == InteractionMode_PositionSelection) {
+        _modes.interactionMode = InteractionMode_Selection;
         return;
     }
 
@@ -251,7 +246,9 @@ void SimulationInteractionController::rightMouseButtonPressed(IntVector2D const&
         SimulationView::get().setMotionBlur(SimulationView::get().getMotionBlur() * 2);
     } else {
         if (!ImGui::GetIO().KeyAlt) {
-            if (!_SimulationFacade::get()->isSimulationRunning() && !_modes.drawMode) {
+            if (_modes.interactionMode == InteractionMode_PointPlacement) {
+                CreatorWindow::get().onRemoveLastPoint();
+            } else if (_modes.interactionMode == InteractionMode_Selection && !_SimulationFacade::get()->isSimulationRunning()) {
                 auto viewPos = toRealVector2D(mousePos);
                 RealRect rect{viewPos, viewPos};
                 _selectionRect = rect;
@@ -262,16 +259,16 @@ void SimulationInteractionController::rightMouseButtonPressed(IntVector2D const&
 
 void SimulationInteractionController::rightMouseButtonHold(IntVector2D const& mousePos, IntVector2D const& prevMousePos)
 {
-    if (_modesAtClick.positionSelectionMode) {
+    if (_modesAtClick.interactionMode == InteractionMode_PositionSelection) {
         return;
     }
 
     if (!_modesAtClick.editMode) {
         Viewport::get().zoom(mousePos, 1.0f / calcZoomFactor(_lastZoomTimepoint ? *_lastZoomTimepoint : std::chrono::steady_clock::now()));
-    } else {
+    } else if (_modesAtClick.interactionMode != InteractionMode_PointPlacement) {
         if (!ImGui::GetIO().KeyAlt) {
             auto isSimulationRunning = _SimulationFacade::get()->isSimulationRunning();
-            if (!isSimulationRunning && !_modesAtClick.drawMode && _selectionRect.has_value()) {
+            if (!isSimulationRunning && _modesAtClick.interactionMode == InteractionMode_Selection && _selectionRect.has_value()) {
                 _selectionRect->bottomRight = toRealVector2D(mousePos);
                 EditorController::get().onUpdateSelectionRect(*_selectionRect);
             }
@@ -291,13 +288,13 @@ void SimulationInteractionController::mouseWheelDown(IntVector2D const& mousePos
 
 void SimulationInteractionController::rightMouseButtonReleased()
 {
-    if (_modesAtClick.positionSelectionMode) {
+    if (_modesAtClick.interactionMode == InteractionMode_PositionSelection) {
         return;
     }
 
     if (!_modesAtClick.editMode) {
         SimulationView::get().setMotionBlur(SimulationView::get().getMotionBlur() / 2);
-    } else {
+    } else if (_modesAtClick.interactionMode != InteractionMode_PointPlacement) {
         if (!_SimulationFacade::get()->isSimulationRunning()) {
             _selectionRect.reset();
         }
@@ -342,7 +339,7 @@ void SimulationInteractionController::drawCursor()
     }
 
     // Position selection cursor
-    if (_modes.positionSelectionMode) {
+    if (_modes.interactionMode == InteractionMode_PositionSelection) {
         auto cursorSize = scale(CursorRadius);
 
         // Shadow
@@ -369,7 +366,7 @@ void SimulationInteractionController::drawCursor()
 
     // Editing cursors
     if (_modes.editMode) {
-        if (!_modes.drawMode) {
+        if (_modes.interactionMode != InteractionMode_Drawing) {
             auto cursorSize = scale(CursorRadius);
 
             // Shadow
@@ -394,11 +391,7 @@ void SimulationInteractionController::drawCursor()
         } else {
             auto zoom = Viewport::get().getZoomFactor();
             auto radius = EditorModel::get().getPencilWidth() * zoom;
-            auto const& customizationColors = _SimulationFacade::get()->getSimulationParameters().customizationColors.value;
-            auto color = customizationColors.values[EditorModel::get().getDefaultColorCode()].toRgbColor();
-            float h, s, v;
-            AlienGui::ConvertRGBtoHSV(color, h, s, v);
-            drawList->AddCircleFilled(mousePos, radius, ImColor::HSV(h, s, v, 0.6f));
+            drawList->AddCircleFilled(mousePos, radius, Const::ConstructionPreviewBrushColor);
         }
         return;
     }

--- a/source/Gui/SimulationInteractionController.h
+++ b/source/Gui/SimulationInteractionController.h
@@ -9,6 +9,15 @@
 #include "Definitions.h"
 #include "MainLoopEntity.h"
 
+using InteractionMode = int;
+enum InteractionMode_
+{
+    InteractionMode_Selection,
+    InteractionMode_Drawing,
+    InteractionMode_PointPlacement,
+    InteractionMode_PositionSelection
+};
+
 class SimulationInteractionController : public MainLoopEntity
 {
     MAKE_SINGLETON(SimulationInteractionController);
@@ -17,17 +26,15 @@ public:
     bool isEditMode() const;
     void setEditMode(bool value);
 
-    bool isDrawMode() const;
-    void setDrawMode(bool value);
+    InteractionMode getInteractionMode() const;
+    void setInteractionMode(InteractionMode value);
 
-    bool isPositionSelectionMode() const;
-    void setPositionSelectionMode(bool value);
     std::optional<RealVector2D> getPositionSelectionData() const;
 
 private:
     void init() override;
     void process() override;
-    void shutdown() override {}
+    void shutdown() override;
 
     void processEditWidget();
     void processEvents();
@@ -60,8 +67,7 @@ private:
     struct Modes
     {
         bool editMode = false;
-        bool drawMode = false;
-        bool positionSelectionMode = false;
+        InteractionMode interactionMode = InteractionMode_Selection;
     };
     Modes _modes;
     Modes _modesAtClick;

--- a/source/Gui/SpecificationGuiService.cpp
+++ b/source/Gui/SpecificationGuiService.cpp
@@ -370,8 +370,10 @@ void SpecificationGuiService::createWidgetsForFloat2Spec(
         }
     }();
 
-    auto getMousePickerEnabledFunc = [&]() { return SimulationInteractionController::get().isPositionSelectionMode(); };
-    auto setMousePickerEnabledFunc = [&](bool value) { SimulationInteractionController::get().setPositionSelectionMode(value); };
+    auto getMousePickerEnabledFunc = [&]() { return SimulationInteractionController::get().getInteractionMode() == InteractionMode_PositionSelection; };
+    auto setMousePickerEnabledFunc = [&](bool value) {
+        SimulationInteractionController::get().setInteractionMode(value ? InteractionMode_PositionSelection : InteractionMode_Selection);
+    };
     auto getMousePickerPositionFunc = [&]() { return SimulationInteractionController::get().getPositionSelectionData(); };
 
     AlienGui::SliderFloat2(

--- a/source/Gui/StyleRepository.h
+++ b/source/Gui/StyleRepository.h
@@ -91,6 +91,11 @@ namespace Const
     ImColor const SelectionAreaFillColor = ImColor::HSV(0.33f, 0.0f, 1.0f, 0.6f);
     ImColor const SelectionAreaBorderColor = ImColor::HSV(0.33f, 0.0f, 1.0f, 1.0f);
 
+    ImColor const ConstructionPreviewLineColor = ImColor::HSV(0.54f, 0.3f, 1.0f, 0.9f);
+    ImColor const ConstructionPreviewHintLineColor = ImColor::HSV(0.54f, 0.3f, 1.0f, 0.4f);
+    ImColor const ConstructionPreviewPointColor = ImColor::HSV(0.54f, 0.0f, 1.0f, 1.0f);
+    ImColor const ConstructionPreviewBrushColor = ImColor::HSV(0.54f, 0.3f, 1.0f, 0.6f);
+
     ImColor const CellTypeOverlayColor = ImColor::HSV(0.0f, 0.0f, 1.0f, 0.5f);
     ImColor const CellTypeOverlayShadowColor = ImColor::HSV(0.0f, 0.0f, 0.0f, 0.7f);
     ImColor const ExecutionNumberOverlayColor = ImColor::HSV(0.0f, 0.0f, 1.0f, 0.8f);


### PR DESCRIPTION
Three new modes in the creator window for building object networks along a shape.

## Modes

- **Line** (`ICON_FA_SLASH`): a polyline through the set points
- **Bezier curve** (`ICON_FA_BEZIER_CURVE`): a Bezier curve over all points as control points
- **Polygon** (`ICON_FA_DRAW_POLYGON`): the polygon spanned by the points

The points are set in the simulation view with the left mouse button, the last one is removed again with the right mouse button. A preview of the resulting shape is drawn while the points are being set. `Build` creates the objects and clears the points, `Clear` discards them.

Objects follow the line and the curve at even arc length spacing (`Object distance`) and fill the polygon on a hexagonal lattice, so the connection radius matches the existing hexagon mode. Material, energy, stiffness, sticky, static and energy particles work as in the other modes.

The toolbar is data driven now and wraps when the window is too narrow; the default window width grew to fit the eight buttons.

## Interaction modes

The mutually exclusive states of the simulation view were four independent flags, although at most one of them applies. They are an `InteractionMode` enum now:

```cpp
enum InteractionMode_
{
    InteractionMode_Selection,
    InteractionMode_Drawing,
    InteractionMode_PointPlacement,
    InteractionMode_PositionSelection
};
```

`editMode` stays a separate flag because it is an independent axis: it gates the editor windows and combines with every mode. A position selection started in another window takes precedence over the creator and discards the points collected so far.

## Other

- The edit mode is stored in the global settings.
- The radiation source marker used a hardcoded near black color and was hard to make out; it is three times brighter now.
