### PR TITLE
Restructure simulation parameters

### DIFF
--- a/source/Base/Resources.h
+++ b/source/Base/Resources.h
@@ -4,7 +4,7 @@
 
 namespace Const
 {
-    std::string const ProgramVersion = "5.0.0-alpha.28";
+    std::string const ProgramVersion = "5.0.0-alpha.29";
     std::string const DiscordURL = "https://discord.gg/7bjyZdXXQ2";
     std::string const AlienServerURL = "api.alien-project.org";
     std::string const StartupSimulationResourceName = "Startup/Version1";

--- a/source/EngineImpl/SimulationParametersUpdateService.cu
+++ b/source/EngineImpl/SimulationParametersUpdateService.cu
@@ -81,7 +81,6 @@ bool SimulationParametersUpdateService::updateSimulationParametersAfterTimestep(
     for (int i = 0; i < MAX_COLORS; ++i) {
         externalEnergyPresent |= settings.simulationParameters.externalEnergyBackflowFactor.value[i] > 0;
     }
-    externalEnergyPresent &= settings.simulationParameters.externalEnergyControlToggle.value;
     if (externalEnergyPresent) {
         double temp;
         CHECK_FOR_DEVICE_ERRORS(cudaMemcpy(&temp, simulationData.externalEnergy, sizeof(double), cudaMemcpyDeviceToHost));

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -120,6 +120,64 @@ ParametersSpec const& SimulationParameters::getSpec()
                                      "higher the value in the height map, the darker the background."),
                 }),
             ParameterGroupSpec()
+                .name("Guided energy supply")
+                .parameters({
+                    ParameterSpec()
+                        .name("External energy amount")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::externalEnergy).min(0.0f).max(100000000.0f).format("%.0f").logarithmic(true).infinity(true))
+                        .description("This parameter can be used to set the amount of energy of an external energy pool. This type of energy can then be "
+                                     "transferred to all constructor cells at a certain rate (see inflow settings).\n\nWarning: Too much external energy can "
+                                     "result in a "
+                                     "massive production of cells and slow down or even crash the simulation."),
+                    ParameterSpec()
+                        .name("Inflow for constructors")
+                        .reference(FloatSpec().member(&SimulationParameters::externalEnergyInflowForConstructor).min(0.0f).max(50.0f).format("%.1f"))
+                        .description(
+                            "The maximum amount of energy that is transferred from the external energy pool to a constructor cell each time it tries to build "
+                            "a new cell.\n\nIf the external energy pool cannot satisfy all requesting constructor cells, the available energy is distributed "
+                            "proportionally."),
+                    ParameterSpec()
+                        .name("Inflow threshold")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::externalEnergyInflowThresholdFactor).min(0.0f).max(1.0f).format("%.5f").logarithmic(true))
+                        .description(
+                            "Here one can specify the fraction of energy that constructor cells must provide by themselves before constructing with external "
+                            "energy inflow.\n\nFor example, a value of 0.6 means that a constructor cell needs energy amounting to at least 60% of the "
+                            "energy required to build the new cell by itself. Otherwise, no external energy inflow is requested."),
+                    ParameterSpec()
+                        .name("Inflow only for first offspring")
+                        .reference(BoolSpec().member(&SimulationParameters::externalEnergyInflowOnlyForFirstOffspring))
+                        .description("If activated, external energy can only be transferred to constructor cells that have not yet produced any offspring. "
+                                     "This option can be used to limit the external energy supply."),
+                    ParameterSpec()
+                        .name("Inflow for sources")
+                        .reference(
+                            FloatSpec().member(&SimulationParameters::externalEnergyInflowForSources).min(0.0f).max(10000.0f).format("%.1f").logarithmic(true))
+                        .description("The absolute amount of energy that is transferred from the external energy pool to the radiation sources in each time "
+                                     "step. Each color entry defines the energy that is emitted in the corresponding color.\n\nEach radiation source receives "
+                                     "these amounts multiplied by its relative strength and emits them as energy particles. If the external energy pool does "
+                                     "not contain enough energy, only the remaining energy is distributed."),
+                    ParameterSpec()
+                        .name("Backflow")
+                        .reference(FloatSpec().member(&SimulationParameters::externalEnergyBackflowFactor).min(0.0f).max(1.0f))
+                        .description("The proportion of energy that flows back from the simulation to the external energy pool. Each time a cell loses energy "
+                                     "or dies a fraction of its energy will be taken. The remaining "
+                                     "fraction of the energy stays in the simulation and will be used to create a new energy particle."),
+                    ParameterSpec()
+                        .name("Backflow limit")
+                        .reference(
+                            FloatSpec()
+                                .member(&SimulationParameters::externalEnergyBackflowLimit)
+                                .min(0.0f)
+                                .max(1e8f)
+                                .format("%.0f")
+                                .logarithmic(true)
+                                .infinity(true))
+                        .description("Energy from the simulation can only flow back into the external energy pool as long as the amount of external energy is "
+                                     "below this value."),
+                }),
+            ParameterGroupSpec()
                 .name("Location")
                 .parameters({
                     ParameterSpec()
@@ -406,11 +464,6 @@ ParametersSpec const& SimulationParameters::getSpec()
                             "The minimum energy of an energy particle after which it can split into two particles, whereby it receives a small momentum. The "
                             "splitting does not occur immediately, but only after a certain time."),
                     ParameterSpec()
-                        .name("Energy to cell transformation")
-                        .reference(BoolSpec().member(&SimulationParameters::particleTransformationAllowed))
-                        .description(
-                            "If activated, an energy particle will transform into a cell if the energy of the particle exceeds the normal energy value."),
-                    ParameterSpec()
                         .name("Radiation angle")
                         .reference(FloatSpec().member(&SimulationParameters::sourceRadiationAngle).min(-180.0f).max(180.0f).format("%.1f")),
                 }),
