### PR TITLE
Add generic toolbar widget with overflow menu

### DIFF
--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -1885,6 +1885,7 @@ namespace
     auto constexpr ToolbarSelectionBarBottom = 5.0f;
     auto constexpr ToolbarSelectionBarHeight = 2.0f;
     auto constexpr ToolbarOverflowSize = 28.0f;
+    auto constexpr ToolbarOverflowIconSize = 15.0f;
     auto constexpr ToolbarOverflowSpacing = 10.0f;
     auto constexpr ToolbarMenuSpacing = 4.0f;
     auto constexpr ToolbarMenuRowHeight = 34.0f;
@@ -2123,13 +2124,15 @@ void AlienGui::Toolbar(ToolbarParameters const& parameters, std::vector<ToolbarI
         }
         auto opened = ImGui::IsPopupOpen("##toolbarMenu");
 
-        ImGui::PushFont(StyleRepository::get().getIconFont());
-        auto iconSize = ImGui::CalcTextSize(ICON_FA_ELLIPSIS_H);
+        auto iconFont = StyleRepository::get().getIconFont();
+        auto iconFontSize = scale(ToolbarOverflowIconSize);
+        auto iconSize = iconFont->CalcTextSizeA(iconFontSize, FLT_MAX, 0.0f, ICON_FA_ELLIPSIS_H);
         drawList->AddText(
+            iconFont,
+            iconFontSize,
             {overflowPos + (overflowSize - iconSize.x) / 2, startPos.y + (toolbarHeight - iconSize.y) / 2},
             hovered || opened ? Const::ToolbarOverflowHoveredColor : Const::ToolbarOverflowColor,
             ICON_FA_ELLIPSIS_H);
-        ImGui::PopFont();
         Tooltip("Show remaining actions");
 
         auto menuWidth = 0.0f;

--- a/source/Gui/AlienGui.cpp
+++ b/source/Gui/AlienGui.cpp
@@ -6,6 +6,7 @@
 #include <ranges>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptors.hpp>
 
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -1872,87 +1873,288 @@ void AlienGui::ListBox(ListBoxParameters const& parameters)
     ImGui::Dummy(ImVec2(0, boxHeight));
 }
 
-bool AlienGui::ToolbarButton(ToolbarButtonParameters const& parameters)
+namespace
 {
-    auto id = std::to_string(ImGui::GetID(parameters._text.c_str()));
-    if (parameters._secondText.has_value()) {
-        id += parameters._secondText.value();
-    }
-    ImGui::PushID(id.c_str());
+    auto constexpr ToolbarButtonSize = 40.0f;
+    auto constexpr ToolbarButtonRounding = 9.0f;
+    auto constexpr ToolbarItemSpacing = 2.0f;
+    auto constexpr ToolbarGroupPadding = 3.0f;
+    auto constexpr ToolbarGroupRounding = 12.0f;
+    auto constexpr ToolbarGroupSpacing = 10.0f;
+    auto constexpr ToolbarSelectionBarInset = 11.0f;
+    auto constexpr ToolbarSelectionBarBottom = 5.0f;
+    auto constexpr ToolbarSelectionBarHeight = 2.0f;
+    auto constexpr ToolbarOverflowSize = 28.0f;
+    auto constexpr ToolbarOverflowSpacing = 10.0f;
+    auto constexpr ToolbarMenuSpacing = 4.0f;
+    auto constexpr ToolbarMenuRowHeight = 34.0f;
+    auto constexpr ToolbarMenuIconSize = 18.0f;
+    auto constexpr ToolbarMenuIconOffset = 12.0f;
+    auto constexpr ToolbarMenuTextOffset = 44.0f;
+    auto constexpr ToolbarMenuRightPadding = 24.0f;
 
-    ImGui::PushFont(StyleRepository::get().getIconFont());
-    ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, {0.5f, 0.75f});
-
-    ImGui::PushStyleColor(ImGuiCol_Button, static_cast<ImVec4>(Const::ToolbarButtonBackgroundColor));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, static_cast<ImVec4>(Const::ToolbarButtonHoveredColor));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, static_cast<ImVec4>(Const::AccentDeepColor));
-    ImGui::PushStyleColor(ImGuiCol_Text, static_cast<ImVec4>(Const::ToolbarButtonTextColor));
-
-    auto buttonSize = scale(40.0f);
-
-    ImGui::BeginDisabled(parameters._disabled);
-
-    auto pos = ImGui::GetCursorScreenPos();
-    auto result = ImGui::Button(parameters._text.c_str(), {buttonSize, buttonSize});
-
-    if (parameters._secondText.has_value()) {
-        ImGui::GetWindowDrawList()->AddText(
-            ImGui::GetFont(),
-            ImGui::GetFontSize() * parameters._secondTextScale,
-            {pos.x + scale(parameters._secondTextOffset.x), pos.y + scale(parameters._secondTextOffset.y)},
-            ImGui::GetColorU32(ImGuiCol_Text),
-            parameters._secondText->c_str());
-    }
-    ImGui::EndDisabled();
-
-    ImGui::PopStyleColor(4);
-    ImGui::PopStyleVar();
-    ImGui::PopFont();
-
-    if (parameters._tooltip) {
-        AlienGui::Tooltip(*parameters._tooltip);
-    }
-    ImGui::PopID();
-    return result;
-}
-
-bool AlienGui::SelectableToolbarButton(std::string const& text, int& value, int selectionValue, int deselectionValue)
-{
-    auto id = std::to_string(ImGui::GetID(text.c_str()));
-
-    ImGui::PushFont(StyleRepository::get().getIconFont());
-    ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, {0.5f, 0.75f});
-    auto color = Const::ToolbarButtonTextColor;
-    float h, s, v;
-    ImGui::ColorConvertRGBtoHSV(color.Value.x, color.Value.y, color.Value.z, h, s, v);
-
-    auto buttonColor = Const::ToolbarButtonBackgroundColor;
-    auto buttonColorHovered = ImColor::HSV(h, s, v * 0.3f);
-    auto buttonColorActive = ImColor::HSV(h, s, v * 0.45f);
-    if (value == selectionValue) {
-        buttonColor = buttonColorActive;
-        buttonColorHovered = buttonColorActive;
+    float calcToolbarWidth(std::vector<AlienGui::ToolbarItem> const& items, int numItems)
+    {
+        auto result = 0.0f;
+        auto numButtonsInGroup = 0;
+        auto numGroups = 0;
+        auto closeGroup = [&] {
+            if (numButtonsInGroup == 0) {
+                return;
+            }
+            if (numGroups > 0) {
+                result += scale(ToolbarGroupSpacing);
+            }
+            result += toFloat(numButtonsInGroup) * scale(ToolbarButtonSize) + toFloat(numButtonsInGroup - 1) * scale(ToolbarItemSpacing)
+                + 2 * scale(ToolbarGroupPadding);
+            ++numGroups;
+            numButtonsInGroup = 0;
+        };
+        for (auto const& [index, item] : items | boost::adaptors::indexed(0)) {
+            if (index >= numItems) {
+                break;
+            }
+            if (item._isSeparator) {
+                closeGroup();
+            } else {
+                ++numButtonsInGroup;
+            }
+        }
+        closeGroup();
+        return result;
     }
 
-    ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)buttonColor);
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)buttonColorHovered);
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)buttonColorActive);
+    int calcToolbarSplitIndex(std::vector<AlienGui::ToolbarItem> const& items, float availableWidth)
+    {
+        auto numItems = toInt(items.size());
+        if (calcToolbarWidth(items, numItems) <= availableWidth) {
+            return numItems;
+        }
+        auto budget = availableWidth - scale(ToolbarOverflowSize) - scale(ToolbarOverflowSpacing);
+        auto result = 0;
+        for (auto numVisibleItems : std::views::iota(1, numItems + 1)) {
+            if (calcToolbarWidth(items, numVisibleItems) > budget) {
+                break;
+            }
+            result = numVisibleItems;
+        }
+        return result;
+    }
 
-    ImGui::PushStyleColor(ImGuiCol_Text, static_cast<ImVec4>(Const::ToolbarButtonTextColor));
-    auto buttonSize = scale(40.0f);
-    auto result = ImGui::Button(text.c_str(), {buttonSize, buttonSize});
-    if (result) {
-        if (value == selectionValue) {
-            value = deselectionValue;
-        } else {
-            value = selectionValue;
+    std::vector<std::vector<int>> calcToolbarGroups(std::vector<AlienGui::ToolbarItem> const& items, int numItems)
+    {
+        std::vector<std::vector<int>> result;
+        for (auto const& [index, item] : items | boost::adaptors::indexed(0)) {
+            if (index >= numItems) {
+                break;
+            }
+            if (item._isSeparator) {
+                if (!result.empty() && !result.back().empty()) {
+                    result.emplace_back();
+                }
+            } else {
+                if (result.empty()) {
+                    result.emplace_back();
+                }
+                result.back().emplace_back(toInt(index));
+            }
+        }
+        if (!result.empty() && result.back().empty()) {
+            result.pop_back();
+        }
+        return result;
+    }
+
+    void processToolbarButton(AlienGui::ToolbarItemParameters const& parameters, ImVec2 const& pos, std::function<void()>& pendingAction)
+    {
+        auto size = scale(ToolbarButtonSize);
+        auto drawList = ImGui::GetWindowDrawList();
+
+        ImGui::SetCursorScreenPos(pos);
+        ImGui::BeginDisabled(parameters._disabled);
+        auto clicked = ImGui::InvisibleButton("##button", {size, size});
+        auto hovered = ImGui::IsItemHovered();
+        ImGui::EndDisabled();
+
+        if (parameters._selected) {
+            drawList->AddRectFilled(pos, {pos.x + size, pos.y + size}, Const::ToolbarButtonSelectedColor, scale(ToolbarButtonRounding));
+        } else if (hovered) {
+            drawList->AddRectFilled(pos, {pos.x + size, pos.y + size}, Const::ToolbarButtonHoveredColor, scale(ToolbarButtonRounding));
+        }
+
+        auto iconColor = parameters._disabled ? Const::ToolbarButtonDisabledTextColor
+            : parameters._selected            ? Const::ToolbarButtonSelectedTextColor
+                                              : Const::ToolbarButtonTextColor;
+        ImGui::PushFont(StyleRepository::get().getIconFont());
+        auto iconSize = ImGui::CalcTextSize(parameters._icon.c_str());
+        drawList->AddText({pos.x + (size - iconSize.x) / 2, pos.y + (size - iconSize.y) / 2}, iconColor, parameters._icon.c_str());
+        if (parameters._secondIcon.has_value()) {
+            drawList->AddText(
+                ImGui::GetFont(),
+                ImGui::GetFontSize() * parameters._secondIconScale,
+                {pos.x + scale(parameters._secondIconOffset.x), pos.y + scale(parameters._secondIconOffset.y)},
+                iconColor,
+                parameters._secondIcon->c_str());
+        }
+        ImGui::PopFont();
+
+        if (parameters._selected) {
+            drawList->AddRectFilled(
+                {pos.x + scale(ToolbarSelectionBarInset), pos.y + size - scale(ToolbarSelectionBarBottom + ToolbarSelectionBarHeight)},
+                {pos.x + size - scale(ToolbarSelectionBarInset), pos.y + size - scale(ToolbarSelectionBarBottom)},
+                Const::ToolbarSelectionBarColor,
+                scale(1.0f));
+        }
+
+        auto tooltip = parameters._tooltip.value_or(parameters._name);
+        if (!tooltip.empty()) {
+            AlienGui::Tooltip(tooltip);
+        }
+        if (clicked) {
+            pendingAction = parameters._action;
         }
     }
 
-    ImGui::PopStyleColor(4);
-    ImGui::PopStyleVar();
-    ImGui::PopFont();
+    void processToolbarMenu(std::vector<AlienGui::ToolbarItem> const& items, int splitIndex, std::function<void()>& pendingAction)
+    {
+        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, static_cast<ImVec4>(Const::ToolbarMenuHoveredColor));
+        ImGui::PushStyleColor(ImGuiCol_HeaderActive, static_cast<ImVec4>(Const::ToolbarMenuHoveredColor));
+        if (ImGui::BeginPopup("##toolbarMenu")) {
+            auto drawList = ImGui::GetWindowDrawList();
+            auto rowHeight = scale(ToolbarMenuRowHeight);
+            auto iconFont = StyleRepository::get().getIconFont();
+            auto iconSize = scale(ToolbarMenuIconSize);
+            for (auto const& [index, item] : items | boost::adaptors::indexed(0)) {
+                if (index < splitIndex) {
+                    continue;
+                }
+                if (item._isSeparator) {
+                    ImGui::Separator();
+                    continue;
+                }
+                auto const& parameters = item._parameters;
+                ImGui::PushID(toInt(index));
+                auto rowPos = ImGui::GetCursorScreenPos();
+                auto flags = parameters._disabled ? ImGuiSelectableFlags_Disabled : ImGuiSelectableFlags_None;
+                if (ImGui::Selectable("##row", false, flags, {0, rowHeight})) {
+                    pendingAction = parameters._action;
+                    ImGui::CloseCurrentPopup();
+                }
+                if (parameters._tooltip.has_value()) {
+                    AlienGui::Tooltip(*parameters._tooltip);
+                }
+                auto iconColor = parameters._disabled ? Const::ToolbarButtonDisabledTextColor : Const::ToolbarButtonTextColor;
+                auto textColor = parameters._disabled ? Const::TextFaintColor : Const::TextBaseColor;
+                drawList->AddText(
+                    iconFont, iconSize, {rowPos.x + scale(ToolbarMenuIconOffset), rowPos.y + (rowHeight - iconSize) / 2}, iconColor, parameters._icon.c_str());
+                auto textSize = ImGui::CalcTextSize(parameters._name.c_str());
+                drawList->AddText({rowPos.x + scale(ToolbarMenuTextOffset), rowPos.y + (rowHeight - textSize.y) / 2}, textColor, parameters._name.c_str());
+                ImGui::PopID();
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleColor(2);
+    }
+}
+
+AlienGui::ToolbarItem AlienGui::ToolbarItem::createButton(ToolbarItemParameters const& parameters)
+{
+    ToolbarItem result;
+    result._parameters = parameters;
     return result;
+}
+
+AlienGui::ToolbarItem AlienGui::ToolbarItem::createSeparator()
+{
+    ToolbarItem result;
+    result._isSeparator = true;
+    return result;
+}
+
+void AlienGui::Toolbar(ToolbarParameters const& parameters, std::vector<ToolbarItem> const& items)
+{
+    ImGui::PushID(parameters._id.c_str());
+
+    auto buttonSize = scale(ToolbarButtonSize);
+    auto groupPadding = scale(ToolbarGroupPadding);
+    auto toolbarHeight = buttonSize + 2 * groupPadding;
+    auto startPos = ImGui::GetCursorScreenPos();
+    auto toolbarWidth = ImGui::GetContentRegionAvail().x;
+    auto trailingWidth = scale(parameters._trailingWidth);
+    auto splitIndex = calcToolbarSplitIndex(items, toolbarWidth - trailingWidth);
+    auto hasOverflow = splitIndex < toInt(items.size());
+
+    std::function<void()> pendingAction;
+    auto drawList = ImGui::GetWindowDrawList();
+
+    auto groupPos = startPos;
+    for (auto const& group : calcToolbarGroups(items, splitIndex)) {
+        auto numButtons = toFloat(group.size());
+        auto groupWidth = numButtons * buttonSize + (numButtons - 1) * scale(ToolbarItemSpacing) + 2 * groupPadding;
+        drawList->AddRectFilled(groupPos, {groupPos.x + groupWidth, groupPos.y + toolbarHeight}, Const::ToolbarGroupColor, scale(ToolbarGroupRounding));
+
+        auto buttonPos = ImVec2{groupPos.x + groupPadding, groupPos.y + groupPadding};
+        for (auto const& index : group) {
+            ImGui::PushID(index);
+            processToolbarButton(items.at(index)._parameters, buttonPos, pendingAction);
+            ImGui::PopID();
+            buttonPos.x += buttonSize + scale(ToolbarItemSpacing);
+        }
+        groupPos.x += groupWidth + scale(ToolbarGroupSpacing);
+    }
+
+    auto rightBorder = startPos.x + toolbarWidth;
+    auto overflowPos = rightBorder - scale(ToolbarOverflowSize);
+
+    if (parameters._trailing) {
+        auto trailingHeight = ImGui::GetTextLineHeight() + 2 * scale(ChipPaddingY);
+        auto trailingPos = (hasOverflow ? overflowPos - scale(ToolbarOverflowSpacing) : rightBorder) - trailingWidth;
+        ImGui::SetCursorScreenPos({trailingPos, startPos.y + (toolbarHeight - trailingHeight) / 2});
+        parameters._trailing();
+    }
+
+    if (hasOverflow) {
+        auto overflowSize = scale(ToolbarOverflowSize);
+        ImGui::SetCursorScreenPos({overflowPos, startPos.y + (toolbarHeight - overflowSize) / 2});
+        ImGui::InvisibleButton("##overflow", {overflowSize, overflowSize});
+        auto hovered = ImGui::IsItemHovered();
+        if (ImGui::IsItemClicked()) {
+            ImGui::OpenPopup("##toolbarMenu");
+        }
+        auto opened = ImGui::IsPopupOpen("##toolbarMenu");
+
+        ImGui::PushFont(StyleRepository::get().getIconFont());
+        auto iconSize = ImGui::CalcTextSize(ICON_FA_ELLIPSIS_H);
+        drawList->AddText(
+            {overflowPos + (overflowSize - iconSize.x) / 2, startPos.y + (toolbarHeight - iconSize.y) / 2},
+            hovered || opened ? Const::ToolbarOverflowHoveredColor : Const::ToolbarOverflowColor,
+            ICON_FA_ELLIPSIS_H);
+        ImGui::PopFont();
+        Tooltip("Show remaining actions");
+
+        auto menuWidth = 0.0f;
+        for (auto const& [index, item] : items | boost::adaptors::indexed(0)) {
+            if (index >= splitIndex && !item._isSeparator) {
+                menuWidth = std::max(menuWidth, ImGui::CalcTextSize(item._parameters._name.c_str()).x);
+            }
+        }
+        menuWidth += scale(ToolbarMenuTextOffset + ToolbarMenuRightPadding);
+        ImGui::SetNextWindowPos({rightBorder - menuWidth, startPos.y + toolbarHeight + scale(ToolbarMenuSpacing)});
+        ImGui::SetNextWindowSize({menuWidth, 0.0f});
+        processToolbarMenu(items, splitIndex, pendingAction);
+    }
+
+    ImGui::SetCursorScreenPos(startPos);
+    ImGui::Dummy({toolbarWidth, toolbarHeight});
+
+    if (parameters._bottomSeparator) {
+        Separator();
+    }
+    ImGui::PopID();
+
+    if (pendingAction) {
+        pendingAction();
+    }
 }
 
 void AlienGui::VerticalSeparator(float height)
@@ -1968,11 +2170,6 @@ void AlienGui::VerticalSeparator(float height)
         color,
         2.0f);
     ImGui::Dummy(ImVec2(padding /** 2*/, 1));
-}
-
-void AlienGui::ToolbarSeparator()
-{
-    VerticalSeparator(40.0f);
 }
 
 void AlienGui::Chip(ChipParameters const& parameters)

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -460,18 +460,38 @@ public:
     };
     static void ListBox(ListBoxParameters const& parameters);
 