@@ -454,6 +507,11 @@ ParametersSpec const& SimulationParameters::getSpec()
                             "The probability per time step with which a cell will disintegrate (i.e. transform into an energy particle) when it is in the "
                             "state 'Dying'. This can occur when one of the following conditions is satisfied:\n\n" ICON_FA_CHEVRON_RIGHT
                             " The cell has too low energy.\n\n" ICON_FA_CHEVRON_RIGHT " The cell has exceeded its maximum age."),
+                    ParameterSpec()
+                        .name("Energy to cell free transformation")
+                        .reference(BoolSpec().member(&SimulationParameters::particleTransformationAllowed))
+                        .description(
+                            "If activated, an energy particle will transform into a cell if the energy of the particle exceeds the normal energy value."),
                 }),
             ParameterGroupSpec()
                 .name("Cell construction")
@@ -677,35 +735,6 @@ ParametersSpec const& SimulationParameters::getSpec()
                             "The probability that the explosion of one detonator will trigger the explosion of other detonators within the blast radius."),
                 }),
             ParameterGroupSpec()
-                .name("Advanced energy absorption control")
-                .expertToggle(&SimulationParameters::advancedAbsorptionControlToggle)
-                .parameters({
-                    ParameterSpec()
-                        .name("Low genome complexity penalty")
-                        .reference(FloatSpec().member(&SimulationParameters::radiationAbsorptionLowNumCellsPenalty).min(0.0f).max(1.0f).format("%.2f"))
-                        .description(
-                            "When this parameter is increased, cells with fewer genome complexity will absorb less energy from an incoming energy particle."),
-                    ParameterSpec()
-                        .name("Low connection penalty")
-                        .reference(FloatSpec().member(&SimulationParameters::radiationAbsorptionLowConnectionPenalty).min(0.0f).max(5.0f).format("%.1f"))
-                        .description(
-                            "When this parameter is increased, cells with fewer cell connections will absorb less energy from an incoming energy particle."),
-                    ParameterSpec()
-                        .name("High velocity penalty")
-                        .reference(
-                            FloatSpec()
-                                .member(&SimulationParameters::radiationAbsorptionHighVelocityPenalty)
-                                .min(0.0f)
-                                .max(30.0f)
-                                .logarithmic(true)
-                                .format("%.2f"))
-                        .description("When this parameter is increased, fast moving cells will absorb less energy from an incoming energy particle."),
-                    ParameterSpec()
-                        .name("Low velocity penalty")
-                        .reference(FloatSpec().member(&SimulationParameters::radiationAbsorptionLowVelocityPenalty).min(0.0f).max(1.0f).format("%.2f"))
-                        .description("When this parameter is increased, slowly moving cells will absorb less energy from an incoming energy particle."),
-                }),
-            ParameterGroupSpec()
                 .name("Cell color transition rules")
                 .expertToggle(&SimulationParameters::colorTransitionRulesToggle)
                 .parameters({
@@ -715,77 +744,6 @@ ParametersSpec const& SimulationParameters::getSpec()
                         .description("Rules can be defined that describe how the colors of cells will change over time. For this purpose, a subsequent "
                                      "color can be defined for each cell color. In addition, durations must be specified that define how many time steps the "
                                      "corresponding color are kept."),
-                }),
-            ParameterGroupSpec()
-                .name("Customize deletion mutations")
-                .expertToggle(&SimulationParameters::customizeDeletionMutationsToggle)
-                .parameters({
-                    ParameterSpec()
-                        .name("Minimum size")
-                        .reference(IntSpec().member(&SimulationParameters::cellCopyMutationDeletionMinSize).min(0).max(1000).logarithmic(true))
-                        .description(
-                            "The minimum size of genomes (on the basis of the coded cells) is determined here that can result from delete mutations. The "
-                            "default is 0."),
-                }),
-            ParameterGroupSpec()
-                .name("External energy control")
-                .expertToggle(&SimulationParameters::externalEnergyControlToggle)
-                .parameters({
-                    ParameterSpec()
-                        .name("External energy amount")
-                        .reference(
-                            FloatSpec().member(&SimulationParameters::externalEnergy).min(0.0f).max(100000000.0f).format("%.0f").logarithmic(true).infinity(true))
-                        .description("This parameter can be used to set the amount of energy of an external energy pool. This type of energy can then be "
-                                     "transferred to all constructor cells at a certain rate (see inflow settings).\n\nWarning: Too much external energy can "
-                                     "result in a "
-                                     "massive production of cells and slow down or even crash the simulation."),
-                    ParameterSpec()
-                        .name("Inflow")
-                        .reference(FloatSpec().member(&SimulationParameters::externalEnergyInflowFactor).min(0.0f).max(1.0f).format("%.5f").logarithmic(true))
-                        .description(
-                            "Here one can specify the fraction of energy transferred to constructor cells.\n\nFor example, a value of 0.05 means that "
-                            "each time a constructor cell tries to build a new cell, 5% of the required energy is transferred for free from the external "
-                            "energy "
-                            "source."),
-                    ParameterSpec()
-                        .name("Inflow threshold")
-                        .reference(
-                            FloatSpec().member(&SimulationParameters::externalEnergyInflowThresholdFactor).min(0.0f).max(1.0f).format("%.5f").logarithmic(true))
-                        .description(
-                            "Here one can specify the fraction of energy that constructor cells must provide by themselves before constructing with external "
-                            "energy inflow.\n\nFor example, a value of 0.6 means that a constructor cell needs energy amounting to at least 60% of the "
-                            "energy required to build the new cell by itself. Otherwise, no external energy inflow is requested."),
-                    ParameterSpec()
-                        .name("Inflow only for first offspring")
-                        .reference(BoolSpec().member(&SimulationParameters::externalEnergyInflowOnlyForFirstOffspring))
-                        .description("If activated, external energy can only be transferred to constructor cells that have not yet produced any offspring. "
-                                     "This option can be used to foster the evolution of additional body parts."),
-                    ParameterSpec()
-                        .name("Inflow for sources")
-                        .reference(
-                            FloatSpec().member(&SimulationParameters::externalEnergyInflowForSources).min(0.0f).max(10000.0f).format("%.1f").logarithmic(true))
-                        .description("The absolute amount of energy that is transferred from the external energy pool to the radiation sources in each time "
-                                     "step. Each color entry defines the energy that is emitted in the corresponding color.\n\nEach radiation source receives "
-                                     "these amounts multiplied by its relative strength and emits them as energy particles. If the external energy pool does "
-                                     "not contain enough energy, only the remaining energy is distributed."),
-                    ParameterSpec()
-                        .name("Backflow")
-                        .reference(FloatSpec().member(&SimulationParameters::externalEnergyBackflowFactor).min(0.0f).max(1.0f))
-                        .description("The proportion of energy that flows back from the simulation to the external energy pool. Each time a cell loses energy "
-                                     "or dies a fraction of its energy will be taken. The remaining "
-                                     "fraction of the energy stays in the simulation and will be used to create a new energy particle."),
-                    ParameterSpec()
-                        .name("Backflow limit")
-                        .reference(
-                            FloatSpec()
-                                .member(&SimulationParameters::externalEnergyBackflowLimit)
-                                .min(0.0f)
-                                .max(1e8f)
-                                .format("%.0f")
-                                .logarithmic(true)
-                                .infinity(true))
-                        .description("Energy from the simulation can only flow back into the external energy pool as long as the amount of external energy is "
-                                     "below this value."),
                 }),
         });
     }

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -735,14 +735,14 @@ ParametersSpec const& SimulationParameters::getSpec()
                             "The probability that the explosion of one detonator will trigger the explosion of other detonators within the blast radius."),
                 }),
             ParameterGroupSpec()