-    struct ToolbarButtonParameters
+    struct ToolbarItemParameters
     {
-        MEMBER(ToolbarButtonParameters, std::string, text, std::string());
-        MEMBER(ToolbarButtonParameters, std::optional<std::string>, secondText, std::nullopt);
-        MEMBER(ToolbarButtonParameters, RealVector2D, secondTextOffset, (RealVector2D{25.0f, 25.0f}));
-        MEMBER(ToolbarButtonParameters, float, secondTextScale, 0.5f);
-        MEMBER(ToolbarButtonParameters, bool, disabled, false);
-        MEMBER(ToolbarButtonParameters, std::optional<std::string>, tooltip, std::nullopt);
+        MEMBER(ToolbarItemParameters, std::string, icon, std::string());
+        MEMBER(ToolbarItemParameters, std::optional<std::string>, secondIcon, std::nullopt);
+        MEMBER(ToolbarItemParameters, RealVector2D, secondIconOffset, (RealVector2D{25.0f, 25.0f}));
+        MEMBER(ToolbarItemParameters, float, secondIconScale, 0.5f);
+        MEMBER(ToolbarItemParameters, std::string, name, std::string());
+        MEMBER(ToolbarItemParameters, std::optional<std::string>, tooltip, std::nullopt);
+        MEMBER(ToolbarItemParameters, bool, disabled, false);
+        MEMBER(ToolbarItemParameters, bool, selected, false);
+        MEMBER(ToolbarItemParameters, std::function<void()>, action, std::function<void()>());
     };
-    static bool ToolbarButton(ToolbarButtonParameters const& parameters);
 
-    static bool SelectableToolbarButton(std::string const& text, int& value, int selectionValue, int deselectionValue);
+    struct ToolbarItem
+    {
+        static ToolbarItem createButton(ToolbarItemParameters const& parameters);
+        static ToolbarItem createSeparator();
+
+        bool _isSeparator = false;
+        ToolbarItemParameters _parameters;
+    };
+
+    struct ToolbarParameters
+    {
+        MEMBER(ToolbarParameters, std::string, id, std::string("Toolbar"));
+        MEMBER(ToolbarParameters, std::function<void()>, trailing, std::function<void()>());
+        MEMBER(ToolbarParameters, float, trailingWidth, 0.0f);
+        MEMBER(ToolbarParameters, bool, bottomSeparator, true);
+    };
+
+    // Draws icon buttons grouped by separators. Items that do not fit are moved to a menu behind an ellipsis at the right border.
+    static void Toolbar(ToolbarParameters const& parameters, std::vector<ToolbarItem> const& items);
 
     struct ChipParameters
     {
@@ -485,7 +505,6 @@ public:
     static void Chip(ChipParameters const& parameters);
 
     static void VerticalSeparator(float height = 23.0f);
-    static void ToolbarSeparator();
     static bool Button(std::string const& text, float size = 0);
     static bool CollapseButton(bool collapsed);
     static bool MaximizeButton(RealVector2D const& pos, float iconSize, bool maximized);
@@ -505,7 +524,7 @@ public:
         MEMBER(TreeNodeParameters, bool, enableBlinking, false);
         MEMBER(TreeNodeParameters, std::optional<std::string>, highlightedSubString, std::nullopt);
     };
-    static bool BeginTreeNode(TreeNodeParameters const& parameters, bool* expandButtonClicked = nullptr);   // Returns true if the tree node is open.
+    static bool BeginTreeNode(TreeNodeParameters const& parameters, bool* expandButtonClicked = nullptr);  // Returns true if the tree node is open.
     static void EndTreeNode();
 
     struct TabItemParameters

--- a/source/Gui/AlienGui.h
+++ b/source/Gui/AlienGui.h
@@ -472,7 +472,6 @@ public:
         MEMBER(ToolbarItemParameters, bool, selected, false);
         MEMBER(ToolbarItemParameters, std::function<void()>, action, std::function<void()>());
     };
-
     struct ToolbarItem
     {
         static ToolbarItem createButton(ToolbarItemParameters const& parameters);
@@ -481,7 +480,6 @@ public:
         bool _isSeparator = false;
         ToolbarItemParameters _parameters;
     };
-
     struct ToolbarParameters
     {
         MEMBER(ToolbarParameters, std::string, id, std::string("Toolbar"));
@@ -489,8 +487,6 @@ public:
         MEMBER(ToolbarParameters, float, trailingWidth, 0.0f);
         MEMBER(ToolbarParameters, bool, bottomSeparator, true);
     };
-
-    // Draws icon buttons grouped by separators. Items that do not fit are moved to a menu behind an ellipsis at the right border.
     static void Toolbar(ToolbarParameters const& parameters, std::vector<ToolbarItem> const& items);
 
     struct ChipParameters

--- a/source/Gui/AutosaveWindow.cpp
+++ b/source/Gui/AutosaveWindow.cpp
@@ -112,31 +112,22 @@ void AutosaveWindow::processBackground()
 
 void AutosaveWindow::processToolbar()
 {
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!_savepointTable.has_value());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PLUS))) {
-        onCreateSavepoint(false);
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Create save point");
-
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!static_cast<bool>(_selectedEntry));
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_MINUS))) {
-        onDeleteSavepoint(_selectedEntry);
-    }
-    AlienGui::Tooltip("Delete save point");
-    ImGui::EndDisabled();
-
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!_savepointTable.has_value() || _savepointTable->isEmpty());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_BROOM))) {
-        GenericMessageDialog::get().yesNo("Delete", "Do you really want to delete all savepoints?", [&]() { scheduleCleanup(); });
-    }
-    AlienGui::Tooltip("Delete all save points");
-    ImGui::EndDisabled();
-
-    AlienGui::Separator();
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("Autosave"),
+        {AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_PLUS).name("Create save point").disabled(!_savepointTable.has_value()).action([&] {
+                 onCreateSavepoint(false);
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_MINUS).name("Delete save point").disabled(!static_cast<bool>(_selectedEntry)).action([&] {
+                 onDeleteSavepoint(_selectedEntry);
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters()
+                 .icon(ICON_FA_BROOM)
+                 .name("Delete all save points")
+                 .disabled(!_savepointTable.has_value() || _savepointTable->isEmpty())
+                 .action([&] { GenericMessageDialog::get().yesNo("Delete", "Do you really want to delete all savepoints?", [&]() { scheduleCleanup(); }); }))});
 }
 
 void AutosaveWindow::processHeader() {}

--- a/source/Gui/BrowserWindow.cpp
+++ b/source/Gui/BrowserWindow.cpp
@@ -226,123 +226,74 @@ void BrowserWindow::processToolbar()
     std::string resourceTypeString = _currentWorkspace.resourceType == NetworkResourceType_Simulation ? "simulation" : "genome";
     auto isOwnerForSelectedItem = isOwner(_selectedTreeTO);
 
-    // Refresh button
-    ImGui::BeginDisabled(_refreshProcessor->pendingTasks());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SYNC))) {
-        onRefresh();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Refresh");
-
-    // Login button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(NetworkService::get().getLoggedInUserName().has_value());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SIGN_IN_ALT))) {
-        LoginDialog::get().open();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Login or register");
-
-    // Logout button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!NetworkService::get().getLoggedInUserName());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SIGN_OUT_ALT))) {
-        NetworkService::get().logout();
-        onRefresh();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Logout");
-
-    // Separator
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    // Upload button
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_UPLOAD))) {
-        std::string prefix = [&] {
-            if (_selectedTreeTO == nullptr || _selectedTreeTO->isLeaf()) {
-                return std::string();
-            }
-            return NetworkResourceService::get().concatenateFolderName(_selectedTreeTO->folderNames, true);
-        }();
-        UploadSimulationDialog::get().open(_currentWorkspace.resourceType, prefix);
-    }
-    AlienGui::Tooltip(
-        "Upload your current " + resourceTypeString
-        + " to the server and made visible in the browser. You can choose whether you want to share it with other users or whether it should only be visible "
-          "in your private workspace.\nIf you have already selected a folder, your "
-        + resourceTypeString + " will be uploaded there.");
-
-    // Edit button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isOwnerForSelectedItem);
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EDIT))) {
-        onEditResource(_selectedTreeTO);
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Change name or description");
-
-    // Replace button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isOwnerForSelectedItem || !_selectedTreeTO->isLeaf());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EXCHANGE_ALT))) {
-        onReplaceResource(_selectedTreeTO->getLeaf());
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip(
-        "Replace the selected " + resourceTypeString + " with the one that is currently open. The name, description and reactions will be preserved.");
-
-    // Move to other workspace button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isOwnerForSelectedItem);
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SHARE_ALT))) {
-        onMoveResource(_selectedTreeTO);
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Change visibility: public " ICON_FA_LONG_ARROW_ALT_RIGHT " private and private " ICON_FA_LONG_ARROW_ALT_RIGHT " public");
-
-    // Delete button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isOwnerForSelectedItem);
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_TRASH))) {
-        onDeleteResource(_selectedTreeTO);
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Delete selected " + resourceTypeString);
-
-    // Separator
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    // Expand button
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_EXPAND_ARROWS_ALT))) {
-        onExpandFolders();
-    }
-    AlienGui::Tooltip("Expand all folders");
-
-    // Collapse button
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COMPRESS_ARROWS_ALT))) {
-        onCollapseFolders();
-    }
-    AlienGui::Tooltip("Collapse all folders");
+    std::vector<AlienGui::ToolbarItem> items{
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_SYNC).name("Refresh").disabled(_refreshProcessor->pendingTasks()).action([&] { onRefresh(); })),
+        AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                .icon(ICON_FA_SIGN_IN_ALT)
+                                                .name("Login or register")
+                                                .disabled(NetworkService::get().getLoggedInUserName().has_value())
+                                                .action([&] { LoginDialog::get().open(); })),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_SIGN_OUT_ALT).name("Logout").disabled(!NetworkService::get().getLoggedInUserName()).action([&] {
+                NetworkService::get().logout();
+                onRefresh();
+            })),
+        AlienGui::ToolbarItem::createSeparator(),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters()
+                .icon(ICON_FA_UPLOAD)
+                .name("Upload " + resourceTypeString)
+                .tooltip(
+                    "Upload your current " + resourceTypeString
+                    + " to the server and made visible in the browser. You can choose whether you want to share it with other users or whether it should only "
+                      "be visible in your private workspace.\nIf you have already selected a folder, your "
+                    + resourceTypeString + " will be uploaded there.")
+                .action([&] {
+                    std::string prefix = [&] {
+                        if (_selectedTreeTO == nullptr || _selectedTreeTO->isLeaf()) {
+                            return std::string();
+                        }
+                        return NetworkResourceService::get().concatenateFolderName(_selectedTreeTO->folderNames, true);
+                    }();
+                    UploadSimulationDialog::get().open(_currentWorkspace.resourceType, prefix);
+                })),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_EDIT).name("Change name or description").disabled(!isOwnerForSelectedItem).action([&] {
+                onEditResource(_selectedTreeTO);
+            })),
+        AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                .icon(ICON_FA_EXCHANGE_ALT)
+                                                .name("Replace " + resourceTypeString)
+                                                .tooltip(
+                                                    "Replace the selected " + resourceTypeString
+                                                    + " with the one that is currently open. The name, description and reactions will be preserved.")
+                                                .disabled(!isOwnerForSelectedItem || !_selectedTreeTO->isLeaf())
+                                                .action([&] { onReplaceResource(_selectedTreeTO->getLeaf()); })),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters()
+                .icon(ICON_FA_SHARE_ALT)
+                .name("Change visibility")
+                .tooltip("Change visibility: public " ICON_FA_LONG_ARROW_ALT_RIGHT " private and private " ICON_FA_LONG_ARROW_ALT_RIGHT " public")
+                .disabled(!isOwnerForSelectedItem)
+                .action([&] { onMoveResource(_selectedTreeTO); })),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_TRASH).name("Delete selected " + resourceTypeString).disabled(!isOwnerForSelectedItem).action([&] {
+                onDeleteResource(_selectedTreeTO);
+            })),
+        AlienGui::ToolbarItem::createSeparator(),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_EXPAND_ARROWS_ALT).name("Expand all folders").action([&] { onExpandFolders(); })),
+        AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(ICON_FA_COMPRESS_ARROWS_ALT).name("Collapse all folders").action([&] { onCollapseFolders(); }))};
 
 #ifdef _WIN32
-    // Separator
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    // Discord button
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COMMENTS))) {
-        openWeblink(Const::DiscordURL);
-    }
-    AlienGui::Tooltip("Open ALIEN Discord server");
+    items.emplace_back(AlienGui::ToolbarItem::createSeparator());
+    items.emplace_back(AlienGui::ToolbarItem::createButton(
+        AlienGui::ToolbarItemParameters().icon(ICON_FA_COMMENTS).name("Open ALIEN Discord server").action([&] { openWeblink(Const::DiscordURL); })));
 #endif
 
-    AlienGui::Separator();
+    AlienGui::Toolbar(AlienGui::ToolbarParameters().id("Browser"), items);
 }
 
 void BrowserWindow::processWorkspace()

--- a/source/Gui/CreatorWindow.cpp
+++ b/source/Gui/CreatorWindow.cpp
@@ -512,18 +512,17 @@ void CreatorWindow::processToolbar()
 {
     auto previousMode = _mode;
 
+    std::vector<AlienGui::ToolbarItem> items;
     for (auto const& [mode, icon] : ToolbarModeIcons) {
-        AlienGui::SelectableToolbarButton(icon, _mode, mode, mode);
-        AlienGui::Tooltip(ModeText.at(mode));
-        ImGui::SameLine();
+        items.emplace_back(AlienGui::ToolbarItem::createButton(
+            AlienGui::ToolbarItemParameters().icon(icon).name(ModeText.at(mode)).selected(_mode == mode).action([this, mode = mode] { _mode = mode; })));
     }
-
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_IMAGE).tooltip("Create a pattern from an image"))) {
-        ImageToPatternDialog::get().show();
-    }
+    items.emplace_back(AlienGui::ToolbarItem::createSeparator());
+    items.emplace_back(AlienGui::ToolbarItem::createButton(
+        AlienGui::ToolbarItemParameters().icon(ICON_FA_IMAGE).name("Pattern from image").tooltip("Create a pattern from an image").action([&] {
+            ImageToPatternDialog::get().show();
+        })));
+    AlienGui::Toolbar(AlienGui::ToolbarParameters().id("Creator").bottomSeparator(false), items);
 
     if (_mode != previousMode) {
         abortPointPlacement();

--- a/source/Gui/GenomeEditorWindow.cpp
+++ b/source/Gui/GenomeEditorWindow.cpp
@@ -109,16 +109,35 @@ bool GenomeEditorWindow::isShown()
     return _on;
 }
 