-                .name("Cell color transition rules")
+                .name("Object color transition rules")
                 .expertToggle(&SimulationParameters::colorTransitionRulesToggle)
                 .parameters({
                     ParameterSpec()
                         .name("Target color and duration")
                         .reference(ColorTransitionRulesSpec().member(&SimulationParameters::colorTransitionRules))
                         .description("Rules can be defined that describe how the colors of cells will change over time. For this purpose, a subsequent "
-                                     "color can be defined for each cell color. In addition, durations must be specified that define how many time steps the "
+                                     "color can be defined for each customization color. In addition, durations must be specified that define how many time steps the "
                                      "corresponding color are kept."),
                 }),
         });

--- a/source/EngineInterface/SimulationParameters.cpp
+++ b/source/EngineInterface/SimulationParameters.cpp
@@ -138,7 +138,7 @@ ParametersSpec const& SimulationParameters::getSpec()
                             "a new cell.\n\nIf the external energy pool cannot satisfy all requesting constructor cells, the available energy is distributed "
                             "proportionally."),
                     ParameterSpec()
-                        .name("Inflow threshold")
+                        .name("Inflow threshold factor")
                         .reference(
                             FloatSpec().member(&SimulationParameters::externalEnergyInflowThresholdFactor).min(0.0f).max(1.0f).format("%.5f").logarithmic(true))
                         .description(

--- a/source/EngineInterface/SimulationParameters.h
+++ b/source/EngineInterface/SimulationParameters.h
@@ -39,6 +39,15 @@ struct SimulationParameters
     SourceParameter<bool> sourceShowRadiationCenter = {true};
     LayerParameter<bool> layerShowForceField = {{true}};
 
+    // External energy control
+    BaseParameter<float> externalEnergy = {0.0f};
+    BaseParameter<ColorVector<float>> externalEnergyInflowForConstructor = {ColorVector<float>::uniform(50.0f)};
+    BaseParameter<ColorVector<float>> externalEnergyInflowThresholdFactor = {ColorVector<float>::uniform(0.0f)};
+    BaseParameter<bool> externalEnergyInflowOnlyForFirstOffspring = {false};
+    BaseParameter<ColorVector<float>> externalEnergyInflowForSources = {ColorVector<float>::uniform(100.0f)};
+    BaseParameter<ColorVector<float>> externalEnergyBackflowFactor = {ColorVector<float>::uniform(0.0f)};
+    BaseParameter<float> externalEnergyBackflowLimit = {Infinity<float>::value};
+
     // Location
     LayerParameter<RealVector2D> layerPosition;
     LayerParameter<RealVector2D> layerVelocity;
@@ -91,7 +100,6 @@ struct SimulationParameters
     BaseParameter<ColorVector<float>> radiationType2_strength = {ColorVector<float>::uniform(0.0f)};
     BaseParameter<ColorVector<float>> radiationType2_energyThreshold = {ColorVector<float>::uniform(500.0f)};
     BaseParameter<ColorVector<float>> particleSplitEnergy = {ColorVector<float>::uniform(50.0f)};
-    BaseParameter<bool> particleTransformationAllowed = {false};
     EnableableSourceParameter<float> sourceRadiationAngle = {{{.value = 0.0f, .enabled = false}}};
     static float constexpr radiationProbability = 0.03f;
     static float constexpr radiationVelocityMultiplier = 1.0f;
@@ -103,6 +111,7 @@ struct SimulationParameters
     BaseLayerParameter<ColorVector<float>> minCellEnergy = {.baseValue = ColorVector<float>::uniform(50.0f)};
     BaseParameter<ColorVector<float>> normalCellEnergy = {ColorVector<float>::uniform(100.0f)};
     BaseLayerParameter<ColorVector<float>> cellDeathProbability = {.baseValue = ColorVector<float>::uniform(0.001f)};
+    BaseParameter<bool> particleTransformationAllowed = {false};
 
     // Cell constructor
     BaseParameter<ColorVector<float>> constructorConnectingCellDistance = {ColorVector<float>::uniform(3.5f)};
@@ -174,30 +183,9 @@ struct SimulationParameters
     BaseParameter<ColorVector<float>> detonatorRadius = {ColorVector<float>::uniform(10.0f)};
     BaseParameter<ColorVector<float>> detonatorChainExplosionProbability = {ColorVector<float>::uniform(0.2f)};
 
-    // Expert settings: Advanced absorption control
-    ExpertToggle advancedAbsorptionControlToggle = {false};
-    BaseLayerParameter<ColorVector<float>> radiationAbsorptionLowNumCellsPenalty = {.baseValue = ColorVector<float>::uniform(0.0f)};
-    BaseParameter<ColorVector<float>> radiationAbsorptionLowConnectionPenalty = {ColorVector<float>::uniform(0.0f)};
-    BaseParameter<ColorVector<float>> radiationAbsorptionHighVelocityPenalty = {ColorVector<float>::uniform(0.0f)};
-    BaseLayerParameter<ColorVector<float>> radiationAbsorptionLowVelocityPenalty = {.baseValue = ColorVector<float>::uniform(0.0f)};
-
     // Expert settings: Cell color transition rules
     ExpertToggle colorTransitionRulesToggle = {false};
     BaseLayerParameter<ColorVector<ColorTransitionRule>> colorTransitionRules;
-
-    // Expert settings: Customize deletion mutations setting
-    ExpertToggle customizeDeletionMutationsToggle = {false};
-    BaseParameter<int> cellCopyMutationDeletionMinSize = {0};
-
-    // Expert settings: External energy settings
-    ExpertToggle externalEnergyControlToggle = {false};
-    BaseParameter<float> externalEnergy = {0.0f};
-    BaseParameter<ColorVector<float>> externalEnergyInflowFactor = {ColorVector<float>::uniform(1.0f)};
-    BaseParameter<ColorVector<float>> externalEnergyInflowThresholdFactor = {ColorVector<float>::uniform(0.0f)};
-    BaseParameter<bool> externalEnergyInflowOnlyForFirstOffspring = {false};
-    BaseParameter<ColorVector<float>> externalEnergyInflowForSources = {ColorVector<float>::uniform(0.0f)};
-    BaseParameter<ColorVector<float>> externalEnergyBackflowFactor = {ColorVector<float>::uniform(0.0f)};
-    BaseParameter<float> externalEnergyBackflowLimit = {Infinity<float>::value};
 
     bool operator==(SimulationParameters const&) const = default;
 

--- a/source/EngineKernels/ConstructorProcessor.cuh
+++ b/source/EngineKernels/ConstructorProcessor.cuh
@@ -732,7 +732,7 @@ __inline__ __device__ bool ConstructorProcessor::hasEnergyForConstructionOrReque
 
 __inline__ __device__ bool ConstructorProcessor::isExternalEnergyInflowAllowed(Object const* hostObject)
 {
-    if (!cudaSimulationParameters.externalEnergyControlToggle.value || cudaSimulationParameters.externalEnergyInflowFactor.value[hostObject->color] <= 0) {
+    if (cudaSimulationParameters.externalEnergyInflowForConstructor.value[hostObject->color] <= 0) {
         return false;
     }
     if (cudaSimulationParameters.externalEnergyInflowOnlyForFirstOffspring.value && hostObject->typeData.cell.constructor.currentOffspring > 0) {

--- a/source/EngineKernels/EnergyProcessor.cuh
+++ b/source/EngineKernels/EnergyProcessor.cuh
@@ -132,22 +132,6 @@ __inline__ __device__ void EnergyProcessor::collision(SimulationData& data)
                     if (particle->tryLock()) {
 
                         auto energyToTransfer = particle->energy * radiationAbsorption;
-                        if (cudaSimulationParameters.advancedAbsorptionControlToggle.value) {
-                            energyToTransfer *= max(
-                                0.0f, 1.0f - Math::length(object->vel) * cudaSimulationParameters.radiationAbsorptionHighVelocityPenalty.value[object->color]);
-
-                            auto radiationAbsorptionLowVelocityPenalty = ParameterCalculator::calcParameter(
-                                cudaSimulationParameters.radiationAbsorptionLowVelocityPenalty, data, object->pos, object->color);
-                            energyToTransfer *= 1.0f - radiationAbsorptionLowVelocityPenalty / powf(1.0f + Math::length(object->vel), 10.0f);
-                            energyToTransfer *= powf(
-                                toFloat(object->numConnections + 1) / 7.0f,
-                                cudaSimulationParameters.radiationAbsorptionLowConnectionPenalty.value[object->color]);
-
-                            //auto radiationAbsorptionLowNumCellsPenalty = ParameterCalculator::calcParameter(
-                            //    cudaSimulationParameters.radiationAbsorptionLowNumCellsPenalty, data, object->pos, object->color);
-                            //energyToTransfer *= 1.0f - radiationAbsorptionLowNumCellsPenalty / powf(1.0f + object->numObjects, 0.1f);
-                        }
-
                         if (particle->energy < 0.01f /* && energyToTransfer > 0.1f*/) {
                             energyToTransfer = particle->energy;
                         }
@@ -282,7 +266,7 @@ __inline__ __device__ void EnergyProcessor::createEnergyParticle(SimulationData&
     data.objectMap.correctPosition(pos);
 
     auto externalEnergyBackflowFactor = 0.0f;
-    if (cudaSimulationParameters.externalEnergyControlToggle.value && cudaSimulationParameters.externalEnergyBackflowFactor.value[color] > 0) {
+    if (cudaSimulationParameters.externalEnergyBackflowFactor.value[color] > 0) {
         auto energyToAdd = toDouble(energy * cudaSimulationParameters.externalEnergyBackflowFactor.value[color]);
         auto origExternalEnergy = atomicAdd(data.externalEnergy, energyToAdd);
         if (origExternalEnergy + energyToAdd > cudaSimulationParameters.externalEnergyBackflowLimit.value) {
@@ -303,9 +287,6 @@ __inline__ __device__ void EnergyProcessor::createEnergyParticle(SimulationData&
 
 __inline__ __device__ void EnergyProcessor::provideExternalEnergyForSources(SimulationData& data)
 {
-    if (!cudaSimulationParameters.externalEnergyControlToggle.value) {
-        return;
-    }
     auto totalInflow = 0.0f;
     for (int color = 0; color < MAX_COLORS; ++color) {
         totalInflow += cudaSimulationParameters.externalEnergyInflowForSources.value[color];

--- a/source/EngineKernels/SimulationKernels.cu
+++ b/source/EngineKernels/SimulationKernels.cu
@@ -148,7 +148,7 @@ __global__ void cudaNextTimestep_constructor_prepareExternalEnergyInflow(Simulat
 {
     auto totalEnergyNeeded = 0.0;
     for (int color = 0; color < MAX_COLORS; ++color) {
-        totalEnergyNeeded += data.numConstructorsNeedingEnergyByColor[color] * 50.0 * cudaSimulationParameters.externalEnergyInflowFactor.value[color];
+        totalEnergyNeeded += data.numConstructorsNeedingEnergyByColor[color] * cudaSimulationParameters.externalEnergyInflowForConstructor.value[color];
     }
     auto externalEnergy = *data.externalEnergy;
     auto factor = 0.0;
@@ -156,7 +156,7 @@ __global__ void cudaNextTimestep_constructor_prepareExternalEnergyInflow(Simulat
         factor = externalEnergy == Infinity<float>::value ? 1.0 : min(1.0, externalEnergy / totalEnergyNeeded);
     }
     for (int color = 0; color < MAX_COLORS; ++color) {
-        data.externalEnergyInflowPerConstructorByColor[color] = 50.0f * toFloat(cudaSimulationParameters.externalEnergyInflowFactor.value[color] * factor);
+        data.externalEnergyInflowPerConstructorByColor[color] = toFloat(cudaSimulationParameters.externalEnergyInflowForConstructor.value[color] * factor);
     }
     if (factor > 0.0 && externalEnergy != Infinity<float>::value) {
         *data.externalEnergy = max(0.0, externalEnergy - totalEnergyNeeded);

--- a/source/EngineTests/ConstructorMutationTests.cpp
+++ b/source/EngineTests/ConstructorMutationTests.cpp
@@ -102,7 +102,6 @@ TEST_F(ConstructorMutationTests, mutatesCreatureWhileConstructingOffspring)
         CreatureDesc().id(1).mutationState(MutationState_NotMutated),
         genome);
 
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 1000.0f;
     _parameters.newLineageThreshold.value = 100.0f;  // Keep accumulatedMutationsInLineage from resetting
     _simulationFacade->setSimulationParameters(_parameters);

--- a/source/EngineTests/ConstructorTests.cpp
+++ b/source/EngineTests/ConstructorTests.cpp
@@ -3414,7 +3414,6 @@ TEST_F(ConstructorTests, regressionTestMassiveReplicationsWithSeeds)
         largeData.add(std::move(clone));
     }
 
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 1e7f;
     _simulationFacade->setSimulationParameters(_parameters);
     _simulationFacade->setSimulationData(largeData);
@@ -3423,7 +3422,6 @@ TEST_F(ConstructorTests, regressionTestMassiveReplicationsWithSeeds)
 
 TEST_F(ConstructorTests, externalEnergyInflowOnlyForFirstOffspring_firstOffspring)
 {
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = Infinity<float>::value;
     _parameters.externalEnergyInflowOnlyForFirstOffspring.value = true;
     _simulationFacade->setSimulationParameters(_parameters);
@@ -3452,7 +3450,6 @@ TEST_F(ConstructorTests, externalEnergyInflowOnlyForFirstOffspring_firstOffsprin
 
 TEST_F(ConstructorTests, externalEnergyInflowOnlyForFirstOffspring_secondOffspring)
 {
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = Infinity<float>::value;
     _parameters.externalEnergyInflowOnlyForFirstOffspring.value = true;
     _simulationFacade->setSimulationParameters(_parameters);
@@ -3481,9 +3478,8 @@ TEST_F(ConstructorTests, externalEnergyInflowOnlyForFirstOffspring_secondOffspri
 
 TEST_F(ConstructorTests, externalEnergyInflow_distributedProportionally)
 {
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 50.0f;
-    _parameters.externalEnergyInflowFactor.value = ColorVector<float>::uniform(1.0f);
+    _parameters.externalEnergyInflowForConstructor.value = ColorVector<float>::uniform(50.0f);
     _simulationFacade->setSimulationParameters(_parameters);
 
     auto normalEnergy = _parameters.normalCellEnergy.value[0];
@@ -3511,9 +3507,8 @@ TEST_F(ConstructorTests, externalEnergyInflow_distributedProportionally)
 
 TEST_F(ConstructorTests, finishedConstructorDoesNotRequestExternalEnergy)
 {
-    _parameters.externalEnergyControlToggle.value = true;
     _parameters.externalEnergy.value = 50.0f;
-    _parameters.externalEnergyInflowFactor.value = ColorVector<float>::uniform(1.0f);
+    _parameters.externalEnergyInflowForConstructor.value = ColorVector<float>::uniform(50.0f);
     _simulationFacade->setSimulationParameters(_parameters);
 
     auto normalEnergy = _parameters.normalCellEnergy.value[0];

--- a/source/Gui/NewSimulationDialog.cpp
+++ b/source/Gui/NewSimulationDialog.cpp
@@ -38,6 +38,7 @@ void NewSimulationDialog::processIntern()
     AlienGui::InputText(AlienGui::InputTextParameters().name("Project name").textWidth(ContentTextInputWidth), _projectName, ProjectNameSize);
     AlienGui::InputInt(AlienGui::InputIntParameters().name("Width").textWidth(ContentTextInputWidth), _width);
     AlienGui::InputInt(AlienGui::InputIntParameters().name("Height").textWidth(ContentTextInputWidth), _height);
+    AlienGui::InputFloat(AlienGui::InputFloatParameters().name("Energy").textWidth(ContentTextInputWidth).format("%.0f").step(1000.0f), _externalEnergy);
     AlienGui::Checkbox(AlienGui::CheckboxParameters().name("Adopt parameters").textWidth(ContentTextInputWidth), _adoptSimulationParameters);
 
     ImGui::Dummy({0, ImGui::GetContentRegionAvail().y - scale(50.0f)});
@@ -57,6 +58,7 @@ void NewSimulationDialog::processIntern()
 
     _width = std::max(1, _width);
     _height = std::max(1, _height);
+    _externalEnergy = std::max(0.0f, _externalEnergy);
 }
 
 void NewSimulationDialog::openIntern()
@@ -64,6 +66,7 @@ void NewSimulationDialog::openIntern()
     auto worldSize = _SimulationFacade::get()->getWorldSize();
     _width = worldSize.x;
     _height = worldSize.y;
+    _externalEnergy = _SimulationFacade::get()->getSimulationParameters().externalEnergy.value;
 }
 
 void NewSimulationDialog::onNewSimulation()
@@ -75,6 +78,7 @@ void NewSimulationDialog::onNewSimulation()
     for (int i = 0; i < ProjectNameSize; ++i) {
         parameters.projectName.value[i] = _projectName[i];
     }
+    parameters.externalEnergy.value = _externalEnergy;
     _SimulationFacade::get()->closeSimulation();
 
     _SimulationFacade::get()->newSimulation(0, {_width, _height}, parameters);

--- a/source/Gui/NewSimulationDialog.h
+++ b/source/Gui/NewSimulationDialog.h
@@ -27,4 +27,5 @@ private:
     Char64 _projectName = "<unnamed simulation>";
     int _width = 0;
     int _height = 0;
+    float _externalEnergy = 0.0f;
 };

--- a/source/PersisterInterface/SettingsParserService.cpp
+++ b/source/PersisterInterface/SettingsParserService.cpp
@@ -190,55 +190,8 @@ boost::property_tree::ptree SettingsParserService::encodeSimulationParameters(Si
     return tree;
 }
 
-// BEGIN: Temporary compatibility code for reading the legacy simulation parameters format. Remove after all simulations have been migrated.
-namespace
-{
-    // The legacy inflow parameter was a fraction of this reference energy instead of an absolute energy.
-    auto constexpr LegacyInflowReferenceEnergy = 50.0f;
-
-    void migrateLegacyExternalEnergyGroup(boost::property_tree::ptree& tree, std::string const& nodeBase)
-    {
-        auto legacyGroup = tree.get_child_optional(nodeBase + ".External energy control");
-        if (!legacyGroup || tree.get_child_optional(nodeBase + ".Guided energy supply")) {
-            return;
-        }
-        auto& group = tree.put_child(nodeBase + ".Guided energy supply", *legacyGroup);
-
-        boost::property_tree::ptree inflowForConstructor;
-        for (int color = 0; color < MAX_COLORS; ++color) {
-            auto colorNode = "Color " + std::to_string(color);
-            if (auto inflowFactor = group.get_optional<float>("Inflow.Base." + colorNode)) {
-                inflowForConstructor.put(colorNode, *inflowFactor * LegacyInflowReferenceEnergy);
-            }
-        }
-        group.put_child("Inflow for constructors.Base", inflowForConstructor);
-
-        // The legacy expert toggle switched off the whole external energy handling.
-        if (auto enabled = group.get_optional<bool>("Enabled"); enabled && !*enabled) {
-            for (int color = 0; color < MAX_COLORS; ++color) {
-                auto colorNode = "Color " + std::to_string(color);
-                group.put("Inflow for constructors.Base." + colorNode, 0.0f);
-                group.put("Inflow for sources.Base." + colorNode, 0.0f);
-                group.put("Backflow.Base." + colorNode, 0.0f);
-            }
-        }
-    }
-
-    void migrateLegacySimulationParameters(boost::property_tree::ptree& tree, std::string const& nodeBase)
-    {
-        migrateLegacyExternalEnergyGroup(tree, nodeBase);
-
-        if (auto transformationAllowed = tree.get_optional<std::string>(nodeBase + ".Radiation.Energy to cell transformation.Base.Value")) {
-            tree.put(nodeBase + ".Cell life cycle.Energy to cell free transformation.Base.Value", *transformationAllowed);
-        }
-    }
-}
-// END: Temporary compatibility code
-
 SimulationParameters SettingsParserService::decodeSimulationParameters(boost::property_tree::ptree tree)
 {
-    migrateLegacySimulationParameters(tree, SimulationParametersNode);
-
     SimulationParameters result;
     encodeDecodeSimulationParameters(tree, result, SimulationParametersNode, ParserTask::Decode);
     return result;

--- a/source/PersisterInterface/SettingsParserService.cpp
+++ b/source/PersisterInterface/SettingsParserService.cpp
@@ -190,8 +190,55 @@ boost::property_tree::ptree SettingsParserService::encodeSimulationParameters(Si
     return tree;
 }
 
+// BEGIN: Temporary compatibility code for reading the legacy simulation parameters format. Remove after all simulations have been migrated.
+namespace
+{
+    // The legacy inflow parameter was a fraction of this reference energy instead of an absolute energy.
+    auto constexpr LegacyInflowReferenceEnergy = 50.0f;
+
+    void migrateLegacyExternalEnergyGroup(boost::property_tree::ptree& tree, std::string const& nodeBase)
+    {
+        auto legacyGroup = tree.get_child_optional(nodeBase + ".External energy control");
+        if (!legacyGroup || tree.get_child_optional(nodeBase + ".Guided energy supply")) {
+            return;
+        }
+        auto& group = tree.put_child(nodeBase + ".Guided energy supply", *legacyGroup);
+
+        boost::property_tree::ptree inflowForConstructor;
+        for (int color = 0; color < MAX_COLORS; ++color) {
+            auto colorNode = "Color " + std::to_string(color);
+            if (auto inflowFactor = group.get_optional<float>("Inflow.Base." + colorNode)) {
+                inflowForConstructor.put(colorNode, *inflowFactor * LegacyInflowReferenceEnergy);
+            }
+        }
+        group.put_child("Inflow for constructors.Base", inflowForConstructor);
+
+        // The legacy expert toggle switched off the whole external energy handling.
+        if (auto enabled = group.get_optional<bool>("Enabled"); enabled && !*enabled) {
+            for (int color = 0; color < MAX_COLORS; ++color) {
+                auto colorNode = "Color " + std::to_string(color);
+                group.put("Inflow for constructors.Base." + colorNode, 0.0f);
+                group.put("Inflow for sources.Base." + colorNode, 0.0f);
+                group.put("Backflow.Base." + colorNode, 0.0f);
+            }
+        }
+    }
+
+    void migrateLegacySimulationParameters(boost::property_tree::ptree& tree, std::string const& nodeBase)
+    {
+        migrateLegacyExternalEnergyGroup(tree, nodeBase);
+
+        if (auto transformationAllowed = tree.get_optional<std::string>(nodeBase + ".Radiation.Energy to cell transformation.Base.Value")) {
+            tree.put(nodeBase + ".Cell life cycle.Energy to cell free transformation.Base.Value", *transformationAllowed);
+        }
+    }
+}
+// END: Temporary compatibility code
+
 SimulationParameters SettingsParserService::decodeSimulationParameters(boost::property_tree::ptree tree)
 {
+    migrateLegacySimulationParameters(tree, SimulationParametersNode);
+
     SimulationParameters result;
     encodeDecodeSimulationParameters(tree, result, SimulationParametersNode, ParserTask::Decode);
     return result;


### PR DESCRIPTION
## Summary

- `Guided energy supply` (formerly `External energy control`) is no longer an expert setting and now follows directly after `Visualization`. The expert toggle and all its guards are gone; with an empty energy pool the default behaviour is unchanged.
- Removed the `Advanced energy absorption control` and `Customize deletion mutations` groups together with their parameters and the corresponding kernel code.
- `externalEnergyInflowFactor` is now `externalEnergyInflowForConstructor` and specifies the maximum energy that flows into a constructor directly (range 0-50) instead of a fraction of a hardcoded reference energy.
- `Energy to cell transformation` moved from `Radiation` to `Cell life cycle` and is now called `Energy to cell free transformation`.
- The new simulation dialog got an `Energy` field, prefilled from the running simulation.

## Compatibility

`SettingsParserService` contains a clearly marked temporary migration that rewrites the legacy parameter nodes before decoding, so simulations in the old format still load and are written back in the new format:

- `External energy control` -> `Guided energy supply`
- `Inflow` -> `Inflow for constructors`, values multiplied by 50
- legacy expert toggle off -> all inflows and the backflow are zeroed, the stored energy amount is kept
- `Radiation.Energy to cell transformation` -> `Cell life cycle.Energy to cell free transformation`

The block is delimited by `// BEGIN:` / `// END:` markers and can be removed once all simulations are migrated.

## Test plan

- `EngineInterfaceTests`, `NetworkTests`, `PersisterTests` pass (`GenomeDescEditServiceTests.createSeedCollectionForPreview_singleSubGenome_noCache` fails in Debug only, unrelated to this change).
- Migration verified against real saves: parameter values decode identically to the stored ones and a save/load round trip in the new format is stable.
- All 19 simulations in the local `Conserve` folder were converted with `cli.exe` and checked to contain no legacy nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)