+namespace
+{
+    float calcUnsavedChangesChipWidth()
+    {
+        return scaleInverse(ImGui::CalcTextSize(UnsavedChangesText).x) + UnsavedChangesChipPadding;
+    }
+
+    void processUnsavedChangesChip()
+    {
+        AlienGui::Chip(AlienGui::ChipParameters()
+                           .text(UnsavedChangesText)
+                           .textColor(Const::UnsavedChangesColor)
+                           .backgroundColor(Const::UnsavedChangesBackgroundColor)
+                           .dotColor(Const::UnsavedChangesColor));
+    }
+}
+
 void GenomeEditorWindow::processToolbar()
 {
     auto hasGenomeChanged = _tabs.at(_selectedTabIndex)->hasGenomeChanged();
     auto creaturesSelected = EditorModel::get().getSelectionShallowData().numCreatures > 0;
 
+    auto toolbarParameters = AlienGui::ToolbarParameters().id("GenomeEditor");
+    if (hasGenomeChanged) {
+        toolbarParameters.trailing([] { processUnsavedChangesChip(); }).trailingWidth(calcUnsavedChangesChipWidth());
+    }
+
     AlienGui::Toolbar(
-        AlienGui::ToolbarParameters()
-            .id("GenomeEditor")
-            .trailing([&] { processUnsavedChangesChip(hasGenomeChanged); })
-            .trailingWidth(hasGenomeChanged ? calcUnsavedChangesChipWidth() : 0.0f),
+        toolbarParameters,
         {AlienGui::ToolbarItem::createButton(
              AlienGui::ToolbarItemParameters().icon(ICON_FA_FOLDER_OPEN).name("Open genome").tooltip("Open genome from file").action([&] { onOpenGenome(); })),
          AlienGui::ToolbarItem::createButton(
@@ -182,23 +201,6 @@ void GenomeEditorWindow::processToolbar()
                                                  .name("Create seed with energy")
                                                  .tooltip("Create a seed with current genome with free energy supply")
                                                  .action([&] { onCreateSeed(true); }))});
-}
-
-float GenomeEditorWindow::calcUnsavedChangesChipWidth() const
-{
-    return scaleInverse(ImGui::CalcTextSize(UnsavedChangesText).x) + UnsavedChangesChipPadding;
-}
-
-void GenomeEditorWindow::processUnsavedChangesChip(bool hasGenomeChanged)
-{
-    if (!hasGenomeChanged) {
-        return;
-    }
-    AlienGui::Chip(AlienGui::ChipParameters()
-                       .text(UnsavedChangesText)
-                       .textColor(Const::UnsavedChangesColor)
-                       .backgroundColor(Const::UnsavedChangesBackgroundColor)
-                       .dotColor(Const::UnsavedChangesColor));
 }
 
 void GenomeEditorWindow::processTabWidget()

--- a/source/Gui/GenomeEditorWindow.cpp
+++ b/source/Gui/GenomeEditorWindow.cpp
@@ -32,6 +32,9 @@
 
 namespace
 {
+    auto constexpr UnsavedChangesText = "Unsaved changes";
+    auto constexpr UnsavedChangesChipPadding = 34.0f;
+
     std::optional<ImColor> getLineageMarkerColor(std::optional<int> const& lineageId)
     {
         if (!lineageId.has_value()) {
@@ -108,99 +111,82 @@ bool GenomeEditorWindow::isShown()
 
 void GenomeEditorWindow::processToolbar()
 {
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_FOLDER_OPEN).tooltip("Open genome from file"))) {
-        onOpenGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SAVE).tooltip("Save genome to file"))) {
-        onSaveGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters()
-                .text(ICON_FA_UPLOAD)
-                .tooltip("Share your genome with other users:\nYour current genome will be uploaded to the server and made visible in the browser."))) {
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CLONE).tooltip("Clone genome"))) {
-        onCloneGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COPY).tooltip("Copy genome to clipboard"))) {
-        onCopyGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_PASTE).tooltip("Paste genome from clipboard").disabled(!_copiedGenome.has_value()))) {
-        onPasteGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_WINDOW_CLOSE).tooltip("Close all tabs except the current one").disabled(_tabs.size() <= 1))) {
-        onCloseOtherTabs();
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
     auto hasGenomeChanged = _tabs.at(_selectedTabIndex)->hasGenomeChanged();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_CAMERA).tooltip("Create save point in this tab").disabled(!hasGenomeChanged))) {
-        onSavepointGenome();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_UNDO).tooltip("Revert genome to save point").disabled(!hasGenomeChanged))) {
-        _tabs.at(_selectedTabIndex)->revertChanges();
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PALETTE).tooltip("Change the color of all nodes with a certain color"))) {
-        ChangeColorDialog::get().open(_tabs.at(_selectedTabIndex)->getEditData());
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
     auto creaturesSelected = EditorModel::get().getSelectionShallowData().numCreatures > 0;
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_SYRINGE)
-                                    .tooltip("Inject the current genome to the selected creatures in the simulation")
-                                    .disabled(!creaturesSelected))) {
-        onInjectGenome();
-    }
 
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_SEEDLING).tooltip("Create a seed with current genome without free energy supply"))) {
-        onCreateSeed(false);
-    }
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_SEEDLING)
-                                    .secondText(ICON_FA_BOLT)
-                                    .secondTextOffset({30.0f, 25.0f})
-                                    .tooltip("Create a seed with current genome with free energy supply"))) {
-        onCreateSeed(true);
-    }
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters()
+            .id("GenomeEditor")
+            .trailing([&] { processUnsavedChangesChip(hasGenomeChanged); })
+            .trailingWidth(hasGenomeChanged ? calcUnsavedChangesChipWidth() : 0.0f),
+        {AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_FOLDER_OPEN).name("Open genome").tooltip("Open genome from file").action([&] { onOpenGenome(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_SAVE).name("Save genome").tooltip("Save genome to file").action([&] { onSaveGenome(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters()
+                 .icon(ICON_FA_UPLOAD)
+                 .name("Share genome")
+                 .tooltip("Share your genome with other users:\nYour current genome will be uploaded to the server and made visible in the browser.")),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_CLONE).name("Clone genome").action([&] { onCloneGenome(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_COPY).name("Copy genome").tooltip("Copy genome to clipboard").action([&] { onCopyGenome(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_PASTE)
+                                                 .name("Paste genome")
+                                                 .tooltip("Paste genome from clipboard")
+                                                 .disabled(!_copiedGenome.has_value())
+                                                 .action([&] { onPasteGenome(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_WINDOW_CLOSE)
+                                                 .name("Close other tabs")
+                                                 .tooltip("Close all tabs except the current one")
+                                                 .disabled(_tabs.size() <= 1)
+                                                 .action([&] { onCloseOtherTabs(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_CAMERA)
+                                                 .name("Create save point")
+                                                 .tooltip("Create save point in this tab")
+                                                 .disabled(!hasGenomeChanged)
+                                                 .action([&] { onSavepointGenome(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_UNDO)
+                                                 .name("Revert to save point")
+                                                 .tooltip("Revert genome to save point")
+                                                 .disabled(!hasGenomeChanged)
+                                                 .action([&] { _tabs.at(_selectedTabIndex)->revertChanges(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_PALETTE)
+                                                 .name("Change colors")
+                                                 .tooltip("Change the color of all nodes with a certain color")
+                                                 .action([&] { ChangeColorDialog::get().open(_tabs.at(_selectedTabIndex)->getEditData()); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_SYRINGE)
+                                                 .name("Inject genome")
+                                                 .tooltip("Inject the current genome to the selected creatures in the simulation")
+                                                 .disabled(!creaturesSelected)
+                                                 .action([&] { onInjectGenome(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_SEEDLING)
+                                                 .name("Create seed")
+                                                 .tooltip("Create a seed with current genome without free energy supply")
+                                                 .action([&] { onCreateSeed(false); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_SEEDLING)
+                                                 .secondIcon(ICON_FA_BOLT)
+                                                 .secondIconOffset({30.0f, 25.0f})
+                                                 .name("Create seed with energy")
+                                                 .tooltip("Create a seed with current genome with free energy supply")
+                                                 .action([&] { onCreateSeed(true); }))});
+}
 
-    processUnsavedChangesChip(hasGenomeChanged);
-
-    AlienGui::Separator();
+float GenomeEditorWindow::calcUnsavedChangesChipWidth() const
+{
+    return scaleInverse(ImGui::CalcTextSize(UnsavedChangesText).x) + UnsavedChangesChipPadding;
 }
 
 void GenomeEditorWindow::processUnsavedChangesChip(bool hasGenomeChanged)
@@ -208,18 +194,8 @@ void GenomeEditorWindow::processUnsavedChangesChip(bool hasGenomeChanged)
     if (!hasGenomeChanged) {
         return;
     }
-    auto text = "Unsaved changes";
-    auto chipWidth = ImGui::CalcTextSize(text).x + scale(34.0f);
-    auto chipHeight = ImGui::GetTextLineHeight() + scale(4.0f);
-    if (ImGui::GetWindowContentRegionMax().x - ImGui::GetCursorPosX() < chipWidth + scale(16.0f)) {
-        return;
-    }
-
-    ImGui::SameLine();
-    ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - chipWidth);
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (scale(40.0f) - chipHeight) / 2);
     AlienGui::Chip(AlienGui::ChipParameters()
-                       .text(text)
+                       .text(UnsavedChangesText)
                        .textColor(Const::UnsavedChangesColor)
                        .backgroundColor(Const::UnsavedChangesBackgroundColor)
                        .dotColor(Const::UnsavedChangesColor));

--- a/source/Gui/GenomeEditorWindow.h
+++ b/source/Gui/GenomeEditorWindow.h
@@ -27,6 +27,7 @@ private:
     bool isShown() override;
 
     void processToolbar();
+    float calcUnsavedChangesChipWidth() const;
     void processUnsavedChangesChip(bool hasGenomeChanged);
     void processTabWidget();
 

--- a/source/Gui/GenomeEditorWindow.h
+++ b/source/Gui/GenomeEditorWindow.h
@@ -27,8 +27,6 @@ private:
     bool isShown() override;
 
     void processToolbar();
-    float calcUnsavedChangesChipWidth() const;
-    void processUnsavedChangesChip(bool hasGenomeChanged);
     void processTabWidget();
 
     void onOpenGenome();

--- a/source/Gui/MultiplierWindow.cpp
+++ b/source/Gui/MultiplierWindow.cpp
@@ -95,10 +95,7 @@ MultiplierWindow::MultiplierWindow()
 
 void MultiplierWindow::processIntern()
 {
-    AlienGui::SelectableToolbarButton(ICON_GRID, _mode, MultiplierMode_Grid, MultiplierMode_Grid);
-
-    ImGui::SameLine();
-    AlienGui::SelectableToolbarButton(ICON_RANDOM, _mode, MultiplierMode_Random, MultiplierMode_Random);
+    processToolbar();
 
     if (ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar)) {
 
@@ -139,6 +136,20 @@ void MultiplierWindow::processIntern()
 bool MultiplierWindow::isShown()
 {
     return _on && EditorController::get().isOn();
+}
+
+void MultiplierWindow::processToolbar()
+{
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("Multiplier").bottomSeparator(false),
+        {AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_GRID).name(ModeText.at(MultiplierMode_Grid)).selected(_mode == MultiplierMode_Grid).action([&] {
+                 _mode = MultiplierMode_Grid;
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_RANDOM).name(ModeText.at(MultiplierMode_Random)).selected(_mode == MultiplierMode_Random).action([&] {
+                 _mode = MultiplierMode_Random;
+             }))});
 }
 
 void MultiplierWindow::processGridPanel()

--- a/source/Gui/MultiplierWindow.h
+++ b/source/Gui/MultiplierWindow.h
@@ -28,6 +28,7 @@ private:
     void processIntern() override;
     bool isShown() override;
 
+    void processToolbar();
     void processGridPanel();
     void processRandomPanel();
 

--- a/source/Gui/PatternEditorWindow.cpp
+++ b/source/Gui/PatternEditorWindow.cpp
@@ -49,80 +49,7 @@ void PatternEditorWindow::processIntern()
         _angularVel = 0;
     }
 
-    // Load button
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_FOLDER_OPEN))) {
-        onOpenPattern();
-    }
-    AlienGui::Tooltip("Open pattern");
-
-    // Save button
-    ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SAVE))) {
-        onSavePattern();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Save pattern");
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    // Copy button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COPY))) {
-        onCopy();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Copy pattern");
-
-    // Paste button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!_copiedSelection.has_value());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PASTE))) {
-        onPaste();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Paste pattern");
-
-    // Delete button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(EditorModel::get().isSelectionEmpty());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_TRASH))) {
-        onDelete();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Delete Pattern");
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    // Inspect objects button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isObjectInspectionPossible());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_MICROSCOPE))) {
-        EditorController::get().onInspectSelectedObjects();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Inspect Objects");
-
-    // Inspect genomes button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isGenomeInspectionPossible());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_DNA))) {
-        EditorController::get().onInspectSelectedGenomes();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Inspect genomes");
-
-    // Inspect creatures button
-    ImGui::SameLine();
-    ImGui::BeginDisabled(!isCreatureInspectionPossible());
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PAW))) {
-        EditorController::get().onInspectSelectedCreatures();
-    }
-    ImGui::EndDisabled();
-    AlienGui::Tooltip("Inspect creatures");
+    processToolbar();
 
     if (ImGui::BeginChild("##", ImVec2(0, ImGui::GetContentRegionAvail().y - scale(50.0f)), false, ImGuiWindowFlags_HorizontalScrollbar)) {
 
@@ -265,6 +192,36 @@ void PatternEditorWindow::processIntern()
                          "If this option is disabled, the changes will be applied only to the selected cells. In this case, the connections between the cells "
                          "and the neighboring cells are recalculated when the positions are changed.\n"
                          "If you hold down the SHIFT key, this toggle button is temporarily turned off.");
+}
+
+void PatternEditorWindow::processToolbar()
+{
+    auto selectionEmpty = EditorModel::get().isSelectionEmpty();
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("PatternEditor").bottomSeparator(false),
+        {AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_FOLDER_OPEN).name("Open pattern").action([&] { onOpenPattern(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_SAVE).name("Save pattern").disabled(selectionEmpty).action([&] { onSavePattern(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_COPY).name("Copy pattern").disabled(selectionEmpty).action([&] { onCopy(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_PASTE).name("Paste pattern").disabled(!_copiedSelection.has_value()).action([&] { onPaste(); })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_TRASH).name("Delete pattern").disabled(selectionEmpty).action([&] { onDelete(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_MICROSCOPE).name("Inspect objects").disabled(!isObjectInspectionPossible()).action([&] {
+                 EditorController::get().onInspectSelectedObjects();
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_DNA).name("Inspect genomes").disabled(!isGenomeInspectionPossible()).action([&] {
+                 EditorController::get().onInspectSelectedGenomes();
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_PAW).name("Inspect creatures").disabled(!isCreatureInspectionPossible()).action([&] {
+                 EditorController::get().onInspectSelectedCreatures();
+             }))});
 }
 
 bool PatternEditorWindow::isShown()

--- a/source/Gui/PatternEditorWindow.h
+++ b/source/Gui/PatternEditorWindow.h
@@ -33,6 +33,8 @@ private:
     void processIntern() override;
     bool isShown() override;
 
+    void processToolbar();
+
     void onOpenPattern();
     void onSavePattern();
     void onMakeSticky();

--- a/source/Gui/SimulationParametersMainWindow.cpp
+++ b/source/Gui/SimulationParametersMainWindow.cpp
@@ -102,109 +102,90 @@ void SimulationParametersMainWindow::shutdownIntern()
 
 void SimulationParametersMainWindow::processToolbar()
 {
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_FOLDER_OPEN).tooltip("Open simulation parameters from file"))) {
-        onOpenParameters();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SAVE).tooltip("Save simulation parameters to file"))) {
-        onSaveParameters();
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_COPY).tooltip("Copy simulation parameters to clipboard"))) {
-        _copiedParameters = _SimulationFacade::get()->getSimulationParameters();
-        printOverlayMessage("Simulation parameters copied");
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_PASTE).tooltip("Paste simulation parameters from clipboard").disabled(!_copiedParameters))) {
-        _SimulationFacade::get()->setSimulationParameters(*_copiedParameters);
-        _SimulationFacade::get()->setOriginalSimulationParameters(*_copiedParameters);
-        printOverlayMessage("Simulation parameters pasted");
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_PASTE)
-                                    .secondText(ICON_FA_UNDO)
-                                    .secondTextOffset(RealVector2D{32.0f, 28.0f})
-                                    .secondTextScale(0.3f)
-                                    .tooltip("Replace reference values by values from the clipboard. This is useful to see the diff between the current "
-                                             "parameters and those from the clipboard.")
-                                    .disabled(!_copiedParameters))) {
-        auto parameters = _SimulationFacade::get()->getSimulationParameters();
-        if (_copiedParameters->numLayers == parameters.numLayers && _copiedParameters->numSources == parameters.numSources) {
-            _SimulationFacade::get()->setOriginalSimulationParameters(*_copiedParameters);
-            printOverlayMessage("Reference simulation parameters replaced");
-        } else {
-            GenericMessageDialog::get().information(
-                "Error", "The number of layers and radiation sources of the current simulation parameters must match with those from the clipboard.");
-        }
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PLUS).secondText(ICON_FA_LAYER_GROUP).tooltip("Add parameter layer"))) {
-        onInsertDefaultLayer();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PLUS).secondText(ICON_FA_SUN).tooltip("Add radiation source"))) {
-        onInsertDefaultSource();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_PLUS)
-                                    .secondText(ICON_FA_CLONE)
-                                    .disabled(_selectedOrderNumber == 0)
-                                    .tooltip("Clone selected layer/radiation source"))) {
-        onCloneLocation();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(
-            AlienGui::ToolbarButtonParameters().text(ICON_FA_MINUS).disabled(_selectedOrderNumber == 0).tooltip("Delete selected layer/radiation source"))) {
-        onDeleteLocation();
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_CHEVRON_UP)
-                                    .disabled(_selectedOrderNumber <= 1)
-                                    .tooltip("Move selected layer/radiation source upward"))) {
-        onDecreaseOrderNumber();
-    }
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_CHEVRON_DOWN)
-                                    .tooltip("Move selected layer/radiation source downward")
-                                    .disabled(_selectedOrderNumber >= _locations.size() - 1 || _selectedOrderNumber == 0))) {
-        onIncreaseOrderNumber();
-    }
-
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-
-    ImGui::SameLine();
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters()
-                                    .text(ICON_FA_EXTERNAL_LINK_SQUARE_ALT)
-                                    .tooltip("Open parameters for selected layer/radiation source in a new window"))) {
-        onOpenInLocationWindow();
-    }
-
-    AlienGui::Separator();
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("SimulationParameters"),
+        {AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_FOLDER_OPEN).name("Open parameters").tooltip("Open simulation parameters from file").action([&] {
+                 onOpenParameters();
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_SAVE).name("Save parameters").tooltip("Save simulation parameters to file").action([&] {
+                 onSaveParameters();
+             })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_COPY).name("Copy parameters").tooltip("Copy simulation parameters to clipboard").action([&] {
+                 _copiedParameters = _SimulationFacade::get()->getSimulationParameters();
+                 printOverlayMessage("Simulation parameters copied");
+             })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_PASTE)
+                                                 .name("Paste parameters")
+                                                 .tooltip("Paste simulation parameters from clipboard")
+                                                 .disabled(!_copiedParameters)
+                                                 .action([&] {
+                                                     _SimulationFacade::get()->setSimulationParameters(*_copiedParameters);
+                                                     _SimulationFacade::get()->setOriginalSimulationParameters(*_copiedParameters);
+                                                     printOverlayMessage("Simulation parameters pasted");
+                                                 })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters()
+                 .icon(ICON_FA_PASTE)
+                 .secondIcon(ICON_FA_UNDO)
+                 .secondIconOffset(RealVector2D{32.0f, 28.0f})
+                 .secondIconScale(0.3f)
+                 .name("Paste reference parameters")
+                 .tooltip("Replace reference values by values from the clipboard. This is useful to see the diff between the current "
+                          "parameters and those from the clipboard.")
+                 .disabled(!_copiedParameters)
+                 .action([&] {
+                     auto parameters = _SimulationFacade::get()->getSimulationParameters();
+                     if (_copiedParameters->numLayers == parameters.numLayers && _copiedParameters->numSources == parameters.numSources) {
+                         _SimulationFacade::get()->setOriginalSimulationParameters(*_copiedParameters);
+                         printOverlayMessage("Reference simulation parameters replaced");
+                     } else {
+                         GenericMessageDialog::get().information(
+                             "Error",
+                             "The number of layers and radiation sources of the current simulation parameters must match with those from the clipboard.");
+                     }
+                 })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_PLUS).secondIcon(ICON_FA_LAYER_GROUP).name("Add parameter layer").action([&] {
+                 onInsertDefaultLayer();
+             })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_PLUS).secondIcon(ICON_FA_SUN).name("Add radiation source").action([&] {
+                 onInsertDefaultSource();
+             })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_PLUS)
+                                                 .secondIcon(ICON_FA_CLONE)
+                                                 .name("Clone selected layer/radiation source")
+                                                 .disabled(_selectedOrderNumber == 0)
+                                                 .action([&] { onCloneLocation(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_MINUS)
+                                                 .name("Delete selected layer/radiation source")
+                                                 .disabled(_selectedOrderNumber == 0)
+                                                 .action([&] { onDeleteLocation(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_CHEVRON_UP)
+                                                 .name("Move selected layer/radiation source upward")
+                                                 .disabled(_selectedOrderNumber <= 1)
+                                                 .action([&] { onDecreaseOrderNumber(); })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_CHEVRON_DOWN)
+                                                 .name("Move selected layer/radiation source downward")
+                                                 .disabled(_selectedOrderNumber >= _locations.size() - 1 || _selectedOrderNumber == 0)
+                                                 .action([&] { onIncreaseOrderNumber(); })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_EXTERNAL_LINK_SQUARE_ALT)
+                                                 .name("Open in new window")
+                                                 .tooltip("Open parameters for selected layer/radiation source in a new window")
+                                                 .action([&] { onOpenInLocationWindow(); }))});
 }
 
 void SimulationParametersMainWindow::processMasterWidget()

--- a/source/Gui/SpatialControlWindow.cpp
+++ b/source/Gui/SpatialControlWindow.cpp
@@ -50,15 +50,7 @@ void SpatialControlWindow::shutdownIntern()
 
 void SpatialControlWindow::processIntern()
 {
-    processZoomInButton();
-    ImGui::SameLine();
-    processZoomOutButton();
-    ImGui::SameLine();
-    processCenterButton();
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-    ImGui::SameLine();
-    processResizeButton();
+    processToolbar();
 
     ImGui::Spacing();
     ImGui::Spacing();
@@ -108,38 +100,24 @@ void SpatialControlWindow::processBackground()
     processCenterOnSelection();
 }
 
-void SpatialControlWindow::processZoomInButton()
+void SpatialControlWindow::processToolbar()
 {
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SEARCH_PLUS))) {
-        Viewport::get().setZoomFactor(Viewport::get().getZoomFactor() * 2);
-    }
-    AlienGui::Tooltip("Zoom in");
-}
-
-void SpatialControlWindow::processZoomOutButton()
-{
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_SEARCH_MINUS))) {
-        Viewport::get().setZoomFactor(Viewport::get().getZoomFactor() / 2);
-    }
-    AlienGui::Tooltip("Zoom out");
-}
-
-void SpatialControlWindow::processCenterButton()
-{
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CROSSHAIRS))) {
-        Viewport::get().setZoomFactor(1.0f);
-        auto worldSize = toRealVector2D(_SimulationFacade::get()->getWorldSize());
-        Viewport::get().setCenterInWorldPos({worldSize.x / 2, worldSize.y / 2});
-    }
-    AlienGui::Tooltip("Center");
-}
-
-void SpatialControlWindow::processResizeButton()
-{
-    if (AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CROP_ALT))) {
-        ResizeWorldDialog::get().open();
-    }
-    AlienGui::Tooltip("Resize");
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("SpatialControl").bottomSeparator(false),
+        {AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_SEARCH_PLUS).name("Zoom in").action([&] {
+             Viewport::get().setZoomFactor(Viewport::get().getZoomFactor() * 2);
+         })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_SEARCH_MINUS).name("Zoom out").action([&] {
+             Viewport::get().setZoomFactor(Viewport::get().getZoomFactor() / 2);
+         })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_CROSSHAIRS).name("Center").action([&] {
+             Viewport::get().setZoomFactor(1.0f);
+             auto worldSize = toRealVector2D(_SimulationFacade::get()->getWorldSize());
+             Viewport::get().setCenterInWorldPos({worldSize.x / 2, worldSize.y / 2});
+         })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_CROP_ALT).name("Resize").action([&] { ResizeWorldDialog::get().open(); }))});
 }
 
 void SpatialControlWindow::processCenterOnSelection()

--- a/source/Gui/SpatialControlWindow.h
+++ b/source/Gui/SpatialControlWindow.h
@@ -20,10 +20,7 @@ private:
     void processIntern() override;
     void processBackground() override;
 
-    void processZoomInButton();
-    void processZoomOutButton();
-    void processCenterButton();
-    void processResizeButton();
+    void processToolbar();
 
     void processCenterOnSelection();
 

--- a/source/Gui/StyleRepository.h
+++ b/source/Gui/StyleRepository.h
@@ -107,6 +107,14 @@ namespace Const
     ImColor const ToolbarButtonTextColor = ImColor::HSV(0.530f, 0.320f, 0.950f);
     ImColor const ToolbarButtonBackgroundColor = ImColor::HSV(0.0f, 0.0f, 0.0f, 0.0f);
     ImColor const ToolbarButtonHoveredColor = RaisedColor;
+    ImColor const ToolbarButtonSelectedColor = AccentDeepColor;
+    ImColor const ToolbarButtonSelectedTextColor = AccentColor;
+    ImColor const ToolbarButtonDisabledTextColor = TextFaintColor;
+    ImColor const ToolbarSelectionBarColor = AccentColor;
+    ImColor const ToolbarGroupColor = ImColor::HSV(0.583f, 0.100f, 1.000f, 0.050f);
+    ImColor const ToolbarOverflowColor = TextFaintColor;
+    ImColor const ToolbarOverflowHoveredColor = AccentColor;
+    ImColor const ToolbarMenuHoveredColor = AccentDeepColor;
 
     ImColor const ActionButtonTextColor = ImColor::HSV(0.530f, 0.400f, 0.950f);
     ImColor const ActionButtonHighlightedTextColor = AccentColor;

--- a/source/Gui/TemporalControlWindow.cpp
+++ b/source/Gui/TemporalControlWindow.cpp
@@ -10,21 +10,18 @@
 #include <EngineInterface/SimulationFacade.h>
 #include <EngineInterface/SpaceCalculator.h>
 
+#include <EngineInterface/SimulationFacade.h>
 #include "AlienGui.h"
 #include "DelayedExecutionController.h"
 #include "OverlayController.h"
 #include "StyleRepository.h"
-#include <EngineInterface/SimulationFacade.h>
 
 namespace
 {
     auto constexpr LeftColumnWidth = 180.0f;
 }
 
-void TemporalControlWindow::initIntern()
-{
-
-}
+void TemporalControlWindow::initIntern() {}
 
 void TemporalControlWindow::onSnapshot()
 {
@@ -37,23 +34,7 @@ TemporalControlWindow::TemporalControlWindow()
 
 void TemporalControlWindow::processIntern()
 {
-    processRunButton();
-    ImGui::SameLine();
-    processPauseButton();
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-    ImGui::SameLine();
-    processStepBackwardButton();
-    ImGui::SameLine();
-    processStepForwardButton();
-    ImGui::SameLine();
-    AlienGui::ToolbarSeparator();
-    ImGui::SameLine();
-    processCreateFlashbackButton();
-    ImGui::SameLine();
-    processLoadFlashbackButton();
-
-    AlienGui::Separator();
+    processToolbar();
 
     if (ImGui::BeginChild("##", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar)) {
         processTpsInfo();
@@ -134,84 +115,61 @@ void TemporalControlWindow::processTpsRestriction()
     ImGui::EndDisabled();
 }
 
-void TemporalControlWindow::processRunButton()
+void TemporalControlWindow::processToolbar()
 {
-    ImGui::BeginDisabled(_SimulationFacade::get()->isSimulationRunning());
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PLAY));
-    AlienGui::Tooltip("Run");
-    if (result) {
-        _history.clear();
-        _SimulationFacade::get()->runSimulation();
-        printOverlayMessage("Run");
-    }
-    ImGui::EndDisabled();
-}
+    auto simulationRunning = _SimulationFacade::get()->isSimulationRunning();
+    AlienGui::Toolbar(
+        AlienGui::ToolbarParameters().id("TemporalControl"),
+        {AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_PLAY).name("Run").disabled(simulationRunning).action([&] {
+             _history.clear();
+             _SimulationFacade::get()->runSimulation();
+             printOverlayMessage("Run");
+         })),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters().icon(ICON_FA_PAUSE).name("Pause").disabled(!simulationRunning).action([&] {
+             _SimulationFacade::get()->pauseSimulation();
+             printOverlayMessage("Pause");
+         })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_CHEVRON_LEFT)
+                                                 .name("Load previous time step")
+                                                 .disabled(_history.empty() || simulationRunning)
+                                                 .action([&] {
+                                                     auto const& snapshot = _history.back();
+                                                     delayedExecution([this, snapshot] { applySnapshot(snapshot); });
+                                                     printOverlayMessage("Loading previous time step ...");
 
-void TemporalControlWindow::processPauseButton()
-{
-    ImGui::BeginDisabled(!_SimulationFacade::get()->isSimulationRunning());
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_PAUSE));
-    AlienGui::Tooltip("Pause");
-    if (result) {
-        _SimulationFacade::get()->pauseSimulation();
-        printOverlayMessage("Pause");
-    }
-    ImGui::EndDisabled();
-}
+                                                     _history.pop_back();
+                                                 })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters().icon(ICON_FA_CHEVRON_RIGHT).name("Process single time step").disabled(simulationRunning).action([&] {
+                 _history.emplace_back(createSnapshot());
+                 _SimulationFacade::get()->calcTimesteps(1);
+             })),
+         AlienGui::ToolbarItem::createSeparator(),
+         AlienGui::ToolbarItem::createButton(AlienGui::ToolbarItemParameters()
+                                                 .icon(ICON_FA_CAMERA)
+                                                 .name("Create flashback")
+                                                 .tooltip("Creating in-memory flashback: It saves the content of the current world to the memory.")
+                                                 .action([&] {
+                                                     delayedExecution([this] { onSnapshot(); });
 
-void TemporalControlWindow::processStepBackwardButton()
-{
-    ImGui::BeginDisabled(_history.empty() || _SimulationFacade::get()->isSimulationRunning());
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CHEVRON_LEFT));
-    AlienGui::Tooltip("Load previous time step");
-    if (result) {
-        auto const& snapshot = _history.back();
-        delayedExecution([this, snapshot] { applySnapshot(snapshot); });
-        printOverlayMessage("Loading previous time step ...");
+                                                     printOverlayMessage("Creating flashback ...", true);
+                                                 })),
+         AlienGui::ToolbarItem::createButton(
+             AlienGui::ToolbarItemParameters()
+                 .icon(ICON_FA_UNDO)
+                 .name("Load flashback")
+                 .tooltip("Loading in-memory flashback: It loads the saved world from the memory. Static simulation parameters will not be changed. "
+                          "Non-static parameters (such as the position of moving layers) will be restored as well.")
+                 .disabled(!_snapshot)
+                 .action([&] {
+                     delayedExecution([this] { applySnapshot(*_snapshot); });
+                     _SimulationFacade::get()->removeSelection();
+                     _history.clear();
 
-        _history.pop_back();
-    }
-    ImGui::EndDisabled();
-}
-
-void TemporalControlWindow::processStepForwardButton()
-{
-    ImGui::BeginDisabled(_SimulationFacade::get()->isSimulationRunning());
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CHEVRON_RIGHT));
-    AlienGui::Tooltip("Process single time step");
-    if (result) {
-        _history.emplace_back(createSnapshot());
-        _SimulationFacade::get()->calcTimesteps(1);
-    }
-    ImGui::EndDisabled();
-}
-
-void TemporalControlWindow::processCreateFlashbackButton()
-{
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_CAMERA));
-    AlienGui::Tooltip("Creating in-memory flashback: It saves the content of the current world to the memory.");
-    if (result) {
-        delayedExecution([this] { onSnapshot(); });
-
-        printOverlayMessage("Creating flashback ...", true);
-    }
-}
-
-void TemporalControlWindow::processLoadFlashbackButton()
-{
-    ImGui::BeginDisabled(!_snapshot);
-    auto result = AlienGui::ToolbarButton(AlienGui::ToolbarButtonParameters().text(ICON_FA_UNDO));
-    AlienGui::Tooltip(
-        "Loading in-memory flashback: It loads the saved world from the memory. Static simulation parameters will not be changed. Non-static parameters "
-        "(such as the position of moving layers) will be restored as well.");
-    if (result) {
-        delayedExecution([this] { applySnapshot(*_snapshot); });
-        _SimulationFacade::get()->removeSelection();
-        _history.clear();
-
-        printOverlayMessage("Loading flashback ...", true);
-    }
-    ImGui::EndDisabled();
+                     printOverlayMessage("Loading flashback ...", true);
+                 }))});
 }
 
 TemporalControlWindow::Snapshot TemporalControlWindow::createSnapshot()

--- a/source/Gui/TemporalControlWindow.h
+++ b/source/Gui/TemporalControlWindow.h
@@ -29,12 +29,7 @@ private:
     void processRealTimeInfo();
     void processTpsRestriction();
 
-    void processRunButton();
-    void processPauseButton();
-    void processStepBackwardButton();
-    void processStepForwardButton();
-    void processCreateFlashbackButton();
-    void processLoadFlashbackButton();
+    void processToolbar();
 
     struct Snapshot
     {


### PR DESCRIPTION
Replaces the hand-assembled toolbars in nine windows by one widget.

## Widget

`AlienGui::Toolbar(ToolbarParameters, std::vector<ToolbarItem>)` takes a declarative item list and handles layout, spacing, grouping, disabled state, tooltips and the overflow. `ToolbarItemParameters` carries `icon`, `secondIcon`, `name`, `tooltip`, `disabled`, `selected` and `action`; `ToolbarItem::createSeparator()` marks a group boundary.

- Items that do not fit the window width are moved to a menu behind an ellipsis at the right border, so no button becomes unreachable in a narrow window. The split point is computed from the exact item widths, so the ellipsis only appears when something is actually hidden.
- The ellipsis sits right of the trailing content and is drawn as a plain glyph, not as a button.
- Separators no longer draw a line: each group sits on a slightly raised rounded surface. Selected buttons get an accent fill plus an underline, which replaces `SelectableToolbarButton`.
- `trailing` / `trailingWidth` place right-aligned content, used by the "Unsaved changes" chip in the genome editor, which loses its own layout math.
- `name` is the short label in the overflow menu and the fallback tooltip, so the scattered `AlienGui::Tooltip` calls after each button moved into the item parameters.

## Migrated

Browser, genome editor, simulation parameters, pattern editor, temporal control, spatial control, autosave, creator and multiplier window. `ToolbarButton`, `SelectableToolbarButton` and `ToolbarSeparator` are removed.

Behavior is unchanged apart from the visual grouping and the new overflow menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